### PR TITLE
PeerAdd and PeerRemove() functionality

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -32,7 +32,7 @@ These definitions are still evolving and may change:
     * **IPFSConnector**: a component which talks to the IPFS daemon and provides a proxy to it. Default: `IPFSHTTPConnector`
     * **API**: a component which offers a public facing API. Default: `RESTAPI`
     * **State**: a component which keeps a list of Pins (maintained by the Consensus component)
-  * The **Consensus** component. This component separate but internal to Cluster in the sense that it cannot be provided arbitrarily during initialization. The consensus component uses `go-libp2p-raft` via `go-libp2p-consensus`. While it is attempted to be agnostic from the underlying consensus implementation, it is not possible in all places. These places are however well marked.
+  * The **Consensus** component. This component is separate but internal to Cluster in the sense that it cannot be provided arbitrarily during initialization. The consensus component uses `go-libp2p-raft` via `go-libp2p-consensus`. While it is attempted to be agnostic from the underlying consensus implementation, it is not possible in all places. These places are however well marked.
 
 Components perform a number of functions and need to be able to communicate with eachothers: i.e.:
 
@@ -61,6 +61,54 @@ This is the service application of IPFS Cluster. It brings up a cluster, connect
 ### `ipfs-cluster-ctl`
 
 This is the client/control application of IPFS Cluster. It is a command line interface which uses the REST API to communicate with Cluster.
+
+## Code paths
+
+This sections explains how some things work in Cluster.
+
+### Startup
+
+* `NewCluster` triggers the Cluster bootstrap. `IPFSConnector`, `State`, `PinTracker` component are provided. These components are up but possibly waiting for a `SetClient(RPCClient)` call. Without having an RPCClient, they are unable to communicate with the other components.
+* The first step bootstrapping is to create the libp2p `Host`. It is using configuration keys to set up public, private keys, the swarm network etc.
+* The `peerManager` is initialized. Peers from the configuration and ourselves are added to the peer list.
+* The `RPCServer` (`go-libp2p-gorpc`) is setup, along with an `RPCClient`. The client can communicate to any RPC server using libp2p, or with the local one (shortcutting). The `RPCAPI` object is registered: it implements all the RPC operations supported by cluster and used for inter-component/inter-peer communication.
+* The `Consensus` component is bootstrapped. It:
+  * Sets up a new Raft node from scratch, including snapshots, stable datastore (boltDB), log store etc...
+  * Initializes `go-libp2p-consensus` components (`Actor` and `LogOpConsensus`) using `go-libp2p-raft`
+  * Returns a new `Consensus` object while asynchronously waiting for a Raft leader and then also for the current Raft peer to catch up with the latest index of the log.
+  * Waits for an RPCClient to be set and when it happens it triggers an asynchronous RPC request (`StateSync`) to the local `Cluster` component and reports `Ready()`
+  * The `StateSync` operation (from the main `Cluster` component) makes a diff between the local `MapPinTracker` state and the consensus-maintained state. It triggers asynchronous local RPC requests (`Track` and `Untrack`) to the `MapPinTracker`.
+  * The `MapPinTracker` receives the `Track` requests and checks, pins or unpins items, as well as updating the local status of a pin (see the Pinning section below)
+* While the consensus is being bootstrapped, `SetClient(RPCClient` is called on all components (tracker, ipfs connector, api and consensus)
+* The new `Cluster` object is returned.
+* Asynchronously, a thread waits for the `Consensus` component to report `Ready()`. When this happens, `Cluster` reports itself `Ready()`. At this moment, all components are up, consensus is working and cluster is ready to perform any operations. The consensus state may still be syncing, or mostly the `MapPinTracker` may still be verifying that pins are there against the daemon, but this does not causes any problems to use cluster.
+
+
+### Adding a peer
+
+* The `RESTAPI` component receives a `PeerAdd` request on the respective endpoint. It makes a `PeerAdd` RPC request.
+* The local RPC server receives it and calls `PeerAdd` method in the main `Cluster` component.
+* A libp2p connection is opened to the new peer's multiaddress. It should be reachable. We note down the local multiaddress used to reach the new peer.
+* A broadcast `PeerManagerAddPeer` request is sent to all peers in the current cluster. It is received and the RPC server calls `peerManager.addPeer`. The `peerManager` is an annex to the main Cluster Component around the peer management functionality (add/remove).
+* The `peerManager` adds the new peer to libp2p's peerstore, asks Raft to make if part of its peerset and adds it to the `ClusterPeers` section
+of the configuration (which is then saved).
+* If the broadcast requests fails somewhere, the operation is aborted, and a `PeerRemove` operation for the new peer is triggered to undo any changes. Otherwise, on success, the local list of ClusterPeers from the configuration, along with the local multiaddress from the connection we noted down are
+sent to the new peer (via the RPC `PeerManagerAddFromMultiaddrs` method).
+* The new peer's `peerManager` updates the current list of peers, the Raft's peer set and the configuration and has become part of the new cluster.
+* The `PeerAdd` method in `Cluster` makes an remote RPC request to the new peers `ID` method. The received ID is used as response to the call.
+* The RPC server takes the response and sends it to the `RESTAPI` component, which in turns converts it and responds to the request.
+
+### Pinning
+
+* The `RESTAPI` component receives a `Pin` request on the respective endpoint. This triggers a `Pin` RPC request.
+* The local RPC server receives it and calls `Pin` method in the main `Cluster` component.
+* The main cluster component calls `LogPin` in the `Consensus` Component.
+* The Consensus component checks that it is the Raft leader, or alternatively makes an `ConsensusLogPin` RPC request to whoever is the leader.
+* The Consensus component of the current Raft's leader builds a pin `clusterLogOp` operation performs a `consensus.Commit(op)`. This is handled by `go-libp2p-raft` and, when the operation makes it to the Raft's log, it triggers `clusterLogOp.ApplyTo(state)` in every peer.
+* `ApplyTo` modifies the local cluster state by adding the pin and triggers an asynchronous `Track` local RPC request. It returns without waiting for the result. While `ApplyTo` is running no other state updates may be applied so it is a critical code path.
+* The RPC server handles the request to the `MapPinTracker` component and its `Track` method. It marks the local state of the pin as `pinning` and makes a local RPC request for the `IPFSHTTPConnector` component (`IPFSPin`) to pin it.
+* The `IPFSHTTPConnector` component receives the request and uses the configured IPFS daemon API to send a pin request with the given hash. It waits until the call comes back and returns success or failure.
+* The `MapPinTracker` component receives the result from the RPC request to the `IPFSHTTPConnector` and updates the local status of the pin to `pinned` or `pin_error`.
 
 ## Legacy illustrations
 

