### PR TITLE
Fix #24: Auto-join and auto-leave operations for Cluster

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -70,33 +70,41 @@ This sections explains how some things work in Cluster.
 
 * `NewCluster` triggers the Cluster bootstrap. `IPFSConnector`, `State`, `PinTracker` component are provided. These components are up but possibly waiting for a `SetClient(RPCClient)` call. Without having an RPCClient, they are unable to communicate with the other components.
 * The first step bootstrapping is to create the libp2p `Host`. It is using configuration keys to set up public, private keys, the swarm network etc.
-* The `peerManager` is initialized. Peers from the configuration and ourselves are added to the peer list.
+* The `peerManager` is initialized. It allows to list known cluster peers and keep components in the loop about changes.
 * The `RPCServer` (`go-libp2p-gorpc`) is setup, along with an `RPCClient`. The client can communicate to any RPC server using libp2p, or with the local one (shortcutting). The `RPCAPI` object is registered: it implements all the RPC operations supported by cluster and used for inter-component/inter-peer communication.
 * The `Consensus` component is bootstrapped. It:
-  * Sets up a new Raft node from scratch, including snapshots, stable datastore (boltDB), log store etc...
+  * Sets up a new Raft node (with the `cluster_peers` from the configuration) from scratch, including snapshots, stable datastore (boltDB), log store etc...
   * Initializes `go-libp2p-consensus` components (`Actor` and `LogOpConsensus`) using `go-libp2p-raft`
-  * Returns a new `Consensus` object while asynchronously waiting for a Raft leader and then also for the current Raft peer to catch up with the latest index of the log.
+  * Returns a new `Consensus` object while asynchronously waiting for a Raft leader and then also for the current Raft peer to catch up with the latest index of the log when there is anything to catch up with.
   * Waits for an RPCClient to be set and when it happens it triggers an asynchronous RPC request (`StateSync`) to the local `Cluster` component and reports `Ready()`
   * The `StateSync` operation (from the main `Cluster` component) makes a diff between the local `MapPinTracker` state and the consensus-maintained state. It triggers asynchronous local RPC requests (`Track` and `Untrack`) to the `MapPinTracker`.
   * The `MapPinTracker` receives the `Track` requests and checks, pins or unpins items, as well as updating the local status of a pin (see the Pinning section below)
 * While the consensus is being bootstrapped, `SetClient(RPCClient` is called on all components (tracker, ipfs connector, api and consensus)
 * The new `Cluster` object is returned.
