### PR TITLE
Fix #15: Peers() provides lots of information now

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Additionally, cluster nodes act as a proxy/wrapper to the IPFS API, so they can 
 
 IPFS Cluster provides a cluster-node application (`ipfs-cluster-service`), a Go API, a HTTP API and a command-line tool (`ipfs-cluster-ctl`).
 
-Current functionality only allows pinning in all cluster members, but more strategies (like setting a replication factor for each pin) will be developed.
+Current functionality only allows pinning in all cluster peers, but more strategies (like setting a replication factor for each pin) will be developed.
 
 ## Table of Contents
 
@@ -41,7 +41,7 @@ Current functionality only allows pinning in all cluster members, but more strat
 
 Since the start of IPFS it was clear that a tool to coordinate a number of different nodes (and the content they are supposed to store) would add a great value to the IPFS ecosystem. Naïve approaches are possible, but they present some weaknesses, specially at dealing with error handling, recovery and implementation of advanced pinning strategies.
 
-`ipfs-cluster` aims to address this issues by providing a IPFS node wrapper which coordinates multiple cluster members via a consensus algorithm. This ensures that the desired state of the system is always agreed upon and can be easily maintained by the members of the cluster. Thus, every cluster member knows which content is tracked, can decide whether asking IPFS to pin it and can react to any contingencies like node reboots.
+`ipfs-cluster` aims to address this issues by providing a IPFS node wrapper which coordinates multiple cluster peers via a consensus algorithm. This ensures that the desired state of the system is always agreed upon and can be easily maintained by the cluster peers. Thus, every cluster node knows which content is tracked, can decide whether asking IPFS to pin it and can react to any contingencies like node reboots.
 
 ## Captain
 
@@ -63,7 +63,7 @@ This will install `ipfs-cluster-service` and `ipfs-cluster-ctl` in your `$GOPATH
 
 ### `ipfs-cluster-service`
 
-`ipfs-cluster-service` runs a member node for the cluster. Usage information can be obtained running:
+`ipfs-cluster-service` runs a cluster peer. Usage information can be obtained running:
 
 ```
 $ ipfs-cluster-service -h
@@ -78,7 +78,7 @@ $ ipfs-cluster-service -init
 
 The configuration will be placed in `~/.ipfs-cluster/service.json` by default.
 
-You can add the multiaddresses for the other members of the cluster in the `cluster_peers` variable. For example, here is a valid configuration for a cluster of 4 members:
+You can add the multiaddresses for the other cluster peers the `cluster_peers` variable. For example, here is a valid configuration for a cluster of 4 peers:
 
 ```json
 {
@@ -101,9 +101,9 @@ You can add the multiaddresses for the other members of the cluster in the `clus
     }
 ```
 
-The configuration file should probably be identical among all cluster members, except for the `id` and `private_key` fields. To facilitate configuration, `cluster_peers` may include its own address, but it does not have to. For additional information about the configuration format, see the [JSONConfig documentation](https://godoc.org/github.com/ipfs/ipfs-cluster#JSONConfig).
+The configuration file should probably be identical among all cluster peers, except for the `id` and `private_key` fields. To facilitate configuration, `cluster_peers` may include its own address, but it does not have to. For additional information about the configuration format, see the [JSONConfig documentation](https://godoc.org/github.com/ipfs/ipfs-cluster#JSONConfig).
 
-Once every cluster member has the configuration in place, you can run `ipfs-cluster-service` to start the cluster.
+Once every cluster peer has the configuration in place, you can run `ipfs-cluster-service` to start the cluster.
 
 
 ### `ipfs-cluster-ctl`
@@ -116,7 +116,7 @@ information about supported commands.
 In summary, it works as follows:
 
 ```
