### PR TITLE
Fix #9: Add customHandlers for pin/add pin/rm and pin/ls

### DIFF
--- a/ipfsmock_test.go
+++ b/ipfsmock_test.go
@@ -143,6 +143,8 @@ func (m *ipfsMock) handler(w http.ResponseWriter, r *http.Request) {
 			j, _ := json.Marshal(resp)
 			w.Write(j)
 		}
+	case "version":
+		w.Write([]byte("{\"Version\":\"m.o.c.k\"}"))
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}


### PR DESCRIPTION
The proxy now mimics the IPFS daemon for these commands, except
the requests trigger cluster operations.

#9 