### PR TITLE
Fix #22: Address feedback regarding configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,20 @@ You can add the multiaddresses for the other members of the cluster in the `clus
           "/ip4/192.168.1.3/tcp/9096/ipfs/QmdFBMf9HMDH3eCWrc1U11YCPenC3Uvy9mZQ2BedTyKTDf",
           "/ip4/192.168.1.4/tcp/9096/ipfs/QmYY1ggjoew5eFrvkenTR3F4uWqtkBkmgfJk8g9Qqcwy51",
           "/ip4/192.168.1.5/tcp/9096/ipfs/QmSGCzHkz8gC9fNndMtaCZdf9RFtwtbTEEsGo4zkVfcykD"
-        ],
-    "cluster_addr": "0.0.0.0",
-    "cluster_port": 9096,
-    "consensus_data_folder": "/home/user/.ipfs-cluster/data",
-    "api_addr": "0.0.0.0",
-    "api_port": 9094,
-    "ipfs_api_addr": "0.0.0.0",
-    "ipfs_api_port": 9095,
-    "ipfs_addr": "127.0.0.1",
-    "ipfs_port": 5001
+          ],
+    "cluster_multiaddress": "/ip4/0.0.0.0/tcp/9096",
+    "api_listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
+    "ipfs_proxy_listen_multiaddress": "/ip4/127.0.0.1/tcp/9095",
+    "ipfs_node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
+    "consensus_data_folder": "/home/hector/go/src/github.com/ipfs/ipfs-cluster/ipfs-cluster-service/data",
+    "raft_config": {
+        "SnapshotIntervalSeconds": 120,
+        "EnableSingleNode": true
+    }
 }
 ```
 
-The configuration file should probably be identical among all cluster members, except for the `id` and `private_key` fields. To facilitate configuration, `cluster_peers` includes its own address, but it does not have to.
+The configuration file should probably be identical among all cluster members, except for the `id` and `private_key` fields. To facilitate configuration, `cluster_peers` may include its own address, but it does not have to. For additional information about the configuration format, see the [JSONConfig documentation](https://godoc.org/github.com/ipfs/ipfs-cluster#JSONConfig).
 
 Once every cluster member has the configuration in place, you can run `ipfs-cluster-service` to start the cluster.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can add the multiaddresses for the other members of the cluster in the `clus
     "api_listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
     "ipfs_proxy_listen_multiaddress": "/ip4/127.0.0.1/tcp/9095",
     "ipfs_node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