-$ ipfs-cluster-ctl member ls                                                # list cluster members
+$ ipfs-cluster-ctl peers ls                                                # list cluster peers
 $ ipfs-cluster-ctl pin add Qma4Lid2T1F68E3Xa3CpE6vVJDLwxXLD8RfiB9g1Tmqp58   # pins a Cid in the cluster
 $ ipfs-cluster-ctl pin rm Qma4Lid2T1F68E3Xa3CpE6vVJDLwxXLD8RfiB9g1Tmqp58    # unpins a Cid from the cluster
 $ ipfs-cluster-ctl status                                                   # display tracked Cids information

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,9 +14,9 @@ This quarter is going to be focused on bringing ipfs-cluster to life as a usable
 
 On these lines, there are several endeavours which stand out for themselves and are officially part of the general IPFS Roadmaps:
 
-* Dynamically add and remove cluster members in an easy fashion (https://github.com/ipfs/pm/issues/353)
+* Dynamically add and remove cluster peers in an easy fashion (https://github.com/ipfs/pm/issues/353)
 
-This involves easily adding a member (or removing) from a running cluster. `ipfs-cluster-service member add <maddress>` should work and should update the peer set of all components of all members, along with their configurations.
+This involves easily adding a peer (or removing) from a running cluster. `ipfs-cluster-service peer add <maddress>` should work and should update the peer set of all components of all peers, along with their configurations.
 
 * Replication-factor-based pinning strategy (https://github.com/ipfs/pm/issues/353)
 

--- a/architecture.md
+++ b/architecture.md
@@ -4,12 +4,12 @@
 
 These definitions are still evolving and may change:
 
-  * Member: an ipfs cluster server node which is member of the consensus. Alternatively: node, peer
+  * Peer: an ipfs cluster service node which is member of the consensus. Alternatively: node, member.
   * ipfs-cluster: the IPFS cluster software
   * ipfs-cluster-ctl: the IPFS cluster client command line application
   * ipfs-cluster-service: the IPFS cluster node application
   * API: the REST-ish API implemented by the RESTAPI component and used by the clients.
-  * RPC API: the internal API that cluster members and components use.
+  * RPC API: the internal API that cluster peers and components use.
   * Go API: the public interface offered by the Cluster object in Go.
   * Component: an ipfs-cluster module which performs specific functions and uses the RPC API to communicate with other parts of the system. Implements the Component interface.
 
@@ -38,7 +38,7 @@ Components perform a number of functions and need to be able to communicate with
 
   * the API needs to use functionality provided by the main component
   * the PinTracker needs to use functionality provided by the IPFSConnector
-  * the main component needs to use functionality provided by the main component of a different member (the leader)
+  * the main component needs to use functionality provided by the main component of a different peer (the leader)
 
 ### RPC API
 
@@ -56,7 +56,7 @@ Currently, all components live in the same `ipfscluster` Go module, but they sha
 
 ### `ipfs-cluster-service`
 
-This is the service application of IPFS Cluster. It brings up a cluster, connects to other members, gets the latest consensus state and participates in cluster.
+This is the service application of IPFS Cluster. It brings up a cluster, connects to other peers, gets the latest consensus state and participates in cluster.
 
 ### `ipfs-cluster-ctl`
 

--- a/captain.log.md
+++ b/captain.log.md
@@ -6,7 +6,7 @@ I have just merged the initial cluster version into master. There are many rough
 
 The rest of the quarter will be focused on 4 main issues:
 
-* Simplify the process of adding and removing members of a cluster
+* Simplify the process of adding and removing cluster peers
 * Implement a replication-factor-based pinning strategy
 * Generate real end to end tests
 * Make ipfs-cluster stable

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -30,6 +30,15 @@ type mockConnector struct {
 	mockComponent
 }
 
+func (ipfs *mockConnector) ID() (IPFSID, error) {
+	if ipfs.returnError {
+		return IPFSID{}, errors.New("")
+	}
+	return IPFSID{
+		ID: testPeerID,
+	}, nil
+}
+
 func (ipfs *mockConnector) Pin(c *cid.Cid) error {
 	if ipfs.returnError {
 		return errors.New("")
@@ -179,14 +188,16 @@ func TestClusterUnpin(t *testing.T) {
 	}
 }
 
-func TestClusterMembers(t *testing.T) {
+func TestClusterPeers(t *testing.T) {
 	cl, _, _, _, _ := testingCluster(t)
 	defer cleanRaft()
 	defer cl.Shutdown()
-	m := cl.Members()
-	id := testingConfig().ID
-	if len(m) != 1 || m[0] != id {
-		t.Error("bad Members()")
+	peers := cl.Peers()
+	if len(peers) != 1 {
+		t.Fatal("expected 1 peer")
+	}
+	if peers[0].ID != testingConfig().ID {
+		t.Error("bad member")
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -72,7 +72,7 @@ type JSONConfig struct {
 	ClusterPeers []string `json:"cluster_peers"`
 
 	// Listen address for the Cluster libp2p host. This is used for
-	// interal RPC and Consensus communications between cluster members.
+	// interal RPC and Consensus communications between cluster peers.
 	ClusterListenMultiaddress string `json:"cluster_multiaddress"`
 
 	// Listen address for the the Cluster HTTP API component.

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -120,17 +120,17 @@ This command will print out information about the cluster peer used
 			},
 		},
 		{
-			Name:  "member",
-			Usage: "list and manage IPFS Cluster members",
+			Name:  "peers",
+			Usage: "list and manage IPFS Cluster peers",
 			UsageText: `
-This command can be used to list and manage IPFS Cluster members.
+This command can be used to list and manage IPFS Cluster peers.
 `,
 			Subcommands: []cli.Command{
 				{
 					Name:  "ls",
 					Usage: "list the nodes participating in the IPFS Cluster",
 					Action: func(c *cli.Context) error {
-						resp := request("GET", "/members")
+						resp := request("GET", "/peers")
 						formatResponse(resp)
 						return nil
 					},

--- a/ipfs_http_connector_test.go
+++ b/ipfs_http_connector_test.go
@@ -34,6 +34,32 @@ func TestNewIPFSHTTPConnector(t *testing.T) {
 	defer ipfs.Shutdown()
 }
 
+func TestIPFSID(t *testing.T) {
+	ipfs, mock := testIPFSConnector(t)
+	defer ipfs.Shutdown()
+	id, err := ipfs.ID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id.ID != testPeerID {
+		t.Error("expected testPeerID")
+	}
+	if len(id.Addresses) != 1 {
+		t.Error("expected 1 address")
+	}
+	if id.Error != "" {
+		t.Error("expected no error")
+	}
+	mock.Close()
+	id, err = ipfs.ID()
+	if err == nil {
+		t.Error("expected an error")
+	}
+	if id.Error != err.Error() {
+		t.Error("error messages should match")
+	}
+}
+
 func TestIPFSPin(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()

--- a/ipfsmock_test.go
+++ b/ipfsmock_test.go
@@ -63,6 +63,15 @@ func (m *ipfsMock) handler(w http.ResponseWriter, r *http.Request) {
 	endp := strings.TrimPrefix(p, "/api/v0/")
 	var cidStr string
 	switch endp {
+	case "id":
+		resp := ipfsIDResp{
+			ID: testPeerID.Pretty(),
+			Addresses: []string{
+				"/ip4/0.0.0.0/tcp/1234",
+			},
+		}
+		j, _ := json.Marshal(resp)
+		w.Write(j)
 	case "pin/add":
 		query := r.URL.Query()
 		arg, ok := query["arg"]

--- a/rest_api_test.go
+++ b/rest_api_test.go
@@ -76,7 +76,7 @@ func TestRESTAPIShutdown(t *testing.T) {
 func TestRestAPIIDEndpoint(t *testing.T) {
 	api := testRESTAPI(t)
 	defer api.Shutdown()
-	id := idResp{}
+	id := restIDResp{}
 	makeGet(t, "/id", &id)
 	if id.ID != testPeerID.Pretty() {
 		t.Error("expected correct id")
@@ -93,13 +93,16 @@ func TestRESTAPIVersionEndpoint(t *testing.T) {
 	}
 }
 
-func TestRESTAPIMemberListEndpoint(t *testing.T) {
+func TestRESTAPIPeerstEndpoint(t *testing.T) {
 	api := testRESTAPI(t)
 	defer api.Shutdown()
 
-	var list []string
-	makeGet(t, "/members", &list)
-	if len(list) != 1 || list[0] != testPeerID.Pretty() {
+	var list []restIDResp
+	makeGet(t, "/peers", &list)
+	if len(list) != 1 {
+		t.Fatal("expected 1 element")
+	}
+	if list[0].ID != testPeerID.Pretty() {
 		t.Error("expected a different peer id list: ", list)
 	}
 }

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -1,12 +1,9 @@
 package ipfscluster
 
-import (
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
-)
+import cid "github.com/ipfs/go-cid"
 
 // RPCAPI is a go-libp2p-gorpc service which provides the internal ipfs-cluster
-// API, which enables components and members of the cluster to communicate and
+// API, which enables components and cluster peers to communicate and
 // request actions from each other.
 //
 // The RPC API methods are usually redirects to the actual methods in
@@ -45,8 +42,9 @@ func (arg *CidArg) CID() (*cid.Cid, error) {
 */
 
 // ID runs Cluster.ID()
-func (api *RPCAPI) ID(in struct{}, out *ID) error {
-	*out = api.cluster.ID()
+func (api *RPCAPI) ID(in struct{}, out *IDSerial) error {
+	id := api.cluster.ID().ToSerial()
+	*out = id
 	return nil
 }
 
@@ -85,9 +83,14 @@ func (api *RPCAPI) Version(in struct{}, out *string) error {
 	return nil
 }
 
-// MemberList runs Cluster.Members().
-func (api *RPCAPI) MemberList(in struct{}, out *[]peer.ID) error {
-	*out = api.cluster.Members()
+// Peers runs Cluster.Peers().
+func (api *RPCAPI) Peers(in struct{}, out *[]IDSerial) error {
+	peers := api.cluster.Peers()
+	var sPeers []IDSerial
+	for _, p := range peers {
+		sPeers = append(sPeers, p.ToSerial())
+	}
+	*out = sPeers
 	return nil
 }
 

--- a/rpc_api_test.go
+++ b/rpc_api_test.go
@@ -44,7 +44,7 @@ func (mock *mockService) PinList(in struct{}, out *[]string) error {
 	return nil
 }
 
-func (mock *mockService) ID(in struct{}, out *ID) error {
+func (mock *mockService) ID(in struct{}, out *IDSerial) error {
 	_, pubkey, _ := crypto.GenerateKeyPair(
 		DefaultConfigCrypto,
 		DefaultConfigKeyLength)
@@ -52,7 +52,10 @@ func (mock *mockService) ID(in struct{}, out *ID) error {
 		ID:        testPeerID,
 		PublicKey: pubkey,
 		Version:   "0.0.mock",
-	}
+		IPFS: IPFSID{
+			ID: testPeerID,
+		},
+	}.ToSerial()
 	return nil
 }
 
@@ -61,8 +64,11 @@ func (mock *mockService) Version(in struct{}, out *string) error {
 	return nil
 }
 
-func (mock *mockService) MemberList(in struct{}, out *[]peer.ID) error {
-	*out = []peer.ID{testPeerID}
+func (mock *mockService) Peers(in struct{}, out *[]IDSerial) error {
+	id := IDSerial{}
+	mock.ID(in, &id)
+
+	*out = []IDSerial{id}
 	return nil
 }
 


### PR DESCRIPTION
I have renamed "members" to "peers".

Added IPFS daemon ID and addresses to the ID object and
have Peers() return the collection of ID() objects from the cluster.

#15 