-* Asynchronously, a thread waits for the `Consensus` component to report `Ready()`. When this happens, `Cluster` reports itself `Ready()`. At this moment, all components are up, consensus is working and cluster is ready to perform any operations. The consensus state may still be syncing, or mostly the `MapPinTracker` may still be verifying that pins are there against the daemon, but this does not causes any problems to use cluster.
+* Asynchronously, a thread triggers the bootsrap process and then waits for the `Consensus` component to report `Ready()`.
+* The bootstrap process uses the configured multiaddresses from the Bootstrap section of the configuration perform a remote RPC `PeerAdd` request (it tries until it works in one of them).
+* The remote node then performs a consensus log operation logging the multiaddress and peer ID of the new cluster member. If the log operation is successful, the new member is added to `Raft` (which internally logs it as well). The new node is contacted by Raft, its internal peerset updated. It receives the state from the cluster, including pins (which are synced to the `PinTracker` and other peers, which are handled by the `peerManager`.
+* If the bootstrap was successful or not necessary, Cluster reports itself `Ready()`. At this moment, all components are up, consensus is working and cluster is ready to perform any operations. The consensus state may still be syncing, or mostly the `MapPinTracker` may still be verifying that pins are there against the daemon, but this does not causes any problems to use cluster.
 
 
 ### Adding a peer
 
 * The `RESTAPI` component receives a `PeerAdd` request on the respective endpoint. It makes a `PeerAdd` RPC request.
 * The local RPC server receives it and calls `PeerAdd` method in the main `Cluster` component.
-* A libp2p connection is opened to the new peer's multiaddress. It should be reachable. We note down the local multiaddress used to reach the new peer.
-* A broadcast `PeerManagerAddPeer` request is sent to all peers in the current cluster. It is received and the RPC server calls `peerManager.addPeer`. The `peerManager` is an annex to the main Cluster Component around the peer management functionality (add/remove).
-* The `peerManager` adds the new peer to libp2p's peerstore, asks Raft to make if part of its peerset and adds it to the `ClusterPeers` section
-of the configuration (which is then saved).
-* If the broadcast requests fails somewhere, the operation is aborted, and a `PeerRemove` operation for the new peer is triggered to undo any changes. Otherwise, on success, the local list of ClusterPeers from the configuration, along with the local multiaddress from the connection we noted down are
-sent to the new peer (via the RPC `PeerManagerAddFromMultiaddrs` method).
-* The new peer's `peerManager` updates the current list of peers, the Raft's peer set and the configuration and has become part of the new cluster.
-* The `PeerAdd` method in `Cluster` makes an remote RPC request to the new peers `ID` method. The received ID is used as response to the call.
-* The RPC server takes the response and sends it to the `RESTAPI` component, which in turns converts it and responds to the request.
+* If there is a connection from the given PID, we use it to determine the true multiaddress (with the right remote IP), in case it was not
+provided correctly (usually when using `Join` since it cannot be determined-see below). This allows to correctly let peers join from accross NATs.
+* The peer is added to the `peerManager` so we can perform RPC requests to it.
+* A remote RPC `RemoteMultiaddressForPeer` is performed to the new peer, so it reports how our multiaddress looks from their side.
+* The address of the new peer is then commited to the consensus state. Since this is a new peer, Raft peerstore is also updated. Raft starts
+sending updates to the new peer, among them prompting it to update its own peerstore with the list of peers in this cluster.
+* The list of cluster peers (plus ourselves with our real multiaddress) is sent to the new cluster in a remote `PeerManagerAddMultiaddrs` RPC request.
+* A remote `ID` RPC request is performed and the information about the new node is returned.
+
+### Joining a cluster
+
+* Joining means calling `AddPeer` on the cluster we want to join.
+* This is used also for bootstrapping.
+* Join is disallowed if we are not a single-peer cluster.
 
 ### Pinning
 

--- a/config_test.go
+++ b/config_test.go
@@ -11,6 +11,7 @@ func testingConfig() *Config {
 		APIListenMultiaddress:       "/ip4/127.0.0.1/tcp/10002",
 		IPFSProxyListenMultiaddress: "/ip4/127.0.0.1/tcp/10001",
 		ConsensusDataFolder:         "./raftFolderFromTests",
+		LeaveOnShutdown:             true,
 	}
 
 	cfg, _ := jcfg.ToConfig()
@@ -85,9 +86,9 @@ func TestConfigToConfig(t *testing.T) {
 	}
 
 	j, _ = cfg.ToJSONConfig()
-	j.ClusterPeers = []string{"abc"}
+	j.Bootstrap = []string{"abc"}
 	_, err = j.ToConfig()
 	if err == nil {
-		t.Error("expected error parsing cluster_peers")
+		t.Error("expected error parsing Bootstrap")
 	}
 }

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestApplyToPin(t *testing.T) {
 	op := &clusterLogOp{
-		Cid:       testCid,
+		Arg:       testCid,
 		Type:      LogOpPin,
 		ctx:       context.Background(),
 		rpcClient: mockRPCClient(t),
@@ -28,7 +28,7 @@ func TestApplyToPin(t *testing.T) {
 
 func TestApplyToUnpin(t *testing.T) {
 	op := &clusterLogOp{
-		Cid:       testCid,
+		Arg:       testCid,
 		Type:      LogOpUnpin,
 		ctx:       context.Background(),
 		rpcClient: mockRPCClient(t),
@@ -52,7 +52,7 @@ func TestApplyToBadState(t *testing.T) {
 	}()
 
 	op := &clusterLogOp{
-		Cid:       testCid,
+		Arg:       testCid,
 		Type:      LogOpUnpin,
 		ctx:       context.Background(),
 		rpcClient: mockRPCClient(t),
@@ -70,7 +70,7 @@ func TestApplyToBadCid(t *testing.T) {
 	}()
 
 	op := &clusterLogOp{
-		Cid:       "agadfaegf",
+		Arg:       "agadfaegf",
 		Type:      LogOpPin,
 		ctx:       context.Background(),
 		rpcClient: mockRPCClient(t),

--- a/debug.go
+++ b/debug.go
@@ -3,5 +3,10 @@
 package ipfscluster
 
 func init() {
-	SetLogLevel("DEBUG")
+	l := "DEBUG"
+	SetFacilityLogLevel("cluster", l)
+	//SetFacilityLogLevel("raft", l)
+	//SetFacilityLogLevel("p2p-gorpc", l)
+	//SetFacilityLogLevel("swarm2", l)
+	//SetFacilityLogLevel("libp2p-raft", l)
 }

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -155,6 +155,7 @@ type State interface {
 	ListPins() []*cid.Cid
 	// HasPin returns true if the state is holding a Cid
 	HasPin(*cid.Cid) bool
+	// AddPeer adds a peer to the shared state
 }
 
 // PinTracker represents a component which tracks the status of

--- a/logging.go
+++ b/logging.go
@@ -14,8 +14,8 @@ var logger = logging.Logger("cluster")
 var raftStdLogger = makeRaftLogger()
 var raftLogger = logging.Logger("raft")
 
-// SetLogLevel sets the level in the logs
-func SetLogLevel(l string) {
+// SetFacilityLogLevel sets the log level for a given module
+func SetFacilityLogLevel(f, l string) {
 	/*
 		CRITICAL Level = iota
 		ERROR
@@ -24,11 +24,7 @@ func SetLogLevel(l string) {
 		INFO
 		DEBUG
 	*/
-	logging.SetLogLevel("cluster", l)
-	//logging.SetLogLevel("raft", l)
-	//logging.SetLogLevel("p2p-gorpc", l)
-	//logging.SetLogLevel("swarm2", l)
-	//logging.SetLogLevel("libp2p-raft", l)
+	logging.SetLogLevel(f, l)
 }
 
 // This redirects Raft output to our logger

--- a/map_state.go
+++ b/map_state.go
@@ -9,21 +9,24 @@ import (
 // MapState is a very simple database to store the state of the system
 // using a Go map. It is thread safe. It implements the State interface.
 type MapState struct {
-	mux    sync.RWMutex
-	PinMap map[string]struct{}
+	pinMux  sync.RWMutex
+	PinMap  map[string]struct{}
+	peerMux sync.RWMutex
+	PeerMap map[string]string
 }
 
 // NewMapState initializes the internal map and returns a new MapState object.
 func NewMapState() *MapState {
 	return &MapState{
-		PinMap: make(map[string]struct{}),
+		PinMap:  make(map[string]struct{}),
+		PeerMap: make(map[string]string),
 	}
 }
 
 // AddPin adds a Cid to the internal map.
 func (st *MapState) AddPin(c *cid.Cid) error {
-	st.mux.Lock()
-	defer st.mux.Unlock()
+	st.pinMux.Lock()
+	defer st.pinMux.Unlock()
 	var a struct{}
 	st.PinMap[c.String()] = a
 	return nil
@@ -31,24 +34,24 @@ func (st *MapState) AddPin(c *cid.Cid) error {
 
 // RmPin removes a Cid from the internal map.
 func (st *MapState) RmPin(c *cid.Cid) error {
-	st.mux.Lock()
-	defer st.mux.Unlock()
+	st.pinMux.Lock()
+	defer st.pinMux.Unlock()
 	delete(st.PinMap, c.String())
 	return nil
 }
 
 // HasPin returns true if the Cid belongs to the State.
 func (st *MapState) HasPin(c *cid.Cid) bool {
-	st.mux.RLock()
-	defer st.mux.RUnlock()
+	st.pinMux.RLock()
+	defer st.pinMux.RUnlock()
 	_, ok := st.PinMap[c.String()]
 	return ok
 }
 
 // ListPins provides a list of Cids in the State.
 func (st *MapState) ListPins() []*cid.Cid {
-	st.mux.RLock()
-	defer st.mux.RUnlock()
+	st.pinMux.RLock()
+	defer st.pinMux.RUnlock()
 	cids := make([]*cid.Cid, 0, len(st.PinMap))
 	for k := range st.PinMap {
 		c, _ := cid.Decode(k)

--- a/nodebug.go
+++ b/nodebug.go
@@ -2,6 +2,11 @@
 
 package ipfscluster
 
+// This is our default logs levels
 func init() {
-	SetLogLevel("INFO")
+	SetFacilityLogLevel("cluster", "INFO")
+	SetFacilityLogLevel("raft", "ERROR")
+	SetFacilityLogLevel("p2p-gorpc", "ERROR")
+	//SetFacilityLogLevel("swarm2", l)
+	SetFacilityLogLevel("libp2p-raft", "CRITICAL")
 }

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -1,8 +1,10 @@
 package ipfscluster
 
 import (
+	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	cid "github.com/ipfs/go-cid"
 	ma "github.com/multiformats/go-multiaddr"
@@ -26,9 +28,7 @@ func peerManagerClusters(t *testing.T) ([]*Cluster, []*ipfsMock) {
 }
 
 func clusterAddr(c *Cluster) ma.Multiaddr {
-	addr := c.config.ClusterAddr
-	pidAddr, _ := ma.NewMultiaddr("/ipfs/" + c.ID().ID.Pretty())
-	return addr.Encapsulate(pidAddr)
+	return multiaddrJoin(c.config.ClusterAddr, c.ID().ID)
 }
 
 func TestClustersPeerAdd(t *testing.T) {
@@ -36,7 +36,7 @@ func TestClustersPeerAdd(t *testing.T) {
 	defer shutdownClusters(t, clusters, mocks)
 
 	if len(clusters) < 2 {
-		t.Fatal("need at least 2 nodes for this test")
+		t.Skip("need at least 2 nodes for this test")
 	}
 
 	for i := 1; i < len(clusters); i++ {
@@ -45,6 +45,7 @@ func TestClustersPeerAdd(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		if len(id.ClusterPeers) != i {
 			// ClusterPeers is originally empty and contains nodes as we add them
 			t.Log(id.ClusterPeers)
@@ -64,6 +65,7 @@ func TestClustersPeerAdd(t *testing.T) {
 
 		// check they are tracked by the peer manager
 		if len(ids) != nClusters {
+			//t.Log(ids)
 			t.Error("added clusters are not part of clusters")
 		}
 
@@ -74,16 +76,21 @@ func TestClustersPeerAdd(t *testing.T) {
 			t.Error("expected 1 pin everywhere")
 		}
 
-		// check that its part of the configuration
-		if len(c.config.ClusterPeers) != nClusters-1 {
-			t.Error("expected different cluster peers in the configuration")
+		if len(c.ID().ClusterPeers) != nClusters-1 {
+			t.Log(c.ID().ClusterPeers)
+			t.Error("By now cluster peers should reflect all peers")
 		}
 
-		for _, peer := range c.config.ClusterPeers {
-			if peer == nil {
-				t.Error("something went wrong adding peer to config")
-			}
-		}
+		// // check that its part of the configuration
+		// if len(c.config.ClusterPeers) != nClusters-1 {
+		// 	t.Error("expected different cluster peers in the configuration")
+		// }
+
+		// for _, peer := range c.config.ClusterPeers {
+		// 	if peer == nil {
+		// 		t.Error("something went wrong adding peer to config")
+		// 	}
+		// }
 	}
 	runF(t, clusters, f)
 }
@@ -93,7 +100,7 @@ func TestClustersPeerAddBadPeer(t *testing.T) {
 	defer shutdownClusters(t, clusters, mocks)
 
 	if len(clusters) < 2 {
-		t.Fatal("need at least 2 nodes for this test")
+		t.Skip("need at least 2 nodes for this test")
 	}
 
 	// We add a cluster that has been shutdown
@@ -114,7 +121,7 @@ func TestClustersPeerAddInUnhealthyCluster(t *testing.T) {
 	defer shutdownClusters(t, clusters, mocks)
 
 	if len(clusters) < 3 {
-		t.Fatal("need at least 3 nodes for this test")
+		t.Skip("need at least 3 nodes for this test")
 	}
 
 	_, err := clusters[0].PeerAdd(clusterAddr(clusters[1]))
@@ -139,10 +146,15 @@ func TestClustersPeerAddInUnhealthyCluster(t *testing.T) {
 }
 
 func TestClustersPeerRemove(t *testing.T) {
-	clusters, mock := createClusters(t)
-	defer shutdownClusters(t, clusters, mock)
+	clusters, mocks := createClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	if len(clusters) < 2 {
+		t.Skip("test needs at least 2 clusters")
+	}
 
 	p := clusters[1].ID().ID
+	//t.Logf("remove %s from %s", p.Pretty(), clusters[0].config.ClusterPeers)
 	err := clusters[0].PeerRemove(p)
 	if err != nil {
 		t.Error(err)
@@ -154,19 +166,143 @@ func TestClustersPeerRemove(t *testing.T) {
 			if ok {
 				t.Error("removed peer should have exited")
 			}
-			if len(c.config.ClusterPeers) != 0 {
-				t.Error("cluster peers should be empty")
-			}
+			//			if len(c.config.ClusterPeers) != 0 {
+			//				t.Error("cluster peers should be empty")
+			//			}
 		} else {
 			ids := c.Peers()
 			if len(ids) != nClusters-1 {
 				t.Error("should have removed 1 peer")
 			}
-			if len(c.config.ClusterPeers) != nClusters-2 {
-				t.Error("should have removed peer from config")
-			}
+			//			if len(c.config.ClusterPeers) != nClusters-1 {
+			//				t.Log(c.config.ClusterPeers)
+			//				t.Error("should have removed peer from config")
+			//			}
 		}
 	}
 
 	runF(t, clusters, f)
+}
+
+func TestClusterPeerRemoveSelf(t *testing.T) {
+	clusters, mocks := createClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	for i := 0; i < len(clusters); i++ {
+		err := clusters[i].PeerRemove(clusters[i].ID().ID)
+		if err != nil {
+			t.Error(err)
+		}
+		time.Sleep(time.Second)
+		_, more := <-clusters[i].Done()
+		if more {
+			t.Error("should be done")
+		}
+	}
+}
+
+func TestClustersPeerJoin(t *testing.T) {
+	clusters, mocks := peerManagerClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	if len(clusters) < 3 {
+		t.Skip("test needs at least 3 clusters")
+	}
+
+	for i := 1; i < len(clusters); i++ {
+		err := clusters[i].Join(clusterAddr(clusters[0]))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	hash, _ := cid.Decode(testCid)
+	clusters[0].Pin(hash)
+	delay()
+
+	f := func(t *testing.T, c *Cluster) {
+		peers := c.Peers()
+		if len(peers) != nClusters {
+			t.Error("all peers should be connected")
+		}
+		pins := c.Pins()
+		if len(pins) != 1 || !pins[0].Equals(hash) {
+			t.Error("all peers should have pinned the cid")
+		}
+	}
+	runF(t, clusters, f)
+}
+
+func TestClustersPeerJoinAllAtOnce(t *testing.T) {
+	clusters, mocks := peerManagerClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	if len(clusters) < 2 {
+		t.Skip("test needs at least 2 clusters")
+	}
+
+	f := func(t *testing.T, c *Cluster) {
+		err := c.Join(clusterAddr(clusters[0]))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	runF(t, clusters[1:], f)
+
+	hash, _ := cid.Decode(testCid)
+	clusters[0].Pin(hash)
+	delay()
+
+	f2 := func(t *testing.T, c *Cluster) {
+		peers := c.Peers()
+		if len(peers) != nClusters {
+			t.Error("all peers should be connected")
+		}
+		pins := c.Pins()
+		if len(pins) != 1 || !pins[0].Equals(hash) {
+			t.Error("all peers should have pinned the cid")
+		}
+	}
+	runF(t, clusters, f2)
+}
+
+func TestClustersPeerJoinAllAtOnceWithRandomBootstrap(t *testing.T) {
+	clusters, mocks := peerManagerClusters(t)
+	defer shutdownClusters(t, clusters, mocks)
+
+	if len(clusters) < 3 {
+		t.Skip("test needs at least 3 clusters")
+	}
+
+	// We have a 2 node cluster and the rest of nodes join
+	// one of the two seeds randomly
+
+	err := clusters[1].Join(clusterAddr(clusters[0]))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f := func(t *testing.T, c *Cluster) {
+		j := rand.Intn(2)
+		err := c.Join(clusterAddr(clusters[j]))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	runF(t, clusters[2:], f)
+
+	hash, _ := cid.Decode(testCid)
+	clusters[0].Pin(hash)
+	delay()
+
+	f2 := func(t *testing.T, c *Cluster) {
+		peers := c.Peers()
+		if len(peers) != nClusters {
+			t.Error("all peers should be connected")
+		}
+		pins := c.Pins()
+		if len(pins) != 1 || !pins[0].Equals(hash) {
+			t.Error("all peers should have pinned the cid")
+		}
+	}
+	runF(t, clusters, f2)
 }

--- a/silent.go
+++ b/silent.go
@@ -3,5 +3,10 @@
 package ipfscluster
 
 func init() {
-	SetLogLevel("CRITICAL")
+	l := "CRITICAL"
+	SetFacilityLogLevel("cluster", l)
+	SetFacilityLogLevel("raft", l)
+	SetFacilityLogLevel("p2p-gorpc", l)
+	SetFacilityLogLevel("swarm2", l)
+	SetFacilityLogLevel("libp2p-raft", l)
 }

--- a/util.go
+++ b/util.go
@@ -3,18 +3,20 @@ package ipfscluster
 import (
 	"fmt"
 
+	host "github.com/libp2p/go-libp2p-host"
+
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
 // The copy functions below are used in calls to Cluste.multiRPC()
-func copyPIDsToIfaces(in []peer.ID) []interface{} {
-	ifaces := make([]interface{}, len(in), len(in))
-	for i := range in {
-		ifaces[i] = &in[i]
-	}
-	return ifaces
-}
+// func copyPIDsToIfaces(in []peer.ID) []interface{} {
+// 	ifaces := make([]interface{}, len(in), len(in))
+// 	for i := range in {
+// 		ifaces[i] = &in[i]
+// 	}
+// 	return ifaces
+// }
 
 func copyIDSerialsToIfaces(in []IDSerial) []interface{} {
 	ifaces := make([]interface{}, len(in), len(in))
@@ -51,7 +53,7 @@ func copyEmptyStructToIfaces(in []struct{}) []interface{} {
 func multiaddrSplit(addr ma.Multiaddr) (peer.ID, ma.Multiaddr, error) {
 	pid, err := addr.ValueForProtocol(ma.P_IPFS)
 	if err != nil {
-		err = fmt.Errorf("Invalid peer multiaddress: %s: %s", addr, err)
+		err = fmt.Errorf("invalid peer multiaddress: %s: %s", addr, err)
 		logger.Error(err)
 		return "", nil, err
 	}
@@ -61,9 +63,60 @@ func multiaddrSplit(addr ma.Multiaddr) (peer.ID, ma.Multiaddr, error) {
 
 	peerID, err := peer.IDB58Decode(pid)
 	if err != nil {
-		err = fmt.Errorf("Invalid peer ID in multiaddress: %s: %s", pid)
+		err = fmt.Errorf("invalid peer ID in multiaddress: %s: %s", pid, err)
 		logger.Error(err)
 		return "", nil, err
 	}
 	return peerID, decapAddr, nil
+}
+
+func multiaddrJoin(addr ma.Multiaddr, p peer.ID) ma.Multiaddr {
+	pidAddr, err := ma.NewMultiaddr("/ipfs/" + peer.IDB58Encode(p))
+	// let this break badly
+	if err != nil {
+		panic("called multiaddrJoin with bad peer!")
+	}
+	return addr.Encapsulate(pidAddr)
+}
+
+func peersFromMultiaddrs(addrs []ma.Multiaddr) []peer.ID {
+	var pids []peer.ID
+	for _, addr := range addrs {
+		pid, _, err := multiaddrSplit(addr)
+		if err != nil {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// // connect to a peer ID.
+// func connectToPeer(ctx context.Context, h host.Host, id peer.ID, addr ma.Multiaddr) error {
+// 	err := h.Connect(ctx, peerstore.PeerInfo{
+// 		ID:    id,
+// 		Addrs: []ma.Multiaddr{addr},
+// 	})
+// 	return err
+// }
+
+// // return the local multiaddresses used to communicate to a peer.
+// func localMultiaddrsTo(h host.Host, pid peer.ID) []ma.Multiaddr {
+// 	var addrs []ma.Multiaddr
+// 	conns := h.Network().ConnsToPeer(pid)
+// 	logger.Debugf("conns to %s are: %s", pid, conns)
+// 	for _, conn := range conns {
+// 		addrs = append(addrs, multiaddrJoin(conn.LocalMultiaddr(), h.ID()))
+// 	}
+// 	return addrs
+// }
+
+// If we have connections open to that PID and they are using a different addr
+// then we return the one we are using, otherwise the one provided
+func getRemoteMultiaddr(h host.Host, pid peer.ID, addr ma.Multiaddr) ma.Multiaddr {
+	conns := h.Network().ConnsToPeer(pid)
+	if len(conns) > 0 {
+		return multiaddrJoin(conns[0].RemoteMultiaddr(), pid)
+	}
+	return multiaddrJoin(addr, pid)
 }


### PR DESCRIPTION
This is the third implementation attempt. This time, rather than
broadcasting PeerAdd/Join requests to the whole cluster, we use the
consensus log to broadcast new peers joining.

This makes it easier to recover from errors and to know who exactly
is member of a cluster and who is not. The consensus is, after all,
meant to agree on things, and the list of cluster peers is something
everyone has to agree on.

Raft itself uses a special log operation to maintain the peer set.

The tests are almost unchanged from the previous attempts so it should
be the same, except it doesn't seem possible to bootstrap a bunch of nodes
at the same time using different bootstrap nodes. It works when using
the same. I'm not sure this worked before either, but the code is
simpler than recursively contacting peers, and scales better for
larger clusters.

Nodes have to be careful about joining clusters while keeping the state
from a different cluster (disjoint logs). This may cause problems with
Raft.

#24 