### PR TITLE
Fix #24: Add Cluster.Join() operation to join an existing cluster

### DIFF
--- a/config.go
+++ b/config.go
@@ -218,6 +218,7 @@ func LoadConfig(path string) (*Config, error) {
 
 // Save stores a configuration as a JSON file in the given path.
 func (cfg *Config) Save(path string) error {
+	logger.Info("Saving configuration")
 	jcfg, err := cfg.ToJSONConfig()
 	if err != nil {
 		logger.Error("error generating JSON config")

--- a/util.go
+++ b/util.go
@@ -67,3 +67,11 @@ func multiaddrSplit(addr ma.Multiaddr) (peer.ID, ma.Multiaddr, error) {
 	}
 	return peerID, decapAddr, nil
 }
+
+func multiaddrJoin(addr ma.Multiaddr, p peer.ID) (ma.Multiaddr, error) {
+	pidAddr, err := ma.NewMultiaddr("/ipfs/" + peer.IDB58Encode(p))
+	if err != nil {
+		return nil, err
+	}
+	return addr.Encapsulate(pidAddr), nil
+}


### PR DESCRIPTION
Join() takes a peer's multiaddress. It then sends a "PeerAdd()"
RPC request with that peer and the local multiaddress by which
the remote peer is reached. The the remote peer uses the PeerAdd()
functionality to a) Tell the rest of the cluster about the new member
and b) send us the list of cluster members.

Join() has no REST API support, but it is provided instead via
"ipfs-cluster-service --join". A "--leave" flag has been included too,
by which a peer triggers "PeerRemove()" on itself when shutting down.

This allows a node to join an existing cluster and leave it by the
end of its life.

#24 

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>