### PR TITLE
Fixes #8: Reworking PinTracker (sync/recover ops)

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -40,6 +40,7 @@ type Cluster struct {
 	wg           sync.WaitGroup
 }
 
+// ID holds information about the Cluster peer
 type ID struct {
 	ID                 peer.ID
 	PublicKey          crypto.PubKey
@@ -137,6 +138,7 @@ func (c *Cluster) Shutdown() error {
 	return nil
 }
 
+// ID returns information about the Cluster peer
 func (c *Cluster) ID() ID {
 	return ID{
 		ID:                 c.host.ID(),
@@ -163,7 +165,7 @@ func (c *Cluster) StateSync() ([]PinInfo, error) {
 
 	// Track items which are not tracked
 	for _, h := range clusterPins {
-		if c.tracker.StatusCid(h).IPFS == Unpinned {
+		if c.tracker.StatusCid(h).Status == TrackerStatusUnpinned {
 			changed = append(changed, h)
 			err := c.rpcClient.Go("",
 				"Cluster",
@@ -219,33 +221,30 @@ func (c *Cluster) StatusCid(h *cid.Cid) (GlobalPinInfo, error) {
 // on all items that need it. Returns PinInfo for items changed on Sync().
 //
 // LocalSync triggers recoveries asynchronously, and will not wait for
-// them to fail or succeed before returning.
+// them to fail or succeed before returning. The PinInfo may not reflect
+// the recovery attempt.
 func (c *Cluster) LocalSync() ([]PinInfo, error) {
-	status := c.tracker.Status()
-	var toRecover []*cid.Cid
-
-	for _, p := range status {
-		h, _ := cid.Decode(p.CidStr)
-		modified := c.tracker.Sync(h)
-		if modified {
-			toRecover = append(toRecover, h)
-		}
+	syncedItems, err := c.tracker.Sync()
+	// Despite errors, tracker provides synced items that we can work with.
+	// However we skip recover() on those cases, as probably the ipfs daemon
+	// is gone.
+	if err != nil {
+		logger.Error("tracker.Sync() returned with error: ", err)
+		logger.Error("Is the ipfs daemon running?")
+		logger.Error("LocalSync returning without attempting recovers")
+		return syncedItems, nil
 	}
 
-	logger.Infof("%d items to recover after sync", len(toRecover))
-	for i, h := range toRecover {
-		logger.Infof("recovering in progress for %s (%d/%d",
-			h, i, len(toRecover))
+	// FIXME: at this point, recover probably deserves it's own api endpoint
+	// or be optional or be synchronous.
+	logger.Infof("%d items changed on sync", len(syncedItems))
+	for _, pInfo := range syncedItems {
+		pCid, _ := cid.Decode(pInfo.CidStr)
 		go func(h *cid.Cid) {
 			c.tracker.Recover(h)
-		}(h)
+		}(pCid)
 	}
-
-	var changed []PinInfo
-	for _, h := range toRecover {
-		changed = append(changed, c.tracker.StatusCid(h))
-	}
-	return changed, nil
+	return syncedItems, nil
 }
 
 // LocalSyncCid performs a Tracker.Sync() operation followed by a
@@ -255,10 +254,16 @@ func (c *Cluster) LocalSync() ([]PinInfo, error) {
 // returning.
 func (c *Cluster) LocalSyncCid(h *cid.Cid) (PinInfo, error) {
 	var err error
-	if c.tracker.Sync(h) {
-		err = c.tracker.Recover(h)
+	pInfo, err := c.tracker.SyncCid(h)
+	// Despite errors, trackers provides an updated PinInfo so
+	// we just log it.
+	if err != nil {
+		logger.Error("tracker.SyncCid() returned with error: ", err)
+		logger.Error("Is the ipfs daemon running?")
+		return pInfo, nil
 	}
-	return c.tracker.StatusCid(h), err
+	c.tracker.Recover(h)
+	return c.tracker.StatusCid(h), nil
 }
 
 // GlobalSync triggers Sync() operations in all members of the Cluster.
@@ -422,8 +427,8 @@ func (c *Cluster) multiRPC(dests []peer.ID, svcName, svcMethod string, args inte
 
 func (c *Cluster) globalPinInfoCid(method string, h *cid.Cid) (GlobalPinInfo, error) {
 	pin := GlobalPinInfo{
-		Cid:    h,
-		Status: make(map[peer.ID]PinInfo),
+		Cid:     h,
+		PeerMap: make(map[peer.ID]PinInfo),
 	}
 
 	members := c.Members()
@@ -436,13 +441,13 @@ func (c *Cluster) globalPinInfoCid(method string, h *cid.Cid) (GlobalPinInfo, er
 	errs := c.multiRPC(members, "Cluster", method, args, ifaceReplies)
 
 	for i, r := range replies {
-		if e := errs[i]; e != nil {
+		if e := errs[i]; e != nil { // This error must come from not being able to contact that cluster member
 			logger.Errorf("%s: error in broadcast response from %s: %s ", c.host.ID(), members[i], e)
-			if r.IPFS == Bug {
+			if r.Status == TrackerStatusBug {
 				r = PinInfo{
 					CidStr: h.String(),
 					Peer:   members[i],
-					IPFS:   ClusterError,
+					Status: TrackerStatusClusterError,
 					TS:     time.Now(),
 					Error:  e.Error(),
 				}
@@ -450,7 +455,7 @@ func (c *Cluster) globalPinInfoCid(method string, h *cid.Cid) (GlobalPinInfo, er
 				r.Error = e.Error()
 			}
 		}
-		pin.Status[members[i]] = r
+		pin.PeerMap[members[i]] = r
 	}
 
 	return pin, nil
@@ -476,19 +481,19 @@ func (c *Cluster) globalPinInfoSlice(method string) ([]GlobalPinInfo, error) {
 			if !ok {
 				fullMap[p.CidStr] = GlobalPinInfo{
 					Cid: c,
-					Status: map[peer.ID]PinInfo{
+					PeerMap: map[peer.ID]PinInfo{
 						p.Peer: p,
 					},
 				}
 			} else {
-				item.Status[p.Peer] = p
+				item.PeerMap[p.Peer] = p
 			}
 		}
 	}
 
 	erroredPeers := make(map[peer.ID]string)
 	for i, r := range replies {
-		if e := errs[i]; e != nil {
+		if e := errs[i]; e != nil { // This error must come from not being able to contact that cluster member
 			logger.Errorf("%s: error in broadcast response from %s: %s ", c.host.ID(), members[i], e)
 			erroredPeers[members[i]] = e.Error()
 		} else {
@@ -499,10 +504,10 @@ func (c *Cluster) globalPinInfoSlice(method string) ([]GlobalPinInfo, error) {
 	// Merge any errors
 	for p, msg := range erroredPeers {
 		for c := range fullMap {
-			fullMap[c].Status[p] = PinInfo{
+			fullMap[c].PeerMap[p] = PinInfo{
 				CidStr: c,
 				Peer:   p,
-				IPFS:   ClusterError,
+				Status: TrackerStatusClusterError,
 				TS:     time.Now(),
 				Error:  msg,
 			}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -44,11 +44,19 @@ func (ipfs *mockConnector) Unpin(c *cid.Cid) error {
 	return nil
 }
 
-func (ipfs *mockConnector) IsPinned(c *cid.Cid) (bool, error) {
+func (ipfs *mockConnector) PinLsCid(c *cid.Cid) (IPFSPinStatus, error) {
 	if ipfs.returnError {
-		return false, errors.New("")
+		return IPFSPinStatusError, errors.New("")
 	}
-	return true, nil
+	return IPFSPinStatusRecursive, nil
+}
+
+func (ipfs *mockConnector) PinLs() (map[string]IPFSPinStatus, error) {
+	if ipfs.returnError {
+		return nil, errors.New("")
+	}
+	m := make(map[string]IPFSPinStatus)
+	return m, nil
 }
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *MapState, *MapPinTracker) {

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -18,7 +18,8 @@ import (
 
 const programName = `ipfs-cluster-ctl`
 
-// Version
+// Version is the cluster-ctl tool version. It should match
+// the IPFS cluster's version
 const Version = "0.0.2"
 
 var (
@@ -175,7 +176,7 @@ This command tells IPFS Cluster to no longer manage a CID. This will
 trigger unpinning operations in all the IPFS nodes holding the content.
 
 When the request has succeeded, the command returns the status of the CID
-in the cluster. The CID should dissapear from the list offered by "pin ls",
+in the cluster. The CID should disappear from the list offered by "pin ls",
 although unpinning operations in the cluster may take longer or fail.
 `,
 					ArgsUsage: "<cid>",

--- a/ipfs_http_connector_test.go
+++ b/ipfs_http_connector_test.go
@@ -43,11 +43,11 @@ func TestIPFSPin(t *testing.T) {
 	if err != nil {
 		t.Error("expected success pinning cid")
 	}
-	yes, err := ipfs.IsPinned(c)
+	pinSt, err := ipfs.PinLsCid(c)
 	if err != nil {
 		t.Fatal("expected success doing ls")
 	}
-	if !yes {
+	if !pinSt.IsPinned() {
 		t.Error("cid should have been pinned")
 	}
 
@@ -74,7 +74,7 @@ func TestIPFSUnpin(t *testing.T) {
 	}
 }
 
-func TestIPFSIsPinned(t *testing.T) {
+func TestIPFSPinLsCid(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()
 	defer ipfs.Shutdown()
@@ -82,14 +82,37 @@ func TestIPFSIsPinned(t *testing.T) {
 	c2, _ := cid.Decode(testCid2)
 
 	ipfs.Pin(c)
-	isp, err := ipfs.IsPinned(c)
-	if err != nil || !isp {
+	ips, err := ipfs.PinLsCid(c)
+	if err != nil || !ips.IsPinned() {
 		t.Error("c should appear pinned")
 	}
 
-	isp, err = ipfs.IsPinned(c2)
-	if err != nil || isp {
+	ips, err = ipfs.PinLsCid(c2)
+	if err != nil || ips != IPFSPinStatusUnpinned {
 		t.Error("c2 should appear unpinned")
+	}
+}
+
+func TestIPFSPinLs(t *testing.T) {
+	ipfs, mock := testIPFSConnector(t)
+	defer mock.Close()
+	defer ipfs.Shutdown()
+	c, _ := cid.Decode(testCid)
+	c2, _ := cid.Decode(testCid2)
+
+	ipfs.Pin(c)
+	ipfs.Pin(c2)
+	ipsMap, err := ipfs.PinLs()
+	if err != nil {
+		t.Error("should not error")
+	}
+
+	if len(ipsMap) != 2 {
+		t.Fatal("the map does not contain expected keys")
+	}
+
+	if !ipsMap[testCid].IsPinned() || !ipsMap[testCid2].IsPinned() {
+		t.Error("c1 and c2 should appear pinned")
 	}
 }
 

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -187,16 +187,16 @@ type PinTracker interface {
 	// Untrack tells the tracker that a Cid is to be forgotten. The tracker
 	// may perform an IPFS unpin operation.
 	Untrack(*cid.Cid) error
-	// Status returns the list of pins with their local status.
-	Status() []PinInfo
-	// StatusCid returns the local status of a given Cid.
-	StatusCid(*cid.Cid) PinInfo
-	// Sync makes sure that all tracked Cids reflect the real IPFS status.
+	// StatusAll returns the list of pins with their local status.
+	StatusAll() []PinInfo
+	// Status returns the local status of a given Cid.
+	Status(*cid.Cid) PinInfo
+	// SyncAll makes sure that all tracked Cids reflect the real IPFS status.
 	// It returns the list of pins which were updated by the call.
-	Sync() ([]PinInfo, error)
-	// SyncCid makes sure that the Cid status reflect the real IPFS status.
-	// It return the local status of the Cid.
-	SyncCid(*cid.Cid) (PinInfo, error)
+	SyncAll() ([]PinInfo, error)
+	// Sync makes sure that the Cid status reflect the real IPFS status.
+	// It returns the local status of the Cid.
+	Sync(*cid.Cid) (PinInfo, error)
 	// Recover retriggers a Pin/Unpin operation in Cids with error status.
-	Recover(*cid.Cid) error
+	Recover(*cid.Cid) (PinInfo, error)
 }

--- a/map_pin_tracker.go
+++ b/map_pin_tracker.go
@@ -2,6 +2,7 @@ package ipfscluster
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -16,6 +17,13 @@ import (
 var (
 	PinningTimeout   = 15 * time.Minute
 	UnpinningTimeout = 10 * time.Second
+)
+
+var (
+	errUnpinningTimeout = errors.New("unpinning operation is taking too long")
+	errPinningTimeout   = errors.New("pinning operation is taking too long")
+	errPinned           = errors.New("the item is unexpectedly pinned on IPFS")
+	errUnpinned         = errors.New("the item is unexpectedly not pinned on IPFS")
 )
 
 // MapPinTracker is a PinTracker implementation which uses a Go map
@@ -83,8 +91,14 @@ func (mpt *MapPinTracker) Shutdown() error {
 	return nil
 }
 
-func (mpt *MapPinTracker) unsafeSet(c *cid.Cid, s IPFSStatus) {
-	if s == Unpinned {
+func (mpt *MapPinTracker) set(c *cid.Cid, s TrackerStatus) {
+	mpt.mux.Lock()
+	defer mpt.mux.Unlock()
+	mpt.unsafeSet(c, s)
+}
+
+func (mpt *MapPinTracker) unsafeSet(c *cid.Cid, s TrackerStatus) {
+	if s == TrackerStatusUnpinned {
 		delete(mpt.status, c.String())
 		return
 	}
@@ -93,28 +107,10 @@ func (mpt *MapPinTracker) unsafeSet(c *cid.Cid, s IPFSStatus) {
 		//		cid:    c,
 		CidStr: c.String(),
 		Peer:   mpt.peerID,
-		IPFS:   s,
+		Status: s,
 		TS:     time.Now(),
+		Error:  "",
 	}
-}
-
-func (mpt *MapPinTracker) set(c *cid.Cid, s IPFSStatus) {
-	mpt.mux.Lock()
-	defer mpt.mux.Unlock()
-	mpt.unsafeSet(c, s)
-}
-
-func (mpt *MapPinTracker) unsafeGet(c *cid.Cid) PinInfo {
-	p, ok := mpt.status[c.String()]
-	if !ok {
-		return PinInfo{
-			CidStr: c.String(),
-			Peer:   mpt.peerID,
-			IPFS:   Unpinned,
-			TS:     time.Now(),
-		}
-	}
-	return p
 }
 
 func (mpt *MapPinTracker) get(c *cid.Cid) PinInfo {
@@ -123,8 +119,51 @@ func (mpt *MapPinTracker) get(c *cid.Cid) PinInfo {
 	return mpt.unsafeGet(c)
 }
 
+func (mpt *MapPinTracker) unsafeGet(c *cid.Cid) PinInfo {
+	p, ok := mpt.status[c.String()]
+	if !ok {
+		return PinInfo{
+			CidStr: c.String(),
+			Peer:   mpt.peerID,
+			Status: TrackerStatusUnpinned,
+			TS:     time.Now(),
+			Error:  "",
+		}
+	}
+	return p
+}
+
+// sets a Cid in error state
+func (mpt *MapPinTracker) setError(c *cid.Cid, err error) {
+	mpt.mux.Lock()
+	defer mpt.mux.Unlock()
+	mpt.unsafeSetError(c, err)
+}
+
+func (mpt *MapPinTracker) unsafeSetError(c *cid.Cid, err error) {
+	p := mpt.unsafeGet(c)
+	switch p.Status {
+	case TrackerStatusPinned, TrackerStatusPinning, TrackerStatusPinError:
+		mpt.status[c.String()] = PinInfo{
+			CidStr: c.String(),
+			Peer:   mpt.peerID,
+			Status: TrackerStatusPinError,
+			TS:     time.Now(),
+			Error:  err.Error(),
+		}
+	case TrackerStatusUnpinned, TrackerStatusUnpinning, TrackerStatusUnpinError:
+		mpt.status[c.String()] = PinInfo{
+			CidStr: c.String(),
+			Peer:   mpt.peerID,
+			Status: TrackerStatusUnpinError,
+			TS:     time.Now(),
+			Error:  err.Error(),
+		}
+	}
+}
+
 func (mpt *MapPinTracker) pin(c *cid.Cid) error {
-	mpt.set(c, Pinning)
+	mpt.set(c, TrackerStatusPinning)
 	err := mpt.rpcClient.Call("",
 		"Cluster",
 		"IPFSPin",
@@ -132,25 +171,25 @@ func (mpt *MapPinTracker) pin(c *cid.Cid) error {
 		&struct{}{})
 
 	if err != nil {
-		mpt.set(c, PinError)
+		mpt.setError(c, err)
 		return err
 	}
-	mpt.set(c, Pinned)
+	mpt.set(c, TrackerStatusPinned)
 	return nil
 }
 
 func (mpt *MapPinTracker) unpin(c *cid.Cid) error {
-	mpt.set(c, Unpinning)
+	mpt.set(c, TrackerStatusUnpinning)
 	err := mpt.rpcClient.Call("",
 		"Cluster",
 		"IPFSUnpin",
 		NewCidArg(c),
 		&struct{}{})
 	if err != nil {
-		mpt.set(c, UnpinError)
+		mpt.setError(c, err)
 		return err
 	}
-	mpt.set(c, Unpinned)
+	mpt.set(c, TrackerStatusUnpinned)
 	return nil
 }
 
@@ -184,74 +223,111 @@ func (mpt *MapPinTracker) Status() []PinInfo {
 	return pins
 }
 
-// Sync verifies that the status of a Cid matches the status
-// of it in the IPFS daemon. If not, it will be transitioned
-// to Pin or Unpin error. Sync returns true if the status was
-// modified or the status is error. Pins in error states can be
-// recovered with Recover().
-func (mpt *MapPinTracker) Sync(c *cid.Cid) bool {
-	var ipfsPinned bool
-	p := mpt.get(c)
+// SyncCid verifies that the status of a Cid matches that of
+// the IPFS daemon. If not, it will be transitioned
+// to PinError or UnpinError.
+//
+// SyncCid returns the updated local status for the given Cid.
+// Pins in error states can be recovered with Recover().
+// An error is returned if we are unable to contact
+// the IPFS daemon.
+func (mpt *MapPinTracker) SyncCid(c *cid.Cid) (PinInfo, error) {
+	var ips IPFSPinStatus
 	err := mpt.rpcClient.Call("",
 		"Cluster",
-		"IPFSIsPinned",
+		"IPFSPinLsCid",
 		NewCidArg(c),
-		&ipfsPinned)
-
+		&ips)
 	if err != nil {
-		switch p.IPFS {
-		case Pinned, Pinning:
-			mpt.set(c, PinError)
-			return true
-		case Unpinned, Unpinning:
-			mpt.set(c, UnpinError)
-			return true
-		case PinError, UnpinError:
-			return true
-		default:
-			return false
+		mpt.setError(c, err)
+		return mpt.get(c), err
+	}
+	return mpt.syncStatus(c, ips), nil
+}
+
+// Sync verifies that the statuses of all tracked Cids match the
+// one reported by the IPFS daemon. If not, they will be transitioned
+// to PinError or UnpinError.
+//
+// Sync returns the list of local status for all tracked Cids which
+// were updated or have errors. Cids in error states can be recovered
+// with Recover().
+// An error is returned if we are unable to contact the IPFS daemon.
+func (mpt *MapPinTracker) Sync() ([]PinInfo, error) {
+	var ipsMap map[string]IPFSPinStatus
+	var pInfos []PinInfo
+	err := mpt.rpcClient.Call("",
+		"Cluster",
+		"IPFSPinLs",
+		struct{}{},
+		&ipsMap)
+	if err != nil {
+		mpt.mux.Lock()
+		for k := range mpt.status {
+			c, _ := cid.Decode(k)
+			mpt.unsafeSetError(c, err)
+			pInfos = append(pInfos, mpt.unsafeGet(c))
 		}
+		mpt.mux.Unlock()
+		return pInfos, err
 	}
 
-	if ipfsPinned {
-		switch p.IPFS {
-		case Pinned:
-			return false
-		case Pinning, PinError:
-			mpt.set(c, Pinned)
-			return true
-		case Unpinning:
+	status := mpt.Status()
+	for _, pInfoOrig := range status {
+		c, err := cid.Decode(pInfoOrig.CidStr)
+		if err != nil { // this should not happen but let's play safe
+			return pInfos, err
+		}
+		var pInfoNew PinInfo
+		ips, ok := ipsMap[pInfoOrig.CidStr]
+		if !ok {
+			pInfoNew = mpt.syncStatus(c, IPFSPinStatusUnpinned)
+		} else {
+			pInfoNew = mpt.syncStatus(c, ips)
+		}
+
+		if pInfoOrig.Status != pInfoNew.Status ||
+			pInfoNew.Status == TrackerStatusUnpinError ||
+			pInfoNew.Status == TrackerStatusPinError {
+			pInfos = append(pInfos, pInfoNew)
+		}
+	}
+	return pInfos, nil
+}
+
+func (mpt *MapPinTracker) syncStatus(c *cid.Cid, ips IPFSPinStatus) PinInfo {
+	p := mpt.get(c)
+	if ips.IsPinned() {
+		switch p.Status {
+		case TrackerStatusPinned: // nothing
+		case TrackerStatusPinning, TrackerStatusPinError:
+			mpt.set(c, TrackerStatusPinned)
+		case TrackerStatusUnpinning:
 			if time.Since(p.TS) > UnpinningTimeout {
-				mpt.set(c, UnpinError)
-				return true
+				mpt.setError(c, errUnpinningTimeout)
 			}
-			return false
-		case Unpinned, UnpinError:
-			mpt.set(c, UnpinError)
-			return true
+		case TrackerStatusUnpinned:
+			mpt.setError(c, errPinned)
+		case TrackerStatusUnpinError: // nothing, keep error as it was
 		default:
-			return false
 		}
 	} else {
-		switch p.IPFS {
-		case Pinned, PinError:
-			mpt.set(c, PinError)
-			return true
-		case Pinning:
+		switch p.Status {
+		case TrackerStatusPinned:
+
+			mpt.setError(c, errUnpinned)
+		case TrackerStatusPinError: // nothing, keep error as it was
+		case TrackerStatusPinning:
 			if time.Since(p.TS) > PinningTimeout {
-				mpt.set(c, PinError)
-				return true
+				mpt.setError(c, errPinningTimeout)
 			}
-			return false
-		case Unpinning, UnpinError:
-			mpt.set(c, Unpinned)
-			return true
-		case Unpinned:
-			return false
+		case TrackerStatusUnpinning, TrackerStatusUnpinError:
+			mpt.set(c, TrackerStatusUnpinned)
+		case TrackerStatusUnpinned: // nothing
 		default:
-			return false
 		}
 	}
+	return mpt.get(c)
 }
 
 // Recover will re-track or re-untrack a Cid in error state,
@@ -259,15 +335,16 @@ func (mpt *MapPinTracker) Sync(c *cid.Cid) bool {
 // only when it is done.
 func (mpt *MapPinTracker) Recover(c *cid.Cid) error {
 	p := mpt.get(c)
-	if p.IPFS != PinError && p.IPFS != UnpinError {
+	if p.Status != TrackerStatusPinError &&
+		p.Status != TrackerStatusUnpinError {
 		return nil
 	}
 	logger.Infof("Recovering %s", c)
 	var err error
-	if p.IPFS == PinError {
+	switch p.Status {
+	case TrackerStatusPinError:
 		err = mpt.Track(c)
-	}
-	if p.IPFS == UnpinError {
+	case TrackerStatusUnpinError:
 		err = mpt.Untrack(c)
 	}
 	if err != nil {

--- a/rest_api.go
+++ b/rest_api.go
@@ -79,13 +79,13 @@ type unpinResp struct {
 }
 
 type statusInfo struct {
-	IPFS  string `json:"ipfs"`
-	Error string `json:"error,omitempty"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
 }
 
 type statusCidResp struct {
-	Cid    string                `json:"cid"`
-	Status map[string]statusInfo `json:"status"`
+	Cid     string                `json:"cid"`
+	PeerMap map[string]statusInfo `json:"peer_map"`
 }
 
 type idResp struct {
@@ -465,11 +465,11 @@ func sendErrorResponse(w http.ResponseWriter, code int, msg string) {
 func transformPinToStatusCid(p GlobalPinInfo) statusCidResp {
 	s := statusCidResp{}
 	s.Cid = p.Cid.String()
-	s.Status = make(map[string]statusInfo)
-	for k, v := range p.Status {
-		s.Status[k.Pretty()] = statusInfo{
-			IPFS:  v.IPFS.String(),
-			Error: v.Error,
+	s.PeerMap = make(map[string]statusInfo)
+	for k, v := range p.PeerMap {
+		s.PeerMap[k.Pretty()] = statusInfo{
+			Status: v.Status.String(),
+			Error:  v.Error,
 		}
 	}
 	return s

--- a/rest_api_test.go
+++ b/rest_api_test.go
@@ -163,7 +163,7 @@ func TestRESTAPIStatusEndpoint(t *testing.T) {
 	makeGet(t, "/status", &resp)
 	if len(resp) != 3 ||
 		resp[0].Cid != testCid1 ||
-		resp[1].Status[testPeerID.Pretty()].IPFS != "pinning" {
+		resp[1].PeerMap[testPeerID.Pretty()].Status != "pinning" {
 		t.Errorf("unexpected statusResp:\n %+v", resp)
 	}
 }
@@ -178,11 +178,11 @@ func TestRESTAPIStatusCidEndpoint(t *testing.T) {
 	if resp.Cid != testCid {
 		t.Error("expected the same cid")
 	}
-	info, ok := resp.Status[testPeerID.Pretty()]
+	info, ok := resp.PeerMap[testPeerID.Pretty()]
 	if !ok {
 		t.Fatal("expected info for testPeerID")
 	}
-	if info.IPFS != "pinned" {
+	if info.Status != "pinned" {
 		t.Error("expected different status")
 	}
 }
@@ -196,7 +196,7 @@ func TestRESTAPIStatusSyncEndpoint(t *testing.T) {
 
 	if len(resp) != 3 ||
 		resp[0].Cid != testCid1 ||
-		resp[1].Status[testPeerID.Pretty()].IPFS != "pinning" {
+		resp[1].PeerMap[testPeerID.Pretty()].Status != "pinning" {
 		t.Errorf("unexpected statusResp:\n %+v", resp)
 	}
 }
@@ -211,11 +211,11 @@ func TestRESTAPIStatusSyncCidEndpoint(t *testing.T) {
 	if resp.Cid != testCid {
 		t.Error("expected the same cid")
 	}
-	info, ok := resp.Status[testPeerID.Pretty()]
+	info, ok := resp.PeerMap[testPeerID.Pretty()]
 	if !ok {
 		t.Fatal("expected info for testPeerID")
 	}
-	if info.IPFS != "pinned" {
+	if info.Status != "pinned" {
 		t.Error("expected different status")
 	}
 }

--- a/rest_api_test.go
+++ b/rest_api_test.go
@@ -147,7 +147,7 @@ func TestRESTAPIPinListEndpoint(t *testing.T) {
 	defer api.Shutdown()
 
 	var resp []string
-	makeGet(t, "/pins", &resp)
+	makeGet(t, "/pinlist", &resp)
 	if len(resp) != 3 ||
 		resp[0] != testCid1 || resp[1] != testCid2 ||
 		resp[2] != testCid3 {
@@ -155,12 +155,12 @@ func TestRESTAPIPinListEndpoint(t *testing.T) {
 	}
 }
 
-func TestRESTAPIStatusEndpoint(t *testing.T) {
+func TestRESTAPIStatusAllEndpoint(t *testing.T) {
 	api := testRESTAPI(t)
 	defer api.Shutdown()
 
 	var resp statusResp
-	makeGet(t, "/status", &resp)
+	makeGet(t, "/pins", &resp)
 	if len(resp) != 3 ||
 		resp[0].Cid != testCid1 ||
 		resp[1].PeerMap[testPeerID.Pretty()].Status != "pinning" {
@@ -168,12 +168,12 @@ func TestRESTAPIStatusEndpoint(t *testing.T) {
 	}
 }
 
-func TestRESTAPIStatusCidEndpoint(t *testing.T) {
+func TestRESTAPIStatusEndpoint(t *testing.T) {
 	api := testRESTAPI(t)
 	defer api.Shutdown()
 
 	var resp statusCidResp
-	makeGet(t, "/status/"+testCid, &resp)
+	makeGet(t, "/pins/"+testCid, &resp)
 
 	if resp.Cid != testCid {
 		t.Error("expected the same cid")
@@ -187,12 +187,12 @@ func TestRESTAPIStatusCidEndpoint(t *testing.T) {
 	}
 }
 
-func TestRESTAPIStatusSyncEndpoint(t *testing.T) {
+func TestRESTAPISyncAllEndpoint(t *testing.T) {
 	api := testRESTAPI(t)
 	defer api.Shutdown()
 
 	var resp statusResp
-	makePost(t, "/status", &resp)
+	makePost(t, "/pins/sync", &resp)
 
 	if len(resp) != 3 ||
 		resp[0].Cid != testCid1 ||
@@ -201,12 +201,31 @@ func TestRESTAPIStatusSyncEndpoint(t *testing.T) {
 	}
 }
 
-func TestRESTAPIStatusSyncCidEndpoint(t *testing.T) {
+func TestRESTAPISyncEndpoint(t *testing.T) {
 	api := testRESTAPI(t)
 	defer api.Shutdown()
 
 	var resp statusCidResp
-	makePost(t, "/status/"+testCid, &resp)
+	makePost(t, "/pins/"+testCid+"/sync", &resp)
+
+	if resp.Cid != testCid {
+		t.Error("expected the same cid")
+	}
+	info, ok := resp.PeerMap[testPeerID.Pretty()]
+	if !ok {
+		t.Fatal("expected info for testPeerID")
+	}
+	if info.Status != "pinned" {
+		t.Error("expected different status")
+	}
+}
+
+func TestRESTAPIRecoverEndpoint(t *testing.T) {
+	api := testRESTAPI(t)
+	defer api.Shutdown()
+
+	var resp statusCidResp
+	makePost(t, "/pins/"+testCid+"/recover", &resp)
 
 	if resp.Cid != testCid {
 		t.Error("expected the same cid")

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -91,56 +91,56 @@ func (api *RPCAPI) MemberList(in struct{}, out *[]peer.ID) error {
 	return nil
 }
 
+// StatusAll runs Cluster.StatusAll().
+func (api *RPCAPI) StatusAll(in struct{}, out *[]GlobalPinInfo) error {
+	pinfo, err := api.cluster.StatusAll()
+	*out = pinfo
+	return err
+}
+
 // Status runs Cluster.Status().
-func (api *RPCAPI) Status(in struct{}, out *[]GlobalPinInfo) error {
-	pinfo, err := api.cluster.Status()
-	*out = pinfo
-	return err
-}
-
-// StatusCid runs Cluster.StatusCid().
-func (api *RPCAPI) StatusCid(in *CidArg, out *GlobalPinInfo) error {
+func (api *RPCAPI) Status(in *CidArg, out *GlobalPinInfo) error {
 	c, err := in.CID()
 	if err != nil {
 		return err
 	}
-	pinfo, err := api.cluster.StatusCid(c)
+	pinfo, err := api.cluster.Status(c)
 	*out = pinfo
 	return err
 }
 
-// LocalSync runs Cluster.LocalSync().
-func (api *RPCAPI) LocalSync(in struct{}, out *[]PinInfo) error {
-	pinfo, err := api.cluster.LocalSync()
+// SyncAllLocal runs Cluster.SyncAllLocal().
+func (api *RPCAPI) SyncAllLocal(in struct{}, out *[]PinInfo) error {
+	pinfo, err := api.cluster.SyncAllLocal()
 	*out = pinfo
 	return err
 }
 
-// LocalSyncCid runs Cluster.LocalSyncCid().
-func (api *RPCAPI) LocalSyncCid(in *CidArg, out *PinInfo) error {
+// SyncLocal runs Cluster.SyncLocal().
+func (api *RPCAPI) SyncLocal(in *CidArg, out *PinInfo) error {
 	c, err := in.CID()
 	if err != nil {
 		return err
 	}
-	pinfo, err := api.cluster.LocalSyncCid(c)
+	pinfo, err := api.cluster.SyncLocal(c)
 	*out = pinfo
 	return err
 }
 
-// GlobalSync runs Cluster.GlobalSync().
-func (api *RPCAPI) GlobalSync(in struct{}, out *[]GlobalPinInfo) error {
-	pinfo, err := api.cluster.GlobalSync()
+// SyncAll runs Cluster.SyncAll().
+func (api *RPCAPI) SyncAll(in struct{}, out *[]GlobalPinInfo) error {
+	pinfo, err := api.cluster.SyncAll()
 	*out = pinfo
 	return err
 }
 
-// GlobalSyncCid runs Cluster.GlobalSyncCid().
-func (api *RPCAPI) GlobalSyncCid(in *CidArg, out *GlobalPinInfo) error {
+// Sync runs Cluster.Sync().
+func (api *RPCAPI) Sync(in *CidArg, out *GlobalPinInfo) error {
 	c, err := in.CID()
 	if err != nil {
 		return err
 	}
-	pinfo, err := api.cluster.GlobalSyncCid(c)
+	pinfo, err := api.cluster.Sync(c)
 	*out = pinfo
 	return err
 }
@@ -148,6 +148,17 @@ func (api *RPCAPI) GlobalSyncCid(in *CidArg, out *GlobalPinInfo) error {
 // StateSync runs Cluster.StateSync().
 func (api *RPCAPI) StateSync(in struct{}, out *[]PinInfo) error {
 	pinfo, err := api.cluster.StateSync()
+	*out = pinfo
+	return err
+}
+
+// Recover runs Cluster.Recover().
+func (api *RPCAPI) Recover(in *CidArg, out *GlobalPinInfo) error {
+	c, err := in.CID()
+	if err != nil {
+		return err
+	}
+	pinfo, err := api.cluster.Recover(c)
 	*out = pinfo
 	return err
 }
@@ -174,24 +185,33 @@ func (api *RPCAPI) Untrack(in *CidArg, out *struct{}) error {
 	return api.cluster.tracker.Untrack(c)
 }
 
-// TrackerStatus runs PinTracker.Status().
-func (api *RPCAPI) TrackerStatus(in struct{}, out *[]PinInfo) error {
-	*out = api.cluster.tracker.Status()
+// TrackerStatusAll runs PinTracker.StatusAll().
+func (api *RPCAPI) TrackerStatusAll(in struct{}, out *[]PinInfo) error {
+	*out = api.cluster.tracker.StatusAll()
 	return nil
 }
 
-// TrackerStatusCid runs PinTracker.StatusCid().
-func (api *RPCAPI) TrackerStatusCid(in *CidArg, out *PinInfo) error {
+// TrackerStatus runs PinTracker.Status().
+func (api *RPCAPI) TrackerStatus(in *CidArg, out *PinInfo) error {
 	c, err := in.CID()
 	if err != nil {
 		return err
 	}
-	pinfo := api.cluster.tracker.StatusCid(c)
+	pinfo := api.cluster.tracker.Status(c)
 	*out = pinfo
 	return nil
 }
 
-// TrackerRecover not sure if needed
+// TrackerRecover runs PinTracker.Recover().
+func (api *RPCAPI) TrackerRecover(in *CidArg, out *PinInfo) error {
+	c, err := in.CID()
+	if err != nil {
+		return err
+	}
+	pinfo, err := api.cluster.tracker.Recover(c)
+	*out = pinfo
+	return err
+}
 
 /*
    IPFS Connector component methods

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -44,6 +44,7 @@ func (arg *CidArg) CID() (*cid.Cid, error) {
    Cluster components methods
 */
 
+// ID runs Cluster.ID()
 func (api *RPCAPI) ID(in struct{}, out *ID) error {
 	*out = api.cluster.ID()
 	return nil
@@ -214,14 +215,21 @@ func (api *RPCAPI) IPFSUnpin(in *CidArg, out *struct{}) error {
 	return api.cluster.ipfs.Unpin(c)
 }
 
-// IPFSIsPinned runs IPFSConnector.IsPinned().
-func (api *RPCAPI) IPFSIsPinned(in *CidArg, out *bool) error {
+// IPFSPinLsCid runs IPFSConnector.PinLsCid().
+func (api *RPCAPI) IPFSPinLsCid(in *CidArg, out *IPFSPinStatus) error {
 	c, err := in.CID()
 	if err != nil {
 		return err
 	}
-	b, err := api.cluster.ipfs.IsPinned(c)
+	b, err := api.cluster.ipfs.PinLsCid(c)
 	*out = b
+	return err
+}
+
+// IPFSPinLs runs IPFSConnector.PinLs().
+func (api *RPCAPI) IPFSPinLs(in struct{}, out *map[string]IPFSPinStatus) error {
+	m, err := api.cluster.ipfs.PinLs()
+	*out = m
 	return err
 }
 

--- a/rpc_api_test.go
+++ b/rpc_api_test.go
@@ -73,33 +73,33 @@ func (mock *mockService) Status(in struct{}, out *[]GlobalPinInfo) error {
 	*out = []GlobalPinInfo{
 		{
 			Cid: c1,
-			Status: map[peer.ID]PinInfo{
+			PeerMap: map[peer.ID]PinInfo{
 				testPeerID: {
 					CidStr: testCid1,
 					Peer:   testPeerID,
-					IPFS:   Pinned,
+					Status: TrackerStatusPinned,
 					TS:     time.Now(),
 				},
 			},
 		},
 		{
 			Cid: c2,
-			Status: map[peer.ID]PinInfo{
+			PeerMap: map[peer.ID]PinInfo{
 				testPeerID: {
 					CidStr: testCid2,
 					Peer:   testPeerID,
-					IPFS:   Pinning,
+					Status: TrackerStatusPinning,
 					TS:     time.Now(),
 				},
 			},
 		},
 		{
 			Cid: c3,
-			Status: map[peer.ID]PinInfo{
+			PeerMap: map[peer.ID]PinInfo{
 				testPeerID: {
 					CidStr: testCid3,
 					Peer:   testPeerID,
-					IPFS:   PinError,
+					Status: TrackerStatusPinError,
 					TS:     time.Now(),
 				},
 			},
@@ -115,11 +115,11 @@ func (mock *mockService) StatusCid(in *CidArg, out *GlobalPinInfo) error {
 	c1, _ := cid.Decode(testCid1)
 	*out = GlobalPinInfo{
 		Cid: c1,
-		Status: map[peer.ID]PinInfo{
+		PeerMap: map[peer.ID]PinInfo{
 			testPeerID: {
 				CidStr: testCid1,
 				Peer:   testPeerID,
-				IPFS:   Pinned,
+				Status: TrackerStatusPinned,
 				TS:     time.Now(),
 			},
 		},

--- a/rpc_api_test.go
+++ b/rpc_api_test.go
@@ -66,7 +66,7 @@ func (mock *mockService) MemberList(in struct{}, out *[]peer.ID) error {
 	return nil
 }
 
-func (mock *mockService) Status(in struct{}, out *[]GlobalPinInfo) error {
+func (mock *mockService) StatusAll(in struct{}, out *[]GlobalPinInfo) error {
 	c1, _ := cid.Decode(testCid1)
 	c2, _ := cid.Decode(testCid2)
 	c3, _ := cid.Decode(testCid3)
@@ -108,7 +108,7 @@ func (mock *mockService) Status(in struct{}, out *[]GlobalPinInfo) error {
 	return nil
 }
 
-func (mock *mockService) StatusCid(in *CidArg, out *GlobalPinInfo) error {
+func (mock *mockService) Status(in *CidArg, out *GlobalPinInfo) error {
 	if in.Cid == errorCid {
 		return errBadCid
 	}
@@ -127,17 +127,21 @@ func (mock *mockService) StatusCid(in *CidArg, out *GlobalPinInfo) error {
 	return nil
 }
 
-func (mock *mockService) GlobalSync(in struct{}, out *[]GlobalPinInfo) error {
-	return mock.Status(in, out)
+func (mock *mockService) SyncAll(in struct{}, out *[]GlobalPinInfo) error {
+	return mock.StatusAll(in, out)
 }
 
-func (mock *mockService) GlobalSyncCid(in *CidArg, out *GlobalPinInfo) error {
-	return mock.StatusCid(in, out)
+func (mock *mockService) Sync(in *CidArg, out *GlobalPinInfo) error {
+	return mock.Status(in, out)
 }
 
 func (mock *mockService) StateSync(in struct{}, out *[]PinInfo) error {
 	*out = []PinInfo{}
 	return nil
+}
+
+func (mock *mockService) Recover(in *CidArg, out *GlobalPinInfo) error {
+	return mock.Status(in, out)
 }
 
 func (mock *mockService) Track(in *CidArg, out *struct{}) error {


### PR DESCRIPTION
* Syncing all Cids should use PinLs
* Renamed API methods, Internal types and endpoints to something I find more consistent
* Moved Recover() ops to it's own endpoint and allow only on single CID.
* Support all this in cluster-ctl