--- a/cluster.go
+++ b/cluster.go
@@ -100,7 +100,7 @@ func NewCluster(cfg *Config, api API, ipfs IPFSConnector, state State, tracker P
 	cluster.rpcClient = rpcClient
 
 	// Setup Consensus
-	consensus, err := NewConsensus(cfg, host, state)
+	consensus, err := NewConsensus(pm.peers(), host, cfg.ConsensusDataFolder, state)
 	if err != nil {
 		logger.Errorf("error creating consensus: %s", err)
 		cluster.Shutdown()
@@ -439,6 +439,7 @@ func (c *Cluster) Recover(h *cid.Cid) (GlobalPinInfo, error) {
 func (c *Cluster) Pins() []*cid.Cid {
 	cState, err := c.consensus.State()
 	if err != nil {
+		logger.Error(err)
 		return []*cid.Cid{}
 	}
 	return cState.ListPins()

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -85,6 +85,7 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *MapState
 	if err != nil {
 		t.Fatal("cannot create cluster:", err)
 	}
+	<-cl.Ready()
 	return cl, api, ipfs, st, tracker
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -11,10 +11,6 @@ func testingConfig() *Config {
 		APIListenMultiaddress:       "/ip4/127.0.0.1/tcp/10002",
 		IPFSProxyListenMultiaddress: "/ip4/127.0.0.1/tcp/10001",
 		ConsensusDataFolder:         "./raftFolderFromTests",
-		RaftConfig: &RaftConfig{
-			EnableSingleNode:        true,
-			SnapshotIntervalSeconds: 120,
-		},
 	}
 
 	cfg, _ := jcfg.ToConfig()

--- a/config_test.go
+++ b/config_test.go
@@ -1,5 +1,7 @@
 package ipfscluster
 
+import "testing"
+
 func testingConfig() *Config {
 	jcfg := &JSONConfig{
 		ID:         "QmUfSFm12eYCaRdypg48m8RqkXfLW7A2ZeGZb2skeHHDGA",
@@ -17,4 +19,79 @@ func testingConfig() *Config {
 
 	cfg, _ := jcfg.ToConfig()
 	return cfg
+}
+
+func TestDefaultConfig(t *testing.T) {
+	_, err := NewDefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConfigToJSON(t *testing.T) {
+	cfg, err := NewDefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cfg.ToJSONConfig()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestConfigToConfig(t *testing.T) {
+	cfg, _ := NewDefaultConfig()
+	j, _ := cfg.ToJSONConfig()
+	_, err := j.ToConfig()
+	if err != nil {
+		t.Error(err)
+	}
+
+	j.ID = "abc"
+	_, err = j.ToConfig()
+	if err == nil {
+		t.Error("expected error decoding ID")
+	}
+
+	j, _ = cfg.ToJSONConfig()
+	j.PrivateKey = "abc"
+	_, err = j.ToConfig()
+	if err == nil {
+		t.Error("expected error parsing private key")
+	}
+
+	j, _ = cfg.ToJSONConfig()
+	j.ClusterListenMultiaddress = "abc"
+	_, err = j.ToConfig()
+	if err == nil {
+		t.Error("expected error parsing cluster_listen_multiaddress")
+	}
+
+	j, _ = cfg.ToJSONConfig()
+	j.APIListenMultiaddress = "abc"
+	_, err = j.ToConfig()
+	if err == nil {
+		t.Error("expected error parsing api_listen_multiaddress")
+	}
+
+	j, _ = cfg.ToJSONConfig()
+	j.IPFSProxyListenMultiaddress = "abc"
+	_, err = j.ToConfig()
+	if err == nil {
+		t.Error("expected error parsing ipfs_proxy_listen_multiaddress")
+	}
+
+	j, _ = cfg.ToJSONConfig()
+	j.IPFSNodeMultiaddress = "abc"
+	_, err = j.ToConfig()
+	if err == nil {
+		t.Error("expected error parsing ipfs_node_multiaddress")
+	}
+
+	j, _ = cfg.ToJSONConfig()
+	j.ClusterPeers = []string{"abc"}
+	_, err = j.ToConfig()
+	if err == nil {
+		t.Error("expected error parsing cluster_peers")
+	}
 }

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -97,6 +97,7 @@ func testingConsensus(t *testing.T) *Consensus {
 		t.Fatal("cannot create Consensus:", err)
 	}
 	cc.SetClient(mockRPCClient(t))
+	<-cc.Ready()
 	return cc
 }
 

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-peer"
 )
 
 func TestApplyToPin(t *testing.T) {
@@ -92,7 +93,7 @@ func testingConsensus(t *testing.T) *Consensus {
 		t.Fatal("cannot create host:", err)
 	}
 	st := NewMapState()
-	cc, err := NewConsensus(cfg, h, st)
+	cc, err := NewConsensus([]peer.ID{cfg.ID}, h, cfg.ConsensusDataFolder, st)
 	if err != nil {
 		t.Fatal("cannot create Consensus:", err)
 	}

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,62 @@
+package ipfscluster
+
+import (
+	"bufio"
+	"bytes"
+	"log"
+	"strings"
+	"time"
+
+	logging "github.com/ipfs/go-log"
+)
+
+var logger = logging.Logger("cluster")
+var raftStdLogger = makeRaftLogger()
+var raftLogger = logging.Logger("raft")
+
+// SetLogLevel sets the level in the logs
+func SetLogLevel(l string) {
+	/*
+		CRITICAL Level = iota
+		ERROR
+		WARNING
+		NOTICE
+		INFO
+		DEBUG
+	*/
+	logging.SetLogLevel("cluster", l)
+	//logging.SetLogLevel("p2p-gorpc", l)
+	//logging.SetLogLevel("swarm2", l)
+	//logging.SetLogLevel("libp2p-raft", l)
+}
+
+// This redirects Raft output to our logger
+func makeRaftLogger() *log.Logger {
+	var buf bytes.Buffer
+	rLogger := log.New(&buf, "", 0)
+	reader := bufio.NewReader(&buf)
+	go func() {
+		for {
+			t, err := reader.ReadString('\n')
+			if err != nil {
+				time.Sleep(time.Second)
+				continue
+			}
+			t = strings.TrimSuffix(t, "\n")
+
+			switch {
+			case strings.Contains(t, "[DEBUG]"):
+				raftLogger.Debug(strings.TrimPrefix(t, "[DEBUG] raft: "))
+			case strings.Contains(t, "[WARN]"):
+				raftLogger.Warning(strings.TrimPrefix(t, "[WARN]  raft: "))
+			case strings.Contains(t, "[ERR]"):
+				raftLogger.Error(strings.TrimPrefix(t, "[ERR] raft: "))
+			case strings.Contains(t, "[INFO]"):
+				raftLogger.Info(strings.TrimPrefix(t, "[INFO] raft: "))
+			default:
+				raftLogger.Debug(t)
+			}
+		}
+	}()
+	return rLogger
+}

--- a/logging.go
+++ b/logging.go
@@ -25,6 +25,7 @@ func SetLogLevel(l string) {
 		DEBUG
 	*/
 	logging.SetLogLevel("cluster", l)
+	//logging.SetLogLevel("raft", l)
 	//logging.SetLogLevel("p2p-gorpc", l)
 	//logging.SetLogLevel("swarm2", l)
 	//logging.SetLogLevel("libp2p-raft", l)

--- a/map_pin_tracker.go
+++ b/map_pin_tracker.go
@@ -53,7 +53,7 @@ func NewMapPinTracker(cfg *Config) *MapPinTracker {
 		status:     make(map[string]PinInfo),
 		rpcReady:   make(chan struct{}, 1),
 		peerID:     cfg.ID,
-		shutdownCh: make(chan struct{}),
+		shutdownCh: make(chan struct{}, 1),
 	}
 	mpt.run()
 	return mpt
@@ -85,6 +85,7 @@ func (mpt *MapPinTracker) Shutdown() error {
 	}
 
 	logger.Info("stopping MapPinTracker")
+	close(mpt.rpcReady)
 	mpt.shutdownCh <- struct{}{}
 	mpt.wg.Wait()
 	mpt.shutdown = true

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -1,0 +1,150 @@
+package ipfscluster
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+type peerManager struct {
+	cluster *Cluster
+
+	peerSetMux sync.RWMutex
+	peerSet    map[peer.ID]struct{}
+}
+
+func newPeerManager(c *Cluster) *peerManager {
+	pm := &peerManager{
+		cluster: c,
+	}
+	pm.resetPeerSet()
+	return pm
+}
+
+func (pm *peerManager) addPeer(addr ma.Multiaddr) (peer.ID, error) {
+	logger.Debugf("adding peer %s", addr)
+
+	peerID, decapAddr, err := multiaddrSplit(addr)
+	if err != nil {
+		return peerID, err
+	}
+
+	pm.peerSetMux.RLock()
+	_, ok := pm.peerSet[peerID]
+	pm.peerSetMux.RUnlock()
+
+	if ok {
+		logger.Debugf("%s is already a peer", peerID)
+		return peerID, nil
+	}
+
+	pm.peerSetMux.Lock()
+	pm.peerSet[peerID] = struct{}{}
+	pm.peerSetMux.Unlock()
+	pm.cluster.host.Peerstore().AddAddr(peerID, decapAddr, peerstore.PermanentAddrTTL)
+	pm.cluster.config.addPeer(addr)
+	if con := pm.cluster.consensus; con != nil {
+		pm.cluster.consensus.AddPeer(peerID)
+	}
+	if path := pm.cluster.config.path; path != "" {
+		err := pm.cluster.config.Save(path)
+		if err != nil {
+			logger.Error(err)
+		}
+	}
+	return peerID, nil
+}
+
+func (pm *peerManager) rmPeer(p peer.ID) error {
+	logger.Debugf("removing peer %s", p.Pretty())
+	pm.peerSetMux.RLock()
+	_, ok := pm.peerSet[p]
+	pm.peerSetMux.RUnlock()
+	if !ok {
+		return nil
+	}
+	pm.peerSetMux.Lock()
+	delete(pm.peerSet, p)
+	pm.peerSetMux.Unlock()
+	pm.cluster.host.Peerstore().ClearAddrs(p)
+	pm.cluster.config.rmPeer(p)
+	pm.cluster.consensus.RemovePeer(p)
+
+	// It's ourselves. This is not very graceful
+	if p == pm.cluster.host.ID() {
+		logger.Warning("this peer has been removed from the Cluster and will shutdown itself")
+		pm.cluster.config.emptyPeers()
+		defer func() {
+			go func() {
+				time.Sleep(time.Second)
+				pm.cluster.consensus.Shutdown()
+				pm.selfShutdown()
+			}()
+		}()
+	}
+
+	if path := pm.cluster.config.path; path != "" {
+		pm.cluster.config.Save(path)
+	}
+
+	return nil
+}
+
+func (pm *peerManager) selfShutdown() {
+	err := pm.cluster.Shutdown()
+	if err == nil {
+		// If the shutdown worked correctly
+		// (including snapshot) we can remove the Raft
+		// database (which traces peers additions
+		// and removals). It makes re-start of the peer
+		// way less confusing for Raft while the state
+		// kept in the snapshot.
+		os.Remove(filepath.Join(pm.cluster.config.ConsensusDataFolder, "raft.db"))
+	}
+}
+
+// empty the peerset and add ourselves only
+func (pm *peerManager) resetPeerSet() {
+	pm.peerSetMux.Lock()
+	defer pm.peerSetMux.Unlock()
+	pm.peerSet = make(map[peer.ID]struct{})
+	pm.peerSet[pm.cluster.host.ID()] = struct{}{}
+}
+
+func (pm *peerManager) peers() []peer.ID {
+	pm.peerSetMux.RLock()
+	defer pm.peerSetMux.RUnlock()
+	var pList []peer.ID
+	for k := range pm.peerSet {
+		pList = append(pList, k)
+	}
+	return pList
+}
+
+func (pm *peerManager) addFromConfig(cfg *Config) error {
+	return pm.addFromMultiaddrs(cfg.ClusterPeers)
+}
+
+func (pm *peerManager) addFromMultiaddrs(mAddrIDs []ma.Multiaddr) error {
+	pm.resetPeerSet()
+	pm.cluster.config.emptyPeers()
+	if len(mAddrIDs) > 0 {
+		logger.Info("adding Cluster peers:")
+	} else {
+		logger.Info("This is a single-node cluster")
+	}
+
+	for _, m := range mAddrIDs {
+		_, err := pm.addPeer(m)
+		if err != nil {
+			return err
+		}
+		logger.Infof("    - %s", m.String())
+	}
+	return nil
+}

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -1,0 +1,168 @@
+package ipfscluster
+
+import (
+	"sync"
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func peerManagerClusters(t *testing.T) ([]*Cluster, []*ipfsMock) {
+	cls := make([]*Cluster, nClusters, nClusters)
+	mocks := make([]*ipfsMock, nClusters, nClusters)
+	var wg sync.WaitGroup
+	for i := 0; i < nClusters; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cl, m := createOnePeerCluster(t, i)
+			cls[i] = cl
+			mocks[i] = m
+		}(i)
+	}
+	wg.Wait()
+	return cls, mocks
+}
+
+func clusterAddr(c *Cluster) ma.Multiaddr {
+	addr := c.config.ClusterAddr
+	pidAddr, _ := ma.NewMultiaddr("/ipfs/" + c.ID().ID.Pretty())
+	return addr.Encapsulate(pidAddr)
+}
+
+func TestClustersPeerAdd(t *testing.T) {
+	clusters, mocks := peerManagerClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	if len(clusters) < 2 {
+		t.Fatal("need at least 2 nodes for this test")
+	}
+
+	for i := 1; i < len(clusters); i++ {
+		addr := clusterAddr(clusters[i])
+		id, err := clusters[0].PeerAdd(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(id.ClusterPeers) != i {
+			// ClusterPeers is originally empty and contains nodes as we add them
+			t.Log(id.ClusterPeers)
+			t.Fatal("cluster peers should be up to date with the cluster")
+		}
+	}
+
+	h, _ := cid.Decode(testCid)
+	clusters[1].Pin(h)
+	delay()
+
+	f := func(t *testing.T, c *Cluster) {
+		ids := c.Peers()
+
+		// check they are tracked by the peer manager
+		if len(ids) != nClusters {
+			t.Error("added clusters are not part of clusters")
+		}
+
+		// Check that they are part of the consensus
+		pins := c.Pins()
+		if len(pins) != 1 {
+			t.Error("expected 1 pin everywhere")
+		}
+
+		// check that its part of the configuration
+		if len(c.config.ClusterPeers) != nClusters-1 {
+			t.Error("expected different cluster peers in the configuration")
+		}
+
+		for _, peer := range c.config.ClusterPeers {
+			if peer == nil {
+				t.Error("something went wrong adding peer to config")
+			}
+		}
+	}
+	runF(t, clusters, f)
+}
+
+func TestClustersPeerAddBadPeer(t *testing.T) {
+	clusters, mocks := peerManagerClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	if len(clusters) < 2 {
+		t.Fatal("need at least 2 nodes for this test")
+	}
+
+	// We add a cluster that has been shutdown
+	// (closed transports)
+	clusters[1].Shutdown()
+	_, err := clusters[0].PeerAdd(clusterAddr(clusters[1]))
+	if err == nil {
+		t.Error("expected an error")
+	}
+	ids := clusters[0].Peers()
+	if len(ids) != 1 {
+		t.Error("cluster should have only one member")
+	}
+}
+
+func TestClustersPeerAddInUnhealthyCluster(t *testing.T) {
+	clusters, mocks := peerManagerClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	if len(clusters) < 3 {
+		t.Fatal("need at least 3 nodes for this test")
+	}
+
+	_, err := clusters[0].PeerAdd(clusterAddr(clusters[1]))
+	ids := clusters[1].Peers()
+	if len(ids) != 2 {
+		t.Error("expected 2 peers")
+	}
+
+	// Now we shutdown one member of the running cluster
+	// and try to add someone else.
+	clusters[1].Shutdown()
+	_, err = clusters[0].PeerAdd(clusterAddr(clusters[2]))
+
+	if err == nil {
+		t.Error("expected an error")
+	}
+
+	ids = clusters[0].Peers()
+	if len(ids) != 2 {
+		t.Error("cluster should still have 2 peers")
+	}
+}
+
+func TestClustersPeerRemove(t *testing.T) {
+	clusters, mock := createClusters(t)
+	defer shutdownClusters(t, clusters, mock)
+
+	p := clusters[1].ID().ID
+	err := clusters[0].PeerRemove(p)
+	if err != nil {
+		t.Error(err)
+	}
+
+	f := func(t *testing.T, c *Cluster) {
+		if c.ID().ID == p { //This is the removed cluster
+			_, ok := <-c.Done()
+			if ok {
+				t.Error("removed peer should have exited")
+			}
+			if len(c.config.ClusterPeers) != 0 {
+				t.Error("cluster peers should be empty")
+			}
+		} else {
+			ids := c.Peers()
+			if len(ids) != nClusters-1 {
+				t.Error("should have removed 1 peer")
+			}
+			if len(c.config.ClusterPeers) != nClusters-2 {
+				t.Error("should have removed peer from config")
+			}
+		}
+	}
+
+	runF(t, clusters, f)
+}

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -53,7 +53,10 @@ func TestClustersPeerAdd(t *testing.T) {
 	}
 
 	h, _ := cid.Decode(testCid)
-	clusters[1].Pin(h)
+	err := clusters[1].Pin(h)
+	if err != nil {
+		t.Fatal(err)
+	}
 	delay()
 
 	f := func(t *testing.T, c *Cluster) {
@@ -67,6 +70,7 @@ func TestClustersPeerAdd(t *testing.T) {
 		// Check that they are part of the consensus
 		pins := c.Pins()
 		if len(pins) != 1 {
+			t.Log(pins)
 			t.Error("expected 1 pin everywhere")
 		}
 

--- a/raft.go
+++ b/raft.go
@@ -1,8 +1,12 @@
 package ipfscluster
 
 import (
+	"context"
+	"errors"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
+	"time"
 
 	hashiraft "github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
@@ -11,9 +15,21 @@ import (
 	libp2praft "github.com/libp2p/go-libp2p-raft"
 )
 
-// libp2pRaftWrap wraps the stuff that we need to run
-// hashicorp raft. We carry it around for convenience
-type libp2pRaftWrap struct {
+// DefaultRaftConfig allows to tweak Raft configuration used by Cluster from
+// from the outside.
+var DefaultRaftConfig = hashiraft.DefaultConfig()
+
+// RaftMaxSnapshots indicates how many snapshots to keep in the consensus data
+// folder.
+var RaftMaxSnapshots = 5
+
+// is this running 64 bits arch? https://groups.google.com/forum/#!topic/golang-nuts/vAckmhUMAdQ
+const sixtyfour = uint64(^uint(0)) == ^uint64(0)
+
+// Raft performs all Raft-specific operations which are needed by Cluster but
+// are not fulfilled by the consensus interface. It should contain most of the
+// Raft-related stuff so it can be easily replaced in the future, if need be.
+type Raft struct {
 	raft          *hashiraft.Raft
 	transport     *libp2praft.Libp2pTransport
 	snapshotStore hashiraft.SnapshotStore
@@ -23,63 +39,62 @@ type libp2pRaftWrap struct {
 	boltdb        *raftboltdb.BoltStore
 }
 
-// This function does all heavy the work which is specifically related to
-// hashicorp's Raft. Other places should just rely on the Consensus interface.
-func makeLibp2pRaft(cfg *Config, host host.Host, state State, op *clusterLogOp) (*libp2praft.Consensus, *libp2praft.Actor, *libp2pRaftWrap, error) {
+func defaultRaftConfig() *hashiraft.Config {
+	// These options are imposed over any Default Raft Config.
+	// Changing them causes cluster peers difficult-to-understand,
+	// behaviours, usually around the add/remove of peers.
+	// That means that changing them will make users wonder why something
+	// does not work the way it is expected to.
+	// i.e. ShutdownOnRemove will cause that no snapshot will be taken
+	// when trying to shutdown a peer after removing it from a cluster.
+	DefaultRaftConfig.DisableBootstrapAfterElect = false
+	DefaultRaftConfig.EnableSingleNode = true
+	DefaultRaftConfig.ShutdownOnRemove = false
+
+	// Set up logging
+	DefaultRaftConfig.LogOutput = ioutil.Discard
+	DefaultRaftConfig.Logger = raftStdLogger // see logging.go
+	return DefaultRaftConfig
+}
+
+// NewRaft launches a go-libp2p-raft consensus peer.
+func NewRaft(peers []peer.ID, host host.Host, dataFolder string, fsm hashiraft.FSM) (*Raft, error) {
 	logger.Debug("creating libp2p Raft transport")
 	transport, err := libp2praft.NewLibp2pTransportWithHost(host)
 	if err != nil {
 		logger.Error("creating libp2p-raft transport: ", err)
-		return nil, nil, nil, err
+		return nil, err
 	}
-
-	//logger.Debug("opening connections")
-	//transport.OpenConns()
 
 	pstore := &libp2praft.Peerstore{}
-	strPeers := []string{peer.IDB58Encode(host.ID())}
-	for _, addr := range cfg.ClusterPeers {
-		p, _, err := multiaddrSplit(addr)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		strPeers = append(strPeers, p.Pretty())
+	peersStr := make([]string, len(peers), len(peers))
+	for i, p := range peers {
+		peersStr[i] = peer.IDB58Encode(p)
 	}
-	pstore.SetPeers(strPeers)
-
-	logger.Debug("creating OpLog")
-	cons := libp2praft.NewOpLog(state, op)
-
-	raftCfg := cfg.RaftConfig
-	if raftCfg == nil {
-		raftCfg = hashiraft.DefaultConfig()
-		raftCfg.EnableSingleNode = raftSingleMode
-	}
-	raftCfg.LogOutput = ioutil.Discard
-	raftCfg.Logger = raftStdLogger
+	pstore.SetPeers(peersStr)
 
 	logger.Debug("creating file snapshot store")
-	snapshots, err := hashiraft.NewFileSnapshotStoreWithLogger(cfg.ConsensusDataFolder, maxSnapshots, raftStdLogger)
+	snapshots, err := hashiraft.NewFileSnapshotStoreWithLogger(dataFolder, RaftMaxSnapshots, raftStdLogger)
 	if err != nil {
 		logger.Error("creating file snapshot store: ", err)
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	logger.Debug("creating BoltDB log store")
-	logStore, err := raftboltdb.NewBoltStore(filepath.Join(cfg.ConsensusDataFolder, "raft.db"))
+	logStore, err := raftboltdb.NewBoltStore(filepath.Join(dataFolder, "raft.db"))
 	if err != nil {
 		logger.Error("creating bolt store: ", err)
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	logger.Debug("creating Raft")
-	r, err := hashiraft.NewRaft(raftCfg, cons.FSM(), logStore, logStore, snapshots, pstore, transport)
+	r, err := hashiraft.NewRaft(defaultRaftConfig(), fsm, logStore, logStore, snapshots, pstore, transport)
 	if err != nil {
 		logger.Error("initializing raft: ", err)
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	return cons, libp2praft.NewActor(r), &libp2pRaftWrap{
+	return &Raft{
 		raft:          r,
 		transport:     transport,
 		snapshotStore: snapshots,
@@ -88,4 +103,124 @@ func makeLibp2pRaft(cfg *Config, host host.Host, state State, op *clusterLogOp) 
 		peerstore:     pstore,
 		boltdb:        logStore,
 	}, nil
+}
+
+// WaitForLeader holds until Raft says we have a leader
+func (r *Raft) WaitForLeader(ctx context.Context) {
+	// Using Raft observers panics on non-64 architectures.
+	// This is a work around
+	if sixtyfour {
+		r.waitForLeader(ctx)
+	} else {
+		r.waitForLeaderLegacy(ctx)
+	}
+}
+
+func (r *Raft) waitForLeader(ctx context.Context) {
+	obsCh := make(chan hashiraft.Observation)
+	filter := func(o *hashiraft.Observation) bool {
+		switch o.Data.(type) {
+		case hashiraft.LeaderObservation:
+			return true
+		default:
+			return false
+		}
+	}
+	observer := hashiraft.NewObserver(obsCh, true, filter)
+	r.raft.RegisterObserver(observer)
+	defer r.raft.DeregisterObserver(observer)
+	select {
+	case obs := <-obsCh:
+		leaderObs := obs.Data.(hashiraft.LeaderObservation)
+		logger.Infof("Raft Leader elected: %s", leaderObs.Leader)
+
+	case <-ctx.Done():
+		return
+	}
+}
+
+func (r *Raft) waitForLeaderLegacy(ctx context.Context) {
+	for {
+		leader := r.raft.Leader()
+		if leader != "" {
+			logger.Infof("Raft Leader elected: %s", leader)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+}
+
+// WaitForUpdates holds until Raft has synced to the last index in the log
+func (r *Raft) WaitForUpdates(ctx context.Context) {
+	logger.Debug("Raft state is catching up")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			lai := r.raft.AppliedIndex()
+			li := r.raft.LastIndex()
+			logger.Debugf("current Raft index: %d/%d",
+				lai, li)
+			if lai == li {
+				return
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+
+	}
+}
+
+// Snapshot tells Raft to take a snapshot.
+func (r *Raft) Snapshot() error {
+	future := r.raft.Snapshot()
+	err := future.Error()
+	if err != nil && !strings.Contains(err.Error(), "Nothing new to snapshot") {
+		return errors.New("could not take snapshot: " + err.Error())
+	}
+	return nil
+}
+
+// Shutdown shutdown Raft and closes the BoltDB.
+func (r *Raft) Shutdown() error {
+	future := r.raft.Shutdown()
+	err := future.Error()
+	errMsgs := ""
+	if err != nil {
+		errMsgs += "could not shutdown raft: " + err.Error() + ".\n"
+	}
+
+	err = r.boltdb.Close() // important!
+	if err != nil {
+		errMsgs += "could not close boltdb: " + err.Error()
+	}
+	if errMsgs != "" {
+		return errors.New(errMsgs)
+	}
+	return nil
+}
+
+// AddPeer adds a peer to Raft
+func (r *Raft) AddPeer(peer string) error {
+	future := r.raft.AddPeer(peer)
+	err := future.Error()
+	return err
+}
+
+// RemovePeer removes a peer from Raft
+func (r *Raft) RemovePeer(peer string) error {
+	future := r.raft.RemovePeer(peer)
+	err := future.Error()
+	return err
+}
+
+// Leader returns Raft's leader. It may be an empty string if
+// there is no leader or it is unknown.
+func (r *Raft) Leader() string {
+	return r.raft.Leader()
 }

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -1,6 +1,10 @@
 package ipfscluster
 
-import cid "github.com/ipfs/go-cid"
+import (
+	cid "github.com/ipfs/go-cid"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+)
 
 // RPCAPI is a go-libp2p-gorpc service which provides the internal ipfs-cluster
 // API, which enables components and cluster peers to communicate and
@@ -92,6 +96,19 @@ func (api *RPCAPI) Peers(in struct{}, out *[]IDSerial) error {
 	}
 	*out = sPeers
 	return nil
+}
+
+// PeerAdd runs Cluster.PeerAdd().
+func (api *RPCAPI) PeerAdd(in MultiaddrSerial, out *IDSerial) error {
+	addr := in.ToMultiaddr()
+	id, err := api.cluster.PeerAdd(addr)
+	*out = id.ToSerial()
+	return err
+}
+
+// PeerRemove runs Cluster.PeerRm().
+func (api *RPCAPI) PeerRemove(in peer.ID, out *struct{}) error {
+	return api.cluster.PeerRemove(in)
 }
 
 // StatusAll runs Cluster.StatusAll().
@@ -276,4 +293,35 @@ func (api *RPCAPI) ConsensusLogUnpin(in *CidArg, out *struct{}) error {
 		return err
 	}
 	return api.cluster.consensus.LogUnpin(c)
+}
+
+/*
+   Peer Manager methods
+
+*/
+
+// PeerManagerAddPeer runs peerManager.addPeer().
+func (api *RPCAPI) PeerManagerAddPeer(in MultiaddrSerial, out *peer.ID) error {
+	mAddr := in.ToMultiaddr()
+	p, err := api.cluster.peerManager.addPeer(mAddr)
+	*out = p
+	return err
+}
+
+// PeerManagerRmPeer runs peerManager.rmPeer().
+func (api *RPCAPI) PeerManagerRmPeer(in peer.ID, out *struct{}) error {
+	return api.cluster.peerManager.rmPeer(in)
+}
+
+// PeerManagerAddFromMultiaddrs runs peerManager.addFromMultiaddrs().
+func (api *RPCAPI) PeerManagerAddFromMultiaddrs(in MultiaddrsSerial, out *struct{}) error {
+	api.cluster.peerManager.addFromMultiaddrs(in.ToMultiaddrs())
+	return nil
+}
+
+// PeerManagerPeers runs peerManager.peers().
+func (api *RPCAPI) PeerManagerPeers(in struct{}, out *[]peer.ID) error {
+	peers := api.cluster.peerManager.peers()
+	*out = peers
+	return nil
 }

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -297,7 +297,6 @@ func (api *RPCAPI) ConsensusLogUnpin(in *CidArg, out *struct{}) error {
 
 /*
    Peer Manager methods
-
 */
 
 // PeerManagerAddPeer runs peerManager.addPeer().

--- a/rpc_api_test.go
+++ b/rpc_api_test.go
@@ -72,6 +72,17 @@ func (mock *mockService) Peers(in struct{}, out *[]IDSerial) error {
 	return nil
 }
 
+func (mock *mockService) PeerAdd(in MultiaddrSerial, out *IDSerial) error {
+	id := IDSerial{}
+	mock.ID(struct{}{}, &id)
+	*out = id
+	return nil
+}
+
+func (mock *mockService) PeerRemove(in peer.ID, out *struct{}) error {
+	return nil
+}
+
 func (mock *mockService) StatusAll(in struct{}, out *[]GlobalPinInfo) error {
 	c1, _ := cid.Decode(testCid1)
 	c2, _ := cid.Decode(testCid2)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,69 @@
+package ipfscluster
+
+import (
+	"fmt"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// The copy functions below are used in calls to Cluste.multiRPC()
+func copyPIDsToIfaces(in []peer.ID) []interface{} {
+	ifaces := make([]interface{}, len(in), len(in))
+	for i := range in {
+		ifaces[i] = &in[i]
+	}
+	return ifaces
+}
+
+func copyIDSerialsToIfaces(in []IDSerial) []interface{} {
+	ifaces := make([]interface{}, len(in), len(in))
+	for i := range in {
+		ifaces[i] = &in[i]
+	}
+	return ifaces
+}
+
+func copyPinInfoToIfaces(in []PinInfo) []interface{} {
+	ifaces := make([]interface{}, len(in), len(in))
+	for i := range in {
+		ifaces[i] = &in[i]
+	}
+	return ifaces
+}
+
+func copyPinInfoSliceToIfaces(in [][]PinInfo) []interface{} {
+	ifaces := make([]interface{}, len(in), len(in))
+	for i := range in {
+		ifaces[i] = &in[i]
+	}
+	return ifaces
+}
+
+func copyEmptyStructToIfaces(in []struct{}) []interface{} {
+	ifaces := make([]interface{}, len(in), len(in))
+	for i := range in {
+		ifaces[i] = &in[i]
+	}
+	return ifaces
+}
+
+func multiaddrSplit(addr ma.Multiaddr) (peer.ID, ma.Multiaddr, error) {
+	pid, err := addr.ValueForProtocol(ma.P_IPFS)
+	if err != nil {
+		err = fmt.Errorf("Invalid peer multiaddress: %s: %s", addr, err)
+		logger.Error(err)
+		return "", nil, err
+	}
+
+	ipfs, _ := ma.NewMultiaddr("/ipfs/" + pid)
+	decapAddr := addr.Decapsulate(ipfs)
+
+	peerID, err := peer.IDB58Decode(pid)
+	if err != nil {
+		err = fmt.Errorf("Invalid peer ID in multiaddress: %s: %s", pid)
+		logger.Error(err)
+		return "", nil, err
+	}
+	return peerID, decapAddr, nil
+}


### PR DESCRIPTION
Fixes #10 

This commit adds PeerAdd() and PeerRemove() endpoints, CLI support,
tests, docs... Peer management is a delicate issue because of how the consensus
works underneath and the places that need to track such peers.

When adding a peer the procedure is as follows:

* Try to open a connection to the new peer and abort if not reachable
* Broadcast a PeerManagerAddPeer operation which tells all cluster members
to add the new Peer. The Raft leader will add it to Raft's peerset and
the multiaddress will be saved in the ClusterPeers configuration key.
* If the above fails because some cluster node is not responding,
broadcast a PeerRemove() and try to undo any damage.
* If the broadcast succeeds, send our ClusterPeers to the new Peer along with
the local multiaddress we are using in the connection opened in the
first step (that is the multiaddress through which the other peer can reach us)
* The new peer updates its configuration with the new list and joins
the consensus.

Additionally, also because it was necessary to make the feature, the code around Raft has been re-organized, including consensus initialization. This re-organization also removes the RaftConfig from the configuration objects but adds an alternative variable to allow toooling (`service` for example) to customize raft options if this is ever needed.