-    "consensus_data_folder": "/home/hector/go/src/github.com/ipfs/ipfs-cluster/ipfs-cluster-service/data",
+    "consensus_data_folder": "/home/user/.ipfs-cluster/data",
     "raft_config": {
         "SnapshotIntervalSeconds": 120,
         "EnableSingleNode": true

--- a/README.md
+++ b/README.md
@@ -95,10 +95,9 @@ You can add the multiaddresses for the other members of the cluster in the `clus
     "ipfs_node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
     "consensus_data_folder": "/home/user/.ipfs-cluster/data",
     "raft_config": {
-        "SnapshotIntervalSeconds": 120,
-        "EnableSingleNode": true
+        "snapshot_interval_seconds": 120,
+        "enable_single_node": true
     }
-}
 ```
 
 The configuration file should probably be identical among all cluster members, except for the `id` and `private_key` fields. To facilitate configuration, `cluster_peers` may include its own address, but it does not have to. For additional information about the configuration format, see the [JSONConfig documentation](https://godoc.org/github.com/ipfs/ipfs-cluster#JSONConfig).

--- a/cluster.go
+++ b/cluster.go
@@ -51,6 +51,8 @@ func NewCluster(cfg *Config, api API, ipfs IPFSConnector, state State, tracker P
 	rpcServer := rpc.NewServer(host, RPCProtocol)
 	rpcClient := rpc.NewClientWithServer(host, RPCProtocol, rpcServer)
 
+	logger.Infof("IPFS Cluster v%s - %s/ipfs/%s", Version, cfg.ClusterAddr, host.ID().Pretty())
+
 	consensus, err := NewConsensus(cfg, host, state)
 	if err != nil {
 		logger.Errorf("error creating consensus: %s", err)
@@ -87,8 +89,6 @@ func NewCluster(cfg *Config, api API, ipfs IPFSConnector, state State, tracker P
 		api.SetClient(rpcClient)
 		consensus.SetClient(rpcClient)
 	}()
-
-	logger.Infof("starting IPFS Cluster v%s", Version)
 
 	cluster.run()
 	return cluster, nil
@@ -136,7 +136,7 @@ func (c *Cluster) StateSync() ([]PinInfo, error) {
 		return nil, err
 	}
 
-	logger.Info("syncing state to tracker")
+	logger.Debug("syncing state to tracker")
 	clusterPins := cState.ListPins()
 	var changed []*cid.Cid
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -160,7 +160,7 @@ func TestClusterMembers(t *testing.T) {
 	defer cl.Shutdown()
 	m := cl.Members()
 	id := testingConfig().ID
-	if len(m) != 1 || m[0].Pretty() != id {
+	if len(m) != 1 || m[0] != id {
 		t.Error("bad Members()")
 	}
 }

--- a/config.go
+++ b/config.go
@@ -3,30 +3,62 @@ package ipfscluster
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+
+	hashiraft "github.com/hashicorp/raft"
 )
 
 // Default parameters for the configuration
 const (
 	DefaultConfigCrypto    = crypto.RSA
 	DefaultConfigKeyLength = 2048
-	DefaultAPIAddr         = "127.0.0.1"
-	DefaultAPIPort         = 9094
-	DefaultIPFSAPIAddr     = "127.0.0.1"
-	DefaultIPFSAPIPort     = 9095
-	DefaultIPFSAddr        = "127.0.0.1"
-	DefaultIPFSPort        = 5001
-	DefaultClusterAddr     = "0.0.0.0"
-	DefaultClusterPort     = 9096
+	DefaultAPIAddr         = "/ip4/127.0.0.1/tcp/9094"
+	DefaultIPFSProxyAddr   = "/ip4/127.0.0.1/tcp/9095"
+	DefaultIPFSNodeAddr    = "/ip4/127.0.0.1/tcp/5001"
+	DefaultClusterAddr     = "/ip4/0.0.0.0/tcp/9096"
 )
 
 // Config represents an ipfs-cluster configuration which can be
 // saved and loaded from disk. Currently it holds configuration
 // values used by all components.
 type Config struct {
+	// Libp2p ID and private key for Cluster communication (including)
+	// the Consensus component.
+	ID         peer.ID
+	PrivateKey crypto.PrivKey
+
+	// List of multiaddresses of the peers of this cluster.
+	ClusterPeers []ma.Multiaddr
+
+	// Listen parameters for the Cluster libp2p Host. Used by
+	// the RPC and Consensus components.
+	ClusterAddr ma.Multiaddr
+
+	// Listen parameters for the the Cluster HTTP API component.
+	APIAddr ma.Multiaddr
+
+	// Listen parameters for the IPFS Proxy. Used by the IPFS
+	// connector component.
+	IPFSProxyAddr ma.Multiaddr
+
+	// Host/Port for the IPFS daemon.
+	IPFSNodeAddr ma.Multiaddr
+
+	// Storage folder for snapshots, log store etc. Used by
+	// the Consensus component.
+	ConsensusDataFolder string
+
+	// Hashicorp's Raft configuration
+	RaftConfig *hashiraft.Config
+}
+
+// This is how a config actually look in JSON
+type JSONConfig struct {
 	// Libp2p ID and private key for Cluster communication (including)
 	// the Consensus component.
 	ID         string `json:"id"`
@@ -36,38 +68,150 @@ type Config struct {
 	ClusterPeers []string `json:"cluster_peers"`
 
 	// Listen parameters for the Cluster libp2p Host. Used by
-	// the Remote RPC and Consensus components.
-	ClusterAddr string `json:"cluster_addr"`
-	ClusterPort int    `json:"cluster_port"`
+	// the RPC and Consensus components.
+	ClusterListenMultiaddress string `json:"cluster_multiaddress"`
+
+	// Listen parameters for the the Cluster HTTP API component.
+	APIListenMultiaddress string `json:"api_multiaddress`
+
+	// Listen parameters for the IPFS Proxy. Used by the IPFS
+	// connector component.
+	IPFSProxyListenMultiaddress string `json:ipfs_proxy_api_multiaddress`
+
+	// Host/Port for the IPFS daemon.
+	IPFSNodeMultiaddress string `json:"ipfs_node_multiaddress"`
 
 	// Storage folder for snapshots, log store etc. Used by
 	// the Consensus component.
 	ConsensusDataFolder string `json:"consensus_data_folder"`
 
-	// Listen parameters for the the Cluster HTTP API component.
-	APIAddr string `json:"api_addr"`
-	APIPort int    `json:"api_port"`
+	// Raft configuration
+	RaftConfig *hashiraft.Config `json:"raft_config"`
+}
 
-	// Listen parameters for the IPFS Proxy. Used by the IPFS
-	// connector component.
-	IPFSAPIAddr string `json:"ipfs_api_addr"`
-	IPFSAPIPort int    `json:"ipfs_api_port"`
+func (cfg *Config) ToJSONConfig() (j *JSONConfig, err error) {
+	// Multiaddress String() may panic
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%s", r)
+		}
+	}()
+	pkeyBytes, err := cfg.PrivateKey.Bytes()
+	if err != nil {
+		return
+	}
+	pKey := base64.StdEncoding.EncodeToString(pkeyBytes)
 
-	// Host/Port for the IPFS daemon.
-	IPFSAddr string `json:"ipfs_addr"`
-	IPFSPort int    `json:"ipfs_port"`
+	clusterPeers := make([]string, len(cfg.ClusterPeers), len(cfg.ClusterPeers))
+	for i := 0; i < len(cfg.ClusterPeers); i++ {
+		clusterPeers[i] = cfg.ClusterPeers[i].String()
+	}
+
+	j = &JSONConfig{
+		ID:                          cfg.ID.Pretty(),
+		PrivateKey:                  pKey,
+		ClusterPeers:                clusterPeers,
+		ClusterListenMultiaddress:   cfg.ClusterAddr.String(),
+		APIListenMultiaddress:       cfg.APIAddr.String(),
+		IPFSProxyListenMultiaddress: cfg.IPFSProxyAddr.String(),
+		IPFSNodeMultiaddress:        cfg.IPFSNodeAddr.String(),
+		ConsensusDataFolder:         cfg.ConsensusDataFolder,
+		RaftConfig:                  cfg.RaftConfig,
+	}
+	return
+}
+
+func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
+	id, err := peer.IDB58Decode(jcfg.ID)
+	if err != nil {
+		return
+	}
+
+	pkb, err := base64.StdEncoding.DecodeString(jcfg.PrivateKey)
+	if err != nil {
+		return
+	}
+	pKey, err := crypto.UnmarshalPrivateKey(pkb)
+	if err != nil {
+		return
+	}
+
+	clusterPeers := make([]ma.Multiaddr, len(jcfg.ClusterPeers))
+	for i := 0; i < len(jcfg.ClusterPeers); i++ {
+		maddr, err := ma.NewMultiaddr(jcfg.ClusterPeers[i])
+		if err != nil {
+			return nil, err
+		}
+		clusterPeers[i] = maddr
+	}
+
+	clusterAddr, err := ma.NewMultiaddr(jcfg.ClusterListenMultiaddress)
+	if err != nil {
+		return
+	}
+
+	apiAddr, err := ma.NewMultiaddr(jcfg.APIListenMultiaddress)
+	if err != nil {
+		return
+	}
+	ipfsProxyAddr, err := ma.NewMultiaddr(jcfg.IPFSProxyListenMultiaddress)
+	if err != nil {
+		return
+	}
+	ipfsNodeAddr, err := ma.NewMultiaddr(jcfg.IPFSNodeMultiaddress)
+	if err != nil {
+		return
+	}
+
+	c = &Config{
+		ID:                  id,
+		PrivateKey:          pKey,
+		ClusterPeers:        clusterPeers,
+		ClusterAddr:         clusterAddr,
+		APIAddr:             apiAddr,
+		IPFSProxyAddr:       ipfsProxyAddr,
+		IPFSNodeAddr:        ipfsNodeAddr,
+		RaftConfig:          jcfg.RaftConfig,
+		ConsensusDataFolder: jcfg.ConsensusDataFolder,
+	}
+	return
 }
 
 // LoadConfig reads a JSON configuration file from the given path,
 // parses it and returns a new Config object.
 func LoadConfig(path string) (*Config, error) {
-	config := &Config{}
+	jcfg := &JSONConfig{}
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
+		logger.Error("error reading the configuration file: ", err)
 		return nil, err
 	}
-	json.Unmarshal(file, config)
-	return config, nil
+	err = json.Unmarshal(file, jcfg)
+	if err != nil {
+		logger.Error("error parsing JSON: ", err)
+		return nil, err
+	}
+	cfg, err := jcfg.ToConfig()
+	if err != nil {
+		logger.Error("error parsing configuration: ", err)
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Save stores a configuration as a JSON file in the given path.
+func (c *Config) Save(path string) error {
+	jcfg, err := c.ToJSONConfig()
+	if err != nil {
+		logger.Error("error generating JSON config")
+		return err
+	}
+	json, err := json.MarshalIndent(jcfg, "", "    ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(path, json, 0600)
+	return err
 }
 
 // NewDefaultConfig returns a default configuration object with a randomly
@@ -83,34 +227,24 @@ func NewDefaultConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	privBytes, err := priv.Bytes()
-	if err != nil {
-		return nil, err
-	}
-	b64priv := base64.StdEncoding.EncodeToString(privBytes)
+
+	raftCfg := hashiraft.DefaultConfig()
+	raftCfg.EnableSingleNode = true
+
+	clusterAddr, _ := ma.NewMultiaddr(DefaultClusterAddr)
+	apiAddr, _ := ma.NewMultiaddr(DefaultAPIAddr)
+	ipfsProxyAddr, _ := ma.NewMultiaddr(DefaultIPFSProxyAddr)
+	ipfsNodeAddr, _ := ma.NewMultiaddr(DefaultIPFSNodeAddr)
 
 	return &Config{
-		ID:                  peer.IDB58Encode(pid),
-		PrivateKey:          b64priv,
-		ClusterPeers:        []string{},
-		ClusterAddr:         DefaultClusterAddr,
-		ClusterPort:         DefaultClusterPort,
+		ID:                  pid,
+		PrivateKey:          priv,
+		ClusterPeers:        []ma.Multiaddr{},
+		ClusterAddr:         clusterAddr,
+		APIAddr:             apiAddr,
+		IPFSProxyAddr:       ipfsProxyAddr,
+		IPFSNodeAddr:        ipfsNodeAddr,
 		ConsensusDataFolder: "ipfscluster-data",
-		APIAddr:             DefaultAPIAddr,
-		APIPort:             DefaultAPIPort,
-		IPFSAPIAddr:         DefaultIPFSAPIAddr,
-		IPFSAPIPort:         DefaultIPFSAPIPort,
-		IPFSAddr:            DefaultIPFSAddr,
-		IPFSPort:            DefaultIPFSPort,
+		RaftConfig:          raftCfg,
 	}, nil
-}
-
-// Save stores a configuration as a JSON file in the given path.
-func (c *Config) Save(path string) error {
-	json, err := json.MarshalIndent(c, "", "    ")
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(path, json, 0600)
-	return err
 }

--- a/config.go
+++ b/config.go
@@ -195,8 +195,10 @@ func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
 	}
 
 	raftCfg := hashiraft.DefaultConfig()
-	raftCfg.SnapshotInterval = time.Duration(jcfg.RaftConfig.SnapshotIntervalSeconds) * time.Second
-	raftCfg.EnableSingleNode = jcfg.RaftConfig.EnableSingleNode
+	if jcfg.RaftConfig != nil {
+		raftCfg.SnapshotInterval = time.Duration(jcfg.RaftConfig.SnapshotIntervalSeconds) * time.Second
+		raftCfg.EnableSingleNode = jcfg.RaftConfig.EnableSingleNode
+	}
 
 	c = &Config{
 		ID:                  id,

--- a/config.go
+++ b/config.go
@@ -133,15 +133,18 @@ func (cfg *Config) ToJSONConfig() (j *JSONConfig, err error) {
 func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
 	id, err := peer.IDB58Decode(jcfg.ID)
 	if err != nil {
+		err = fmt.Errorf("error decoding cluster ID: %s", err)
 		return
 	}
 
 	pkb, err := base64.StdEncoding.DecodeString(jcfg.PrivateKey)
 	if err != nil {
+		err = fmt.Errorf("error decoding private_key: %s", err)
 		return
 	}
 	pKey, err := crypto.UnmarshalPrivateKey(pkb)
 	if err != nil {
+		err = fmt.Errorf("error parsing private_key ID: %s", err)
 		return
 	}
 
@@ -149,6 +152,8 @@ func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
 	for i := 0; i < len(jcfg.ClusterPeers); i++ {
 		maddr, err := ma.NewMultiaddr(jcfg.ClusterPeers[i])
 		if err != nil {
+			err = fmt.Errorf("error parsing multiaddress for peer %s: %s",
+				jcfg.ClusterPeers[i], err)
 			return nil, err
 		}
 		clusterPeers[i] = maddr
@@ -156,19 +161,23 @@ func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
 
 	clusterAddr, err := ma.NewMultiaddr(jcfg.ClusterListenMultiaddress)
 	if err != nil {
+		err = fmt.Errorf("error parsing cluster_listen_multiaddress: %s", err)
 		return
 	}
 
 	apiAddr, err := ma.NewMultiaddr(jcfg.APIListenMultiaddress)
 	if err != nil {
+		err = fmt.Errorf("error parsing api_listen_multiaddress: %s", err)
 		return
 	}
 	ipfsProxyAddr, err := ma.NewMultiaddr(jcfg.IPFSProxyListenMultiaddress)
 	if err != nil {
+		err = fmt.Errorf("error parsing ipfs_proxy_listen_multiaddress: %s", err)
 		return
 	}
 	ipfsNodeAddr, err := ma.NewMultiaddr(jcfg.IPFSNodeMultiaddress)
 	if err != nil {
+		err = fmt.Errorf("error parsing ipfs_node_multiaddress: %s", err)
 		return
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,21 +1,16 @@
 package ipfscluster
 
 func testingConfig() *Config {
-	cfg := &Config{
+	jcfg := &JSONConfig{
 		ID:         "QmUfSFm12eYCaRdypg48m8RqkXfLW7A2ZeGZb2skeHHDGA",
 		PrivateKey: "CAASqAkwggSkAgEAAoIBAQDpT16IRF6bb9tHsCbQ7M+nb2aI8sz8xyt8PoAWM42ki+SNoESIxKb4UhFxixKvtEdGxNE6aUUVc8kFk6wTStJ/X3IGiMetwkXiFiUxabUF/8A6SyvnSVDm+wFuavugpVrZikjLcfrf2xOVgnG3deQQvd/qbAv14jTwMFl+T+8d/cXBo8Mn/leLZCQun/EJEnkXP5MjgNI8XcWUE4NnH3E0ESSm6Pkm8MhMDZ2fmzNgqEyJ0GVinNgSml3Pyha3PBSj5LRczLip/ie4QkKx5OHvX2L3sNv/JIUHse5HSbjZ1c/4oGCYMVTYCykWiczrxBUOlcr8RwnZLOm4n2bCt5ZhAgMBAAECggEAVkePwfzmr7zR7tTpxeGNeXHtDUAdJm3RWwUSASPXgb5qKyXVsm5nAPX4lXDE3E1i/nzSkzNS5PgIoxNVU10cMxZs6JW0okFx7oYaAwgAddN6lxQtjD7EuGaixN6zZ1k/G6vT98iS6i3uNCAlRZ9HVBmjsOF8GtYolZqLvfZ5izEVFlLVq/BCs7Y5OrDrbGmn3XupfitVWYExV0BrHpobDjsx2fYdTZkmPpSSvXNcm4Iq2AXVQzoqAfGo7+qsuLCZtVlyTfVKQjMvE2ffzN1dQunxixOvev/fz4WSjGnRpC6QLn6Oqps9+VxQKqKuXXqUJC+U45DuvA94Of9MvZfAAQKBgQD7xmXueXRBMr2+0WftybAV024ap0cXFrCAu+KWC1SUddCfkiV7e5w+kRJx6RH1cg4cyyCL8yhHZ99Z5V0Mxa/b/usuHMadXPyX5szVI7dOGgIC9q8IijN7B7GMFAXc8+qC7kivehJzjQghpRRAqvRzjDls4gmbNPhbH1jUiU124QKBgQDtOaW5/fOEtOq0yWbDLkLdjImct6oKMLhENL6yeIKjMYgifzHb2adk7rWG3qcMrdgaFtDVfqv8UmMEkzk7bSkovMVj3SkLzMz84ii1SkSfyaCXgt/UOzDkqAUYB0cXMppYA7jxHa2OY8oEHdBgmyJXdLdzJxCp851AoTlRUSePgQKBgQCQgKgUHOUaXnMEx88sbOuBO14gMg3dNIqM+Ejt8QbURmI8k3arzqA4UK8Tbb9+7b0nzXWanS5q/TT1tWyYXgW28DIuvxlHTA01aaP6WItmagrphIelERzG6f1+9ib/T4czKmvROvDIHROjq8lZ7ERs5Pg4g+sbh2VbdzxWj49EQQKBgFEna36ZVfmMOs7mJ3WWGeHY9ira2hzqVd9fe+1qNKbHhx7mDJR9fTqWPxuIh/Vac5dZPtAKqaOEO8OQ6f9edLou+ggT3LrgsS/B3tNGOPvA6mNqrk/Yf/15TWTO+I8DDLIXc+lokbsogC+wU1z5NWJd13RZZOX/JUi63vTmonYBAoGBAIpglLCH2sPXfmguO6p8QcQcv4RjAU1c0GP4P5PNN3Wzo0ItydVd2LHJb6MdmL6ypeiwNklzPFwTeRlKTPmVxJ+QPg1ct/3tAURN/D40GYw9ojDhqmdSl4HW4d6gHS2lYzSFeU5jkG49y5nirOOoEgHy95wghkh6BfpwHujYJGw4",
 
-		ClusterAddr: "127.0.0.1",
-		ClusterPort: 10000,
-
-		ConsensusDataFolder: "./raftFolderFromTests",
-
-		APIAddr: "127.0.0.1",
-		APIPort: 10002,
-
-		IPFSAPIAddr: "127.0.0.1",
-		IPFSAPIPort: 10001,
+		ClusterListenMultiaddress:   "/ip4/127.0.0.1/tcp/10000",
+		APIListenMultiaddress:       "/ip4/127.0.0.1/tcp/10002",
+		IPFSProxyListenMultiaddress: "/ip4/127.0.0.1/tcp/10001",
+		ConsensusDataFolder:         "./raftFolderFromTests",
 	}
 
+	cfg, _ := jcfg.ToConfig()
 	return cfg
 }

--- a/config_test.go
+++ b/config_test.go
@@ -9,6 +9,10 @@ func testingConfig() *Config {
 		APIListenMultiaddress:       "/ip4/127.0.0.1/tcp/10002",
 		IPFSProxyListenMultiaddress: "/ip4/127.0.0.1/tcp/10001",
 		ConsensusDataFolder:         "./raftFolderFromTests",
+		RaftConfig: &RaftConfig{
+			EnableSingleNode:        true,
+			SnapshotIntervalSeconds: 120,
+		},
 	}
 
 	cfg, _ := jcfg.ToConfig()

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -165,7 +165,7 @@ func TestConsensusLeader(t *testing.T) {
 		t.Fatal("No leader:", err)
 	}
 
-	if l.Pretty() != pID {
+	if l != pID {
 		t.Errorf("expected %s but the leader appears as %s", pID, l)
 	}
 }

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -63,6 +63,7 @@ var (
 var (
 	initFlag     bool
 	configFlag   string
+	forceFlag    bool
 	debugFlag    bool
 	logLevelFlag string
 	versionFlag  bool
@@ -94,6 +95,8 @@ func init() {
 		"create a default configuration and exit")
 	flag.StringVar(&configFlag, "config", configPath,
 		"path to the ipfs-cluster-service configuration file")
+	flag.BoolVar(&forceFlag, "f", false,
+		"force configuration overwrite when running -init")
 	flag.BoolVar(&debugFlag, "debug", false,
 		"enable full debug logs of ipfs cluster and consensus layers")
 	flag.StringVar(&logLevelFlag, "loglevel", "info",
@@ -108,7 +111,7 @@ func init() {
 	if versionFlag {
 		fmt.Println(ipfscluster.Version)
 	}
-	if initFlag {
+	if initFlag || flag.Arg(0) == "init" {
 		err := initConfig()
 		checkErr("creating configuration", err)
 		os.Exit(0)
@@ -166,7 +169,7 @@ func setupDebug() {
 
 func initConfig() error {
 	if _, err := os.Stat(configPath); err == nil {
-		return fmt.Errorf("%s exists. Try deleting it first", configPath)
+		return fmt.Errorf("%s exists. Try running with -f", configPath)
 	}
 	cfg, err := ipfscluster.NewDefaultConfig()
 	if err != nil {

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -81,8 +81,6 @@ func init() {
 			usr.HomeDir,
 			".ipfs-cluster")
 	}
-	configPath = filepath.Join(DefaultPath, DefaultConfigFile)
-	dataPath = filepath.Join(DefaultPath, DefaultDataFolder)
 
 	flag.Usage = func() {
 		out("Usage: %s [options]\n", programName)
@@ -93,8 +91,8 @@ func init() {
 	}
 	flag.BoolVar(&initFlag, "init", false,
 		"create a default configuration and exit")
-	flag.StringVar(&configFlag, "config", configPath,
-		"path to the ipfs-cluster-service configuration file")
+	flag.StringVar(&configFlag, "config", DefaultPath,
+		"path to the ipfs-cluster-service configuration and data folder")
 	flag.BoolVar(&forceFlag, "f", false,
 		"force configuration overwrite when running -init")
 	flag.BoolVar(&debugFlag, "debug", false,
@@ -104,7 +102,13 @@ func init() {
 	flag.BoolVar(&versionFlag, "version", false,
 		fmt.Sprintf("display %s version", programName))
 	flag.Parse()
-	configPath = configFlag
+
+	absPath, err := filepath.Abs(configFlag)
+	if err != nil {
+		panic("error expading " + configFlag)
+	}
+	configPath = filepath.Join(absPath, DefaultConfigFile)
+	dataPath = filepath.Join(absPath, DefaultDataFolder)
 
 	setupLogging()
 	setupDebug()
@@ -168,7 +172,7 @@ func setupDebug() {
 }
 
 func initConfig() error {
-	if _, err := os.Stat(configPath); err == nil {
+	if _, err := os.Stat(configPath); err == nil && !forceFlag {
 		return fmt.Errorf("%s exists. Try running with -f", configPath)
 	}
 	cfg, err := ipfscluster.NewDefaultConfig()

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -132,7 +132,7 @@ func main() {
 	signal.Notify(signalChan, os.Interrupt)
 
 	cfg, err := loadConfig()
-	checkErr("loading configuration", err)
+	checkErr("error loading configuration", err)
 	api, err := ipfscluster.NewRESTAPI(cfg)
 	checkErr("creating REST API component", err)
 	proxy, err := ipfscluster.NewIPFSHTTPConnector(cfg)

--- a/ipfs_http_connector_test.go
+++ b/ipfs_http_connector_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 func testIPFSConnectorConfig(mock *ipfsMock) *Config {
 	cfg := testingConfig()
-	cfg.IPFSAddr = mock.addr
-	cfg.IPFSPort = mock.port
+	addr, _ := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", mock.addr, mock.port))
+	cfg.IPFSNodeAddr = addr
 	return cfg
 }
 
@@ -98,9 +99,11 @@ func TestIPFSProxy(t *testing.T) {
 	defer ipfs.Shutdown()
 
 	cfg := testingConfig()
-	res, err := http.Get(fmt.Sprintf("http://%s:%d/api/v0/add?arg=%s",
-		cfg.IPFSAPIAddr,
-		cfg.IPFSAPIPort,
+	host, _ := cfg.IPFSProxyAddr.ValueForProtocol(ma.P_IP4)
+	port, _ := cfg.IPFSProxyAddr.ValueForProtocol(ma.P_TCP)
+	res, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/add?arg=%s",
+		host,
+		port,
 		testCid))
 	if err != nil {
 		t.Fatal("should forward requests to ipfs host: ", err)

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -41,6 +41,9 @@ func SetLogLevel(l string) {
 		DEBUG
 	*/
 	logging.SetLogLevel("cluster", l)
+	//logging.SetLogLevel("libp2p-rpc", l)
+	//logging.SetLogLevel("swarm2", l)
+	//logging.SetLogLevel("libp2p-raft", l)
 }
 
 // IPFSStatus values

--- a/map_pin_tracker.go
+++ b/map_pin_tracker.go
@@ -40,16 +40,11 @@ type MapPinTracker struct {
 func NewMapPinTracker(cfg *Config) *MapPinTracker {
 	ctx := context.Background()
 
-	pID, err := peer.IDB58Decode(cfg.ID)
-	if err != nil {
-		panic(err)
-	}
-
 	mpt := &MapPinTracker{
 		ctx:        ctx,
 		status:     make(map[string]PinInfo),
 		rpcReady:   make(chan struct{}, 1),
-		peerID:     pID,
+		peerID:     cfg.ID,
 		shutdownCh: make(chan struct{}),
 	}
 	logger.Info("starting MapPinTracker")

--- a/map_pin_tracker.go
+++ b/map_pin_tracker.go
@@ -47,7 +47,6 @@ func NewMapPinTracker(cfg *Config) *MapPinTracker {
 		peerID:     cfg.ID,
 		shutdownCh: make(chan struct{}),
 	}
-	logger.Info("starting MapPinTracker")
 	mpt.run()
 	return mpt
 }
@@ -60,7 +59,8 @@ func (mpt *MapPinTracker) run() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		mpt.ctx = ctx
-		//<-mpt.rpcReady
+		<-mpt.rpcReady
+		logger.Info("PinTracker ready")
 		<-mpt.shutdownCh
 	}()
 }

--- a/raft.go
+++ b/raft.go
@@ -49,8 +49,11 @@ func makeLibp2pRaft(cfg *Config, host host.Host, state State, op *clusterLogOp) 
 	logger.Debug("creating OpLog")
 	cons := libp2praft.NewOpLog(state, op)
 
-	raftCfg := hashiraft.DefaultConfig()
-	raftCfg.EnableSingleNode = raftSingleMode
+	raftCfg := cfg.RaftConfig
+	if raftCfg == nil {
+		raftCfg = hashiraft.DefaultConfig()
+		raftCfg.EnableSingleNode = raftSingleMode
+	}
 	if SilentRaft {
 		raftCfg.LogOutput = ioutil.Discard
 		raftCfg.Logger = nil

--- a/rest_api.go
+++ b/rest_api.go
@@ -34,6 +34,7 @@ var (
 // a RESTful HTTP API for Cluster.
 type RESTAPI struct {
 	ctx        context.Context
+	apiAddr    ma.Multiaddr
 	listenAddr string
 	listenPort int
 	rpcClient  *rpc.Client
@@ -122,6 +123,7 @@ func NewRESTAPI(cfg *Config) (*RESTAPI, error) {
 
 	api := &RESTAPI{
 		ctx:        ctx,
+		apiAddr:    cfg.APIAddr,
 		listenAddr: listenAddr,
 		listenPort: listenPort,
 		listener:   l,
@@ -138,7 +140,6 @@ func NewRESTAPI(cfg *Config) (*RESTAPI, error) {
 	}
 
 	api.router = router
-	logger.Infof("starting Cluster API on %s:%d", api.listenAddr, api.listenPort)
 	api.run()
 	return api, nil
 }
@@ -212,6 +213,7 @@ func (api *RESTAPI) run() {
 
 		<-api.rpcReady
 
+		logger.Infof("REST API: %s", api.apiAddr)
 		err := api.server.Serve(api.listener)
 		if err != nil && !strings.Contains(err.Error(), "closed network connection") {
 			logger.Error(err)


### PR DESCRIPTION
Fixes #22 

* Use multiaddresses
* Give more meaningful errors if a config is badly formatted
* Be more clever as where to place the data folder
* Bonus: workaround tests randomly failing