### PR TITLE
Add replication factor support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ install:
 - go get github.com/mattn/goveralls
 - make deps
 script:
-- make service
-- make ctl
-- ./coverage.sh
+- make service && make ctl && ./coverage.sh
 env:
   global:
     secure: M3K3y9+D933tCda7+blW3qqVV8fA6PBDRdJoQvmQc1f0XYbWinJ+bAziFp6diKkF8sMQ+cPwLMONYJuaNT2h7/PkG+sIwF0PuUo5VVCbhGmSDrn2qOjmSnfawNs8wW31f44FQA8ICka1EFZcihohoIMf0e5xZ0tXA9jqw+ngPJiRnv4zyzC3r6t4JMAZcbS9w4KTYpIev5Yj72eCvk6lGjadSVCDVXo2sVs27tNt+BSgtMXiH6Sv8GLOnN2kFspGITgivHgB/jtU6QVtFXB+cbBJJAs3lUYnzmQZ5INecbjweYll07ilwFiCVNCX67+L15gpymKGJbQggloIGyTWrAOa2TMaB/bvblzwwQZ8wE5P3Rss5L0TFkUAcdU+3BUHM+TwV4e8F9x10v1PjgWNBRJQzd1sjKKgGUBCeyCY7VeYDKn9AXI5llISgY/AAfCZwm2cbckMHZZJciMjm+U3Q1FCF+rfhlvUcMG1VEj8r9cGpmWIRjFYVm0NmpUDDNjlC3/lUfTCOOJJyM254EUw63XxabbK6EtDN1yQe8kYRcXH//2rtEwgtMBgqHVY+OOkekzGz8Ra3EBkh6jXrAQL3zKu/GwRlK7/a1OU5MQ7dWcTjbx1AQ6Zfyjg5bZ+idqPgMbqM9Zn2+OaSby8HEEXS0QeZVooDVf/6wdYO4MQ/0A=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ install:
 - go get github.com/mattn/goveralls
 - make deps
 script:
-- make test
 - make service
 - make ctl
-- "$GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN"
+- ./coverage.sh
 env:
   global:
     secure: M3K3y9+D933tCda7+blW3qqVV8fA6PBDRdJoQvmQc1f0XYbWinJ+bAziFp6diKkF8sMQ+cPwLMONYJuaNT2h7/PkG+sIwF0PuUo5VVCbhGmSDrn2qOjmSnfawNs8wW31f44FQA8ICka1EFZcihohoIMf0e5xZ0tXA9jqw+ngPJiRnv4zyzC3r6t4JMAZcbS9w4KTYpIev5Yj72eCvk6lGjadSVCDVXo2sVs27tNt+BSgtMXiH6Sv8GLOnN2kFspGITgivHgB/jtU6QVtFXB+cbBJJAs3lUYnzmQZ5INecbjweYll07ilwFiCVNCX67+L15gpymKGJbQggloIGyTWrAOa2TMaB/bvblzwwQZ8wE5P3Rss5L0TFkUAcdU+3BUHM+TwV4e8F9x10v1PjgWNBRJQzd1sjKKgGUBCeyCY7VeYDKn9AXI5llISgY/AAfCZwm2cbckMHZZJciMjm+U3Q1FCF+rfhlvUcMG1VEj8r9cGpmWIRjFYVm0NmpUDDNjlC3/lUfTCOOJJyM254EUw63XxabbK6EtDN1yQe8kYRcXH//2rtEwgtMBgqHVY+OOkekzGz8Ra3EBkh6jXrAQL3zKu/GwRlK7/a1OU5MQ7dWcTjbx1AQ6Zfyjg5bZ+idqPgMbqM9Zn2+OaSby8HEEXS0QeZVooDVf/6wdYO4MQ/0A=

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ deps: gx
 	$(gx_bin) --verbose install --global
 	$(gx-go_bin) rewrite
 test: deps
-	go test -tags silent -v -covermode count -coverprofile=coverage.out ./...
+	go test -tags silent -v ./...
 rw: gx
 	$(gx-go_bin) rewrite
 rwundo: gx

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ deps: gx
 	$(gx_bin) --verbose install --global
 	$(gx-go_bin) rewrite
 test: deps
-	go test -tags silent -v -covermode count -coverprofile=coverage.out .
+	go test -tags silent -v -covermode count -coverprofile=coverage.out ./...
 rw: gx
 	$(gx-go_bin) rewrite
 rwundo: gx

--- a/allocator/numpinalloc/numpinalloc.go
+++ b/allocator/numpinalloc/numpinalloc.go
@@ -1,0 +1,93 @@
+// Package numpinalloc implements an ipfscluster.Allocator based on the "numpin"
+// Informer. It is a simple example on how an allocator is implemented.
+package numpinalloc
+
+import (
+	"sort"
+	"strconv"
+
+	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/informer/numpin"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	cid "github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+var logger = logging.Logger("numpinalloc")
+
+// Allocator implements ipfscluster.Allocate.
+type Allocator struct{}
+
+func NewAllocator() *Allocator {
+	return &Allocator{}
+}
+
+// SetClient does nothing in this allocator
+func (alloc *Allocator) SetClient(c *rpc.Client) {}
+
+// Shutdown does nothing in this allocator
+func (alloc *Allocator) Shutdown() error { return nil }
+
+// Allocate returns where to allocate a pin request based on "numpin"-Informer
+// metrics. In this simple case, we do not pay attention to the metrics
+// of the current, we just need to sort the candidates by number of pins.
+func (alloc *Allocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
+	// sort our metrics
+	numpins := newMetricsSorter(candidates)
+	sort.Sort(numpins)
+	return numpins.peers, nil
+}
+
+// metricsSorter attaches sort.Interface methods to our metrics and sorts
+// a slice of peers in the way that interest us
+type metricsSorter struct {
+	peers []peer.ID
+	m     map[peer.ID]int
+}
+
+func newMetricsSorter(m map[peer.ID]api.Metric) *metricsSorter {
+	vMap := make(map[peer.ID]int)
+	peers := make([]peer.ID, 0, len(m))
+	for k, v := range m {
+		if v.Name != numpin.MetricName || v.Discard() {
+			continue
+		}
+		val, err := strconv.Atoi(v.Value)
+		if err != nil {
+			continue
+		}
+		peers = append(peers, k)
+		vMap[k] = val
+	}
+
+	sorter := &metricsSorter{
+		m:     vMap,
+		peers: peers,
+	}
+	return sorter
+}
+
+// Len returns the number of metrics
+func (s metricsSorter) Len() int {
+	return len(s.peers)
+}
+
+// Less reports if the element in position i is less than the element in j
+func (s metricsSorter) Less(i, j int) bool {
+	peeri := s.peers[i]
+	peerj := s.peers[j]
+
+	x := s.m[peeri]
+	y := s.m[peerj]
+
+	return x < y
+}
+
+// Swap swaps the elements in positions i and j
+func (s metricsSorter) Swap(i, j int) {
+	temp := s.peers[i]
+	s.peers[i] = s.peers[j]
+	s.peers[j] = temp
+}

--- a/allocator/numpinalloc/numpinalloc_test.go
+++ b/allocator/numpinalloc/numpinalloc_test.go
@@ -1,0 +1,134 @@
+package numpinalloc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/informer/numpin"
+
+	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type testcase struct {
+	candidates map[peer.ID]api.Metric
+	current    map[peer.ID]api.Metric
+	expected   []peer.ID
+}
+
+var (
+	peer0      = peer.ID("QmUQ6Nsejt1SuZAu8yL8WgqQZHHAYreLVYYa4VPsLUCed7")
+	peer1      = peer.ID("QmUZ13osndQ5uL4tPWHXe3iBgBgq9gfewcBMSCAuMBsDJ6")
+	peer2      = peer.ID("QmPrSBATWGAN56fiiEWEhKX3L1F3mTghEQR7vQwaeo7zHi")
+	peer3      = peer.ID("QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa")
+	testCid, _ = cid.Decode("QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq")
+)
+
+var inAMinute = time.Now().Add(time.Minute).Format(time.RFC1123)
+
+var testCases = []testcase{
+	{ // regular sort
+		candidates: map[peer.ID]api.Metric{
+			peer0: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "5",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+			peer1: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "1",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+			peer2: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "3",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+			peer3: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "2",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+		},
+		current:  map[peer.ID]api.Metric{},
+		expected: []peer.ID{peer1, peer3, peer2, peer0},
+	},
+	{ // filter invalid
+		candidates: map[peer.ID]api.Metric{
+			peer0: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "1",
+				Expire: inAMinute,
+				Valid:  false,
+			},
+			peer1: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "5",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+		},
+		current:  map[peer.ID]api.Metric{},
+		expected: []peer.ID{peer1},
+	},
+	{ // filter bad metric name
+		candidates: map[peer.ID]api.Metric{
+			peer0: api.Metric{
+				Name:   "lalala",
+				Value:  "1",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+			peer1: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "5",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+		},
+		current:  map[peer.ID]api.Metric{},
+		expected: []peer.ID{peer1},
+	},
+	{ // filter bad value
+		candidates: map[peer.ID]api.Metric{
+			peer0: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "abc",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+			peer1: api.Metric{
+				Name:   numpin.MetricName,
+				Value:  "5",
+				Expire: inAMinute,
+				Valid:  true,
+			},
+		},
+		current:  map[peer.ID]api.Metric{},
+		expected: []peer.ID{peer1},
+	},
+}
+
+func Test(t *testing.T) {
+	alloc := &Allocator{}
+	for i, tc := range testCases {
+		t.Logf("Test case %d", i)
+		res, err := alloc.Allocate(testCid, tc.current, tc.candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res) == 0 {
+			t.Fatal("0 allocations")
+		}
+		for i, r := range res {
+			if e := tc.expected[i]; r != e {
+				t.Errorf("Expect r[%d]=%s but got %s", i, r, e)
+			}
+		}
+	}
+}

--- a/api/types.go
+++ b/api/types.go
@@ -170,7 +170,7 @@ func (pi PinInfo) ToSerial() PinInfoSerial {
 		Cid:    pi.Cid.String(),
 		Peer:   peer.IDB58Encode(pi.Peer),
 		Status: pi.Status.String(),
-		TS:     pi.TS.String(),
+		TS:     pi.TS.Format(time.RFC1123),
 		Error:  pi.Error,
 	}
 }

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,359 @@
+// Package api holds declarations for types used in ipfs-cluster APIs to make
+// them re-usable across differen tools. This include RPC API "Serial[izable]"
+// versions for types. The Go API uses natives types, while RPC API,
+// REST APIs etc use serializable types (i.e. json format). Converstion methods
+// exists between types.
+//
+// Note that all conversion methods ignore any parsing errors. All values must
+// be validated first before initializing any of the types defined here.
+package api
+
+import (
+	"time"
+
+	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+	protocol "github.com/libp2p/go-libp2p-protocol"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// TrackerStatus values
+const (
+	// IPFSStatus should never take this value
+	TrackerStatusBug = iota
+	// The cluster node is offline or not responding
+	TrackerStatusClusterError
+	// An error occurred pinning
+	TrackerStatusPinError
+	// An error occurred unpinning
+	TrackerStatusUnpinError
+	// The IPFS daemon has pinned the item
+	TrackerStatusPinned
+	// The IPFS daemon is currently pinning the item
+	TrackerStatusPinning
+	// The IPFS daemon is currently unpinning the item
+	TrackerStatusUnpinning
+	// The IPFS daemon is not pinning the item
+	TrackerStatusUnpinned
+	// The IPFS deamon is not pinning the item but it is being tracked
+	TrackerStatusRemotePin
+)
+
+// TrackerStatus represents the status of a tracked Cid in the PinTracker
+type TrackerStatus int
+
+var trackerStatusString = map[TrackerStatus]string{
+	TrackerStatusBug:          "bug",
+	TrackerStatusClusterError: "cluster_error",
+	TrackerStatusPinError:     "pin_error",
+	TrackerStatusUnpinError:   "unpin_error",
+	TrackerStatusPinned:       "pinned",
+	TrackerStatusPinning:      "pinning",
+	TrackerStatusUnpinning:    "unpinning",
+	TrackerStatusUnpinned:     "unpinned",
+	TrackerStatusRemotePin:    "remote",
+}
+
+// String converts a TrackerStatus into a readable string.
+func (st TrackerStatus) String() string {
+	return trackerStatusString[st]
+}
+
+// TrackerStatusFromString parses a string and returns the matching
+// TrackerStatus value.
+func TrackerStatusFromString(str string) TrackerStatus {
+	for k, v := range trackerStatusString {
+		if v == str {
+			return k
+		}
+	}
+	return TrackerStatusBug
+}
+
+// IPFSPinStatus values
+const (
+	IPFSPinStatusBug = iota
+	IPFSPinStatusError
+	IPFSPinStatusDirect
+	IPFSPinStatusRecursive
+	IPFSPinStatusIndirect
+	IPFSPinStatusUnpinned
+)
+
+// IPFSPinStatus represents the status of a pin in IPFS (direct, recursive etc.)
+type IPFSPinStatus int
+
+// IPFSPinStatusFromString parses a string and returns the matching
+// IPFSPinStatus.
+func IPFSPinStatusFromString(t string) IPFSPinStatus {
+	// TODO: This is only used in the http_connector to parse
+	// ipfs-daemon-returned values. Maybe it should be extended.
+	switch {
+	case t == "indirect":
+		return IPFSPinStatusIndirect
+	case t == "direct":
+		return IPFSPinStatusDirect
+	case t == "recursive":
+		return IPFSPinStatusRecursive
+	default:
+		return IPFSPinStatusBug
+	}
+}
+
+// IsPinned returns true if the status is Direct or Recursive
+func (ips IPFSPinStatus) IsPinned() bool {
+	return ips == IPFSPinStatusDirect || ips == IPFSPinStatusRecursive
+}
+
+// GlobalPinInfo contains cluster-wide status information about a tracked Cid,
+// indexed by cluster peer.
+type GlobalPinInfo struct {
+	Cid     *cid.Cid
+	PeerMap map[peer.ID]PinInfo
+}
+
+// GlobalPinInfoSerial is the serializable version of GlobalPinInfo.
+type GlobalPinInfoSerial struct {
+	Cid     string                   `json:"cid"`
+	PeerMap map[string]PinInfoSerial `json:"peer_map"`
+}
+
+// ToSerial converts a GlobalPinInfo to its serializable version.
+func (gpi GlobalPinInfo) ToSerial() GlobalPinInfoSerial {
+	s := GlobalPinInfoSerial{}
+	s.Cid = gpi.Cid.String()
+	s.PeerMap = make(map[string]PinInfoSerial)
+	for k, v := range gpi.PeerMap {
+		s.PeerMap[peer.IDB58Encode(k)] = v.ToSerial()
+	}
+	return s
+}
+
+// ToGlobalPinInfo converts a GlobalPinInfoSerial to its native version.
+func (gpis GlobalPinInfoSerial) ToGlobalPinInfo() GlobalPinInfo {
+	c, _ := cid.Decode(gpis.Cid)
+	gpi := GlobalPinInfo{
+		Cid:     c,
+		PeerMap: make(map[peer.ID]PinInfo),
+	}
+	for k, v := range gpis.PeerMap {
+		p, _ := peer.IDB58Decode(k)
+		gpi.PeerMap[p] = v.ToPinInfo()
+	}
+	return gpi
+}
+
+// PinInfo holds information about local pins. PinInfo is
+// serialized when requesting the Global status, therefore
+// we cannot use *cid.Cid.
+type PinInfo struct {
+	Cid    *cid.Cid
+	Peer   peer.ID
+	Status TrackerStatus
+	TS     time.Time
+	Error  string
+}
+
+// PinInfoSerial is a serializable version of PinInfo.
+// information is marked as
+type PinInfoSerial struct {
+	Cid    string `json:"cid"`
+	Peer   string `json:"peer"`
+	Status string `json:"status"`
+	TS     string `json:"timestamp"`
+	Error  string `json:"error"`
+}
+
+// ToSerial converts a PinInfo to its serializable version.
+func (pi PinInfo) ToSerial() PinInfoSerial {
+	return PinInfoSerial{
+		Cid:    pi.Cid.String(),
+		Peer:   peer.IDB58Encode(pi.Peer),
+		Status: pi.Status.String(),
+		TS:     pi.TS.String(),
+		Error:  pi.Error,
+	}
+}
+
+// ToPinInfo converts a PinInfoSerial to its native version.
+func (pis PinInfoSerial) ToPinInfo() PinInfo {
+	c, _ := cid.Decode(pis.Cid)
+	p, _ := peer.IDB58Decode(pis.Peer)
+	ts, _ := time.Parse(time.RFC1123, pis.TS)
+	return PinInfo{
+		Cid:    c,
+		Peer:   p,
+		Status: TrackerStatusFromString(pis.Status),
+		TS:     ts,
+		Error:  pis.Error,
+	}
+}
+
+// Version holds version information
+type Version struct {
+	Version string `json:"Version"`
+}
+
+// IPFSID is used to store information about the underlying IPFS daemon
+type IPFSID struct {
+	ID        peer.ID
+	Addresses []ma.Multiaddr
+	Error     string
+}
+
+// IPFSIDSerial is the serializable IPFSID for RPC requests
+type IPFSIDSerial struct {
+	ID        string           `json:"id"`
+	Addresses MultiaddrsSerial `json:"addresses"`
+	Error     string           `json:"error"`
+}
+
+// ToSerial converts IPFSID to a go serializable object
+func (id *IPFSID) ToSerial() IPFSIDSerial {
+	return IPFSIDSerial{
+		ID:        peer.IDB58Encode(id.ID),
+		Addresses: MultiaddrsToSerial(id.Addresses),
+		Error:     id.Error,
+	}
+}
+
+// ToIPFSID converts an IPFSIDSerial to IPFSID
+func (ids *IPFSIDSerial) ToIPFSID() IPFSID {
+	id := IPFSID{}
+	if pID, err := peer.IDB58Decode(ids.ID); err == nil {
+		id.ID = pID
+	}
+	id.Addresses = ids.Addresses.ToMultiaddrs()
+	id.Error = ids.Error
+	return id
+}
+
+// ID holds information about the Cluster peer
+type ID struct {
+	ID                 peer.ID
+	Addresses          []ma.Multiaddr
+	ClusterPeers       []ma.Multiaddr
+	Version            string
+	Commit             string
+	RPCProtocolVersion protocol.ID
+	Error              string
+	IPFS               IPFSID
+	//PublicKey          crypto.PubKey
+}
+
+// IDSerial is the serializable ID counterpart for RPC requests
+type IDSerial struct {
+	ID                 string           `json:"id"`
+	Addresses          MultiaddrsSerial `json:"addresses"`
+	ClusterPeers       MultiaddrsSerial `json:"cluster_peers"`
+	Version            string           `json:"version"`
+	Commit             string           `json:"commit"`
+	RPCProtocolVersion string           `json:"rpc_protocol_version"`
+	Error              string           `json:"error"`
+	IPFS               IPFSIDSerial     `json:"ipfs"`
+	//PublicKey          []byte
+}
+
+// ToSerial converts an ID to its Go-serializable version
+func (id ID) ToSerial() IDSerial {
+	//var pkey []byte
+	//if id.PublicKey != nil {
+	//	pkey, _ = id.PublicKey.Bytes()
+	//}
+
+	return IDSerial{
+		ID: peer.IDB58Encode(id.ID),
+		//PublicKey:          pkey,
+		Addresses:          MultiaddrsToSerial(id.Addresses),
+		ClusterPeers:       MultiaddrsToSerial(id.ClusterPeers),
+		Version:            id.Version,
+		Commit:             id.Commit,
+		RPCProtocolVersion: string(id.RPCProtocolVersion),
+		Error:              id.Error,
+		IPFS:               id.IPFS.ToSerial(),
+	}
+}
+
+// ToID converts an IDSerial object to ID.
+// It will ignore any errors when parsing the fields.
+func (ids IDSerial) ToID() ID {
+	id := ID{}
+	p, _ := peer.IDB58Decode(ids.ID)
+	id.ID = p
+
+	//if pkey, err := crypto.UnmarshalPublicKey(ids.PublicKey); err == nil {
+	//	id.PublicKey = pkey
+	//}
+
+	id.Addresses = ids.Addresses.ToMultiaddrs()
+	id.ClusterPeers = ids.ClusterPeers.ToMultiaddrs()
+	id.Version = ids.Version
+	id.Commit = ids.Commit
+	id.RPCProtocolVersion = protocol.ID(ids.RPCProtocolVersion)
+	id.Error = ids.Error
+	id.IPFS = ids.IPFS.ToIPFSID()
+	return id
+}
+
+// MultiaddrSerial is a Multiaddress in a serializable form
+type MultiaddrSerial string
+
+// MultiaddrsSerial is an array of Multiaddresses in serializable form
+type MultiaddrsSerial []MultiaddrSerial
+
+// MultiaddrToSerial converts a Multiaddress to its serializable form
+func MultiaddrToSerial(addr ma.Multiaddr) MultiaddrSerial {
+	return MultiaddrSerial(addr.String())
+}
+
+// ToMultiaddr converts a serializable Multiaddress to its original type.
+// All errors are ignored.
+func (addrS MultiaddrSerial) ToMultiaddr() ma.Multiaddr {
+	a, _ := ma.NewMultiaddr(string(addrS))
+	return a
+}
+
+// MultiaddrsToSerial converts a slice of Multiaddresses to its
+// serializable form.
+func MultiaddrsToSerial(addrs []ma.Multiaddr) MultiaddrsSerial {
+	addrsS := make([]MultiaddrSerial, len(addrs), len(addrs))
+	for i, a := range addrs {
+		addrsS[i] = MultiaddrToSerial(a)
+	}
+	return addrsS
+}
+
+// ToMultiaddrs converts MultiaddrsSerial back to a slice of Multiaddresses
+func (addrsS MultiaddrsSerial) ToMultiaddrs() []ma.Multiaddr {
+	addrs := make([]ma.Multiaddr, len(addrsS), len(addrsS))
+	for i, addrS := range addrsS {
+		addrs[i] = addrS.ToMultiaddr()
+	}
+	return addrs
+}
+
+// CidArg is an arguments that carry a Cid. It may carry more things in the
+// future.
+type CidArg struct {
+	Cid *cid.Cid
+}
+
+// CidArgSerial is a serializable version of CidArg
+type CidArgSerial struct {
+	Cid string `json:"cid"`
+}
+
+// ToSerial converts a CidArg to CidArgSerial.
+func (carg CidArg) ToSerial() CidArgSerial {
+	return CidArgSerial{
+		Cid: carg.Cid.String(),
+	}
+}
+
+// ToCidArg converts a CidArgSerial to its native form.
+func (cargs CidArgSerial) ToCidArg() CidArg {
+	c, _ := cid.Decode(cargs.Cid)
+	return CidArg{
+		Cid: c,
+	}
+}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+var testTime = time.Date(2017, 12, 31, 15, 45, 50, 0, time.UTC)
+var testMAddr, _ = ma.NewMultiaddr("/ip4/1.2.3.4")
+var testCid1, _ = cid.Decode("QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq")
+var testPeerID1, _ = peer.IDB58Decode("QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabc")
+var testPeerID2, _ = peer.IDB58Decode("QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabd")
+
+func TestTrackerFromString(t *testing.T) {
+	testcases := []string{"bug", "cluster_error", "pin_error", "unpin_error", "pinned", "pinning", "unpinning", "unpinned", "remote"}
+	for i, tc := range testcases {
+		if TrackerStatusFromString(tc).String() != TrackerStatus(i).String() {
+			t.Errorf("%s does not match  %s", tc, i)
+		}
+	}
+}
+
+func TestIPFSPinStatusFromString(t *testing.T) {
+	testcases := []string{"direct", "recursive", "indirect"}
+	for i, tc := range testcases {
+		if IPFSPinStatusFromString(tc) != IPFSPinStatus(i+2) {
+			t.Errorf("%s does not match IPFSPinStatus %d", tc, i+2)
+		}
+	}
+}
+
+func TestGlobalPinInfoConv(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("paniced")
+		}
+	}()
+
+	gpi := GlobalPinInfo{
+		Cid: testCid1,
+		PeerMap: map[peer.ID]PinInfo{
+			testPeerID1: {
+				Cid:    testCid1,
+				Peer:   testPeerID1,
+				Status: TrackerStatusPinned,
+				TS:     testTime,
+			},
+		},
+	}
+
+	newgpi := gpi.ToSerial().ToGlobalPinInfo()
+	if gpi.Cid.String() != newgpi.Cid.String() {
+		t.Error("mismatching CIDs")
+	}
+	if gpi.PeerMap[testPeerID1].Cid.String() != newgpi.PeerMap[testPeerID1].Cid.String() {
+		t.Error("mismatching PinInfo CIDs")
+	}
+
+	if !gpi.PeerMap[testPeerID1].TS.Equal(newgpi.PeerMap[testPeerID1].TS) {
+		t.Error("bad time")
+	}
+}
+
+func TestIDConv(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("paniced")
+		}
+	}()
+
+	id := ID{
+		ID:                 testPeerID1,
+		Addresses:          []ma.Multiaddr{testMAddr},
+		ClusterPeers:       []ma.Multiaddr{testMAddr},
+		Version:            "testv",
+		Commit:             "ab",
+		RPCProtocolVersion: "testp",
+		Error:              "teste",
+		IPFS: IPFSID{
+			ID:        testPeerID2,
+			Addresses: []ma.Multiaddr{testMAddr},
+			Error:     "abc",
+		},
+	}
+
+	newid := id.ToSerial().ToID()
+
+	if id.ID != newid.ID {
+		t.Error("mismatching Peer IDs")
+	}
+
+	if !id.Addresses[0].Equal(newid.Addresses[0]) {
+		t.Error("mismatching addresses")
+	}
+
+	if !id.ClusterPeers[0].Equal(newid.ClusterPeers[0]) {
+		t.Error("mismatching clusterPeers")
+	}
+
+	if id.Version != newid.Version ||
+		id.Commit != newid.Commit ||
+		id.RPCProtocolVersion != newid.RPCProtocolVersion ||
+		id.Error != newid.Error {
+		t.Error("some field didn't survive")
+	}
+
+	if id.IPFS.ID != newid.IPFS.ID {
+		t.Error("ipfs daemon id mismatch")
+	}
+
+	if !id.IPFS.Addresses[0].Equal(newid.IPFS.Addresses[0]) {
+		t.Error("mismatching addresses")
+	}
+	if id.IPFS.Error != newid.IPFS.Error {
+		t.Error("ipfs error mismatch")
+	}
+}
+
+func TestMultiaddrConv(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("paniced")
+		}
+	}()
+	addrs := []ma.Multiaddr{testMAddr}
+	new := MultiaddrsToSerial(addrs).ToMultiaddrs()
+	if !addrs[0].Equal(new[0]) {
+		t.Error("mismatch")
+	}
+}
+
+func TestCidArgConv(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("paniced")
+		}
+	}()
+
+	c := CidArg{
+		Cid:         testCid1,
+		Allocations: []peer.ID{testPeerID1},
+		Everywhere:  true,
+	}
+
+	newc := c.ToSerial().ToCidArg()
+	if c.Cid.String() != newc.Cid.String() ||
+		c.Allocations[0] != newc.Allocations[0] ||
+		c.Everywhere != newc.Everywhere {
+		t.Error("mismatch")
+	}
+}
+
+func TestMetric(t *testing.T) {
+	m := Metric{
+		Name:  "hello",
+		Value: "abc",
+	}
+
+	if !m.Expired() {
+		t.Error("metric should be expire")
+	}
+
+	m.SetTTL(1)
+	if m.Expired() {
+		t.Error("metric should not be expired")
+	}
+
+	// let it expire
+	time.Sleep(1500 * time.Millisecond)
+
+	if !m.Expired() {
+		t.Error("metric should be expired")
+	}
+
+	m.SetTTL(30)
+	m.Valid = true
+
+	if m.Discard() {
+		t.Error("metric should be valid")
+	}
+
+	m.Valid = false
+	if !m.Discard() {
+		t.Error("metric should be invalid")
+	}
+
+	ttl := m.GetTTL()
+	if ttl > 30*time.Second || ttl < 29*time.Second {
+		t.Error("looks like a bad ttl")
+	}
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ipfs/ipfs-cluster/api"
+
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 	cid "github.com/ipfs/go-cid"
 )
@@ -30,11 +32,11 @@ type mockConnector struct {
 	mockComponent
 }
 
-func (ipfs *mockConnector) ID() (IPFSID, error) {
+func (ipfs *mockConnector) ID() (api.IPFSID, error) {
 	if ipfs.returnError {
-		return IPFSID{}, errors.New("")
+		return api.IPFSID{}, errors.New("")
 	}
-	return IPFSID{
+	return api.IPFSID{
 		ID: testPeerID,
 	}, nil
 }
@@ -53,18 +55,18 @@ func (ipfs *mockConnector) Unpin(c *cid.Cid) error {
 	return nil
 }
 
-func (ipfs *mockConnector) PinLsCid(c *cid.Cid) (IPFSPinStatus, error) {
+func (ipfs *mockConnector) PinLsCid(c *cid.Cid) (api.IPFSPinStatus, error) {
 	if ipfs.returnError {
-		return IPFSPinStatusError, errors.New("")
+		return api.IPFSPinStatusError, errors.New("")
 	}
-	return IPFSPinStatusRecursive, nil
+	return api.IPFSPinStatusRecursive, nil
 }
 
-func (ipfs *mockConnector) PinLs() (map[string]IPFSPinStatus, error) {
+func (ipfs *mockConnector) PinLs() (map[string]api.IPFSPinStatus, error) {
 	if ipfs.returnError {
 		return nil, errors.New("")
 	}
-	m := make(map[string]IPFSPinStatus)
+	m := make(map[string]api.IPFSPinStatus)
 	return m, nil
 }
 
@@ -109,7 +111,7 @@ func TestClusterStateSync(t *testing.T) {
 	defer cl.Shutdown()
 	_, err := cl.StateSync()
 	if err == nil {
-		t.Error("expected an error as there is no state to sync")
+		t.Fatal("expected an error as there is no state to sync")
 	}
 
 	c, _ := cid.Decode(testCid)
@@ -146,9 +148,9 @@ func TestClusterID(t *testing.T) {
 	if id.Version != Version {
 		t.Error("version should match current version")
 	}
-	if id.PublicKey == nil {
-		t.Error("publicKey should not be empty")
-	}
+	//if id.PublicKey == nil {
+	//	t.Error("publicKey should not be empty")
+	//}
 }
 
 func TestClusterPin(t *testing.T) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/state/mapstate"
+	"github.com/ipfs/ipfs-cluster/test"
 
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 	cid "github.com/ipfs/go-cid"
@@ -37,7 +39,7 @@ func (ipfs *mockConnector) ID() (api.IPFSID, error) {
 		return api.IPFSID{}, errors.New("")
 	}
 	return api.IPFSID{
-		ID: testPeerID,
+		ID: test.TestPeerID1,
 	}, nil
 }
 
@@ -62,7 +64,7 @@ func (ipfs *mockConnector) PinLsCid(c *cid.Cid) (api.IPFSPinStatus, error) {
 	return api.IPFSPinStatusRecursive, nil
 }
 
-func (ipfs *mockConnector) PinLs() (map[string]api.IPFSPinStatus, error) {
+func (ipfs *mockConnector) PinLs(filter string) (map[string]api.IPFSPinStatus, error) {
 	if ipfs.returnError {
 		return nil, errors.New("")
 	}
@@ -70,11 +72,11 @@ func (ipfs *mockConnector) PinLs() (map[string]api.IPFSPinStatus, error) {
 	return m, nil
 }
 
-func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *MapState, *MapPinTracker) {
+func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *MapPinTracker) {
 	api := &mockAPI{}
 	ipfs := &mockConnector{}
 	cfg := testingConfig()
-	st := NewMapState()
+	st := mapstate.NewMapState()
 	tracker := NewMapPinTracker(cfg)
 
 	cl, err := NewCluster(
@@ -114,7 +116,7 @@ func TestClusterStateSync(t *testing.T) {
 		t.Fatal("expected an error as there is no state to sync")
 	}
 
-	c, _ := cid.Decode(testCid)
+	c, _ := cid.Decode(test.TestCid1)
 	err = cl.Pin(c)
 	if err != nil {
 		t.Fatal("pin should have worked:", err)
@@ -158,7 +160,7 @@ func TestClusterPin(t *testing.T) {
 	defer cleanRaft()
 	defer cl.Shutdown()
 
-	c, _ := cid.Decode(testCid)
+	c, _ := cid.Decode(test.TestCid1)
 	err := cl.Pin(c)
 	if err != nil {
 		t.Fatal("pin should have worked:", err)
@@ -177,7 +179,7 @@ func TestClusterUnpin(t *testing.T) {
 	defer cleanRaft()
 	defer cl.Shutdown()
 
-	c, _ := cid.Decode(testCid)
+	c, _ := cid.Decode(test.TestCid1)
 	err := cl.Unpin(c)
 	if err != nil {
 		t.Fatal("pin should have worked:", err)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ipfs/ipfs-cluster/allocator/numpinalloc"
 	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/informer/numpin"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 	"github.com/ipfs/ipfs-cluster/test"
 
@@ -78,6 +80,9 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate
 	cfg := testingConfig()
 	st := mapstate.NewMapState()
 	tracker := NewMapPinTracker(cfg)
+	mon := NewStdPeerMonitor(5)
+	alloc := numpinalloc.NewAllocator()
+	inf := numpin.NewInformer()
 
 	cl, err := NewCluster(
 		cfg,
@@ -85,7 +90,9 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate
 		ipfs,
 		st,
 		tracker,
-	)
+		mon,
+		alloc,
+		inf)
 	if err != nil {
 		t.Fatal("cannot create cluster:", err)
 	}
@@ -129,7 +136,7 @@ func TestClusterStateSync(t *testing.T) {
 
 	// Modify state on the side so the sync does not
 	// happen on an empty slide
-	st.RmPin(c)
+	st.Rm(c)
 	_, err = cl.StateSync()
 	if err != nil {
 		t.Fatal("sync with recover should have worked:", err)

--- a/coverage.sh
+++ b/coverage.sh
@@ -12,7 +12,7 @@ for dir in $dirs;
 do
         if ls "$dir"/*.go &> /dev/null;
         then
-            go test -coverprofile=profile.out -covermode=count -tags silent "$dir"
+            go test -v -coverprofile=profile.out -covermode=count -tags silent "$dir"
             if [ $? -ne 0 ];
             then
                 exit 1

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ -z $COVERALLS_TOKEN ]
+then
+    exit 1
+fi
+
+echo "mode: count" > fullcov.out
+dirs=$(find ./* -maxdepth 10 -type d )
+dirs=". $dirs"
+for dir in $dirs;
+do
+        if ls "$dir"/*.go &> /dev/null;
+        then
+            go test -coverprofile=profile.out -covermode=count -tags silent "$dir"
+            if [ $? -ne 0 ];
+            then
+                exit 1
+            fi
+            if [ -f profile.out ]
+            then
+                cat profile.out | grep -v "^mode: count" >> fullcov.out
+            fi
+        fi
+done
+$HOME/gopath/bin/goveralls -coverprofile=fullcov.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+rm -rf ./profile.out
+rm -rf ./fullcov.out

--- a/informer/numpin/numpin.go
+++ b/informer/numpin/numpin.go
@@ -1,0 +1,77 @@
+// Package numpin implements an ipfs-cluster informer which determines how many
+// items this peer is pinning and returns it as api.Metric
+package numpin
+
+import (
+	"fmt"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+
+	"github.com/ipfs/ipfs-cluster/api"
+)
+
+// MetricTTL specifies how long our reported metric is valid in seconds.
+var MetricTTL = 10
+
+// MetricName specifies the name of our metric
+var MetricName = "numpin"
+
+// Informer is a simple object to implement the ipfscluster.Informer
+// and Component interfaces
+type Informer struct {
+	rpcClient *rpc.Client
+}
+
+func NewInformer() *Informer {
+	return &Informer{}
+}
+
+// SetClient provides us with an rpc.Client which allows
+// contacting other components in the cluster.
+func (npi *Informer) SetClient(c *rpc.Client) {
+	npi.rpcClient = c
+}
+
+// Shutdown is called on cluster shutdown. We just invalidate
+// any metrics from this point.
+func (npi *Informer) Shutdown() error {
+	npi.rpcClient = nil
+	return nil
+}
+
+// Name returns the name of this informer
+func (npi *Informer) Name() string {
+	return MetricName
+}
+
+// GetMetric contacts the IPFSConnector component and
+// requests the `pin ls` command. We return the number
+// of pins in IPFS.
+func (npi *Informer) GetMetric() api.Metric {
+	if npi.rpcClient == nil {
+		return api.Metric{
+			Valid: false,
+		}
+	}
+
+	pinMap := make(map[string]api.IPFSPinStatus)
+
+	// make use of the RPC API to obtain information
+	// about the number of pins in IPFS. See RPCAPI docs.
+	err := npi.rpcClient.Call("", // Local call
+		"Cluster",   // Service name
+		"IPFSPinLs", // Method name
+		"recursive", // in arg
+		&pinMap)     // out arg
+
+	valid := err == nil
+
+	m := api.Metric{
+		Name:  MetricName,
+		Value: fmt.Sprintf("%d", len(pinMap)),
+		Valid: valid,
+	}
+
+	m.SetTTL(MetricTTL)
+	return m
+}

--- a/informer/numpin/numpin_test.go
+++ b/informer/numpin/numpin_test.go
@@ -1,0 +1,45 @@
+package numpin
+
+import (
+	"testing"
+
+	"github.com/ipfs/ipfs-cluster/api"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+)
+
+type mockService struct{}
+
+func mockRPCClient(t *testing.T) *rpc.Client {
+	s := rpc.NewServer(nil, "mock")
+	c := rpc.NewClientWithServer(nil, "mock", s)
+	err := s.RegisterName("Cluster", &mockService{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func (mock *mockService) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) error {
+	*out = map[string]api.IPFSPinStatus{
+		"QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa": api.IPFSPinStatusRecursive,
+		"QmUZ13osndQ5uL4tPWHXe3iBgBgq9gfewcBMSCAuMBsDJ6": api.IPFSPinStatusRecursive,
+	}
+	return nil
+}
+
+func Test(t *testing.T) {
+	inf := NewInformer()
+	m := inf.GetMetric()
+	if m.Valid {
+		t.Error("metric should be invalid")
+	}
+	inf.SetClient(mockRPCClient(t))
+	m = inf.GetMetric()
+	if !m.Valid {
+		t.Error("metric should be valid")
+	}
+	if m.Value != "2" {
+		t.Error("bad metric value")
+	}
+}

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ipfs/ipfs-cluster/api"
+)
+
+const (
+	formatNone = iota
+	formatID
+	formatGPInfo
+	formatString
+	formatVersion
+)
+
+type format int
+
+func textFormat(body []byte, format int) {
+	if len(body) < 2 {
+		fmt.Println("")
+	}
+
+	slice := body[0] == '['
+	if slice {
+		textFormatSlice(body, format)
+	} else {
+		textFormatObject(body, format)
+	}
+}
+
+func textFormatObject(body []byte, format int) {
+	switch format {
+	case formatID:
+		var obj api.IDSerial
+		textFormatDecodeOn(body, &obj)
+		textFormatPrintIDSerial(&obj)
+	case formatGPInfo:
+		var obj api.GlobalPinInfoSerial
+		textFormatDecodeOn(body, &obj)
+		textFormatPrintGPinfo(&obj)
+	case formatVersion:
+		var obj api.Version
+		textFormatDecodeOn(body, &obj)
+		textFormatPrintVersion(&obj)
+	default:
+		var obj interface{}
+		textFormatDecodeOn(body, &obj)
+		fmt.Printf("%s\n", obj)
+	}
+}
+
+func textFormatSlice(body []byte, format int) {
+	var rawMsg []json.RawMessage
+	textFormatDecodeOn(body, &rawMsg)
+	for _, raw := range rawMsg {
+		textFormatObject(raw, format)
+	}
+}
+
+func textFormatDecodeOn(body []byte, obj interface{}) {
+	checkErr("decoding JSON", json.Unmarshal(body, obj))
+}
+
+func textFormatPrintIDSerial(obj *api.IDSerial) {
+	if obj.Error != "" {
+		fmt.Printf("%s | ERROR: %s\n", obj.ID, obj.Error)
+		return
+	}
+
+	fmt.Printf("%s | %d peers\n", obj.ID, len(obj.ClusterPeers))
+	fmt.Println("  > Addresses:")
+	for _, a := range obj.Addresses {
+		fmt.Printf("    - %s\n", a)
+	}
+	if obj.IPFS.Error != "" {
+		fmt.Printf("  > IPFS ERROR: %s\n", obj.IPFS.Error)
+		return
+	}
+	fmt.Printf("  > IPFS: %s\n", obj.IPFS.ID)
+	for _, a := range obj.IPFS.Addresses {
+		fmt.Printf("    - %s\n", a)
+	}
+}
+
+func textFormatPrintGPinfo(obj *api.GlobalPinInfoSerial) {
+	fmt.Printf("%s:\n", obj.Cid)
+	for k, v := range obj.PeerMap {
+		if v.Error != "" {
+			fmt.Printf("  - %s ERROR: %s\n", k, v.Error)
+			continue
+		}
+		fmt.Printf("    > Peer %s: %s | %s\n", k, strings.ToUpper(v.Status), v.TS)
+	}
+}
+
+func textFormatPrintVersion(obj *api.Version) {
+	fmt.Println(obj.Version)
+}

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -14,6 +14,7 @@ const (
 	formatGPInfo
 	formatString
 	formatVersion
+	formatCidArg
 )
 
 type format int
@@ -45,6 +46,10 @@ func textFormatObject(body []byte, format int) {
 		var obj api.Version
 		textFormatDecodeOn(body, &obj)
 		textFormatPrintVersion(&obj)
+	case formatCidArg:
+		var obj api.CidArgSerial
+		textFormatDecodeOn(body, &obj)
+		textFormatPrintCidArg(&obj)
 	default:
 		var obj interface{}
 		textFormatDecodeOn(body, &obj)
@@ -98,4 +103,13 @@ func textFormatPrintGPinfo(obj *api.GlobalPinInfoSerial) {
 
 func textFormatPrintVersion(obj *api.Version) {
 	fmt.Println(obj.Version)
+}
+
+func textFormatPrintCidArg(obj *api.CidArgSerial) {
+	fmt.Printf("%s | Allocations: ", obj.Cid)
+	if obj.Everywhere {
+		fmt.Printf("[everywhere]\n")
+	} else {
+		fmt.Printf("%s", obj.Allocations)
+	}
 }

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -90,6 +90,11 @@ func main() {
 			Name:  "https, s",
 			Usage: "use https to connect to the API",
 		},
+		cli.StringFlag{
+			Name:  "encoding, enc",
+			Value: "text",
+			Usage: "output format encoding [text, json]",
+		},
 		cli.IntFlag{
 			Name:  "timeout, t",
 			Value: defaultTimeout,
@@ -120,9 +125,10 @@ func main() {
 			UsageText: `
 This command will print out information about the cluster peer used
 `,
+			Flags: []cli.Flag{parseFlag(formatID)},
 			Action: func(c *cli.Context) error {
 				resp := request("GET", "/id", nil)
-				formatResponse(resp)
+				formatResponse(c, resp)
 				return nil
 			},
 		},
@@ -139,9 +145,10 @@ This command can be used to list and manage IPFS Cluster peers.
 					UsageText: `
 This commands provides a list of the ID information of all the peers in the Cluster.
 `,
+					Flags: []cli.Flag{parseFlag(formatID)},
 					Action: func(c *cli.Context) error {
 						resp := request("GET", "/peers", nil)
-						formatResponse(resp)
+						formatResponse(c, resp)
 						return nil
 					},
 				},
@@ -154,6 +161,7 @@ succeed, the new peer needs to be reachable and any other member of the cluster
 should be online. The operation returns the ID information for the new peer.
 `,
 					ArgsUsage: "<multiaddress>",
+					Flags:     []cli.Flag{parseFlag(formatID)},
 					Action: func(c *cli.Context) error {
 						addr := c.Args().First()
 						if addr == "" {
@@ -166,7 +174,7 @@ should be online. The operation returns the ID information for the new peer.
 						enc := json.NewEncoder(&buf)
 						enc.Encode(addBody)
 						resp := request("POST", "/peers", &buf)
-						formatResponse(resp)
+						formatResponse(c, resp)
 						return nil
 					},
 				},
@@ -180,12 +188,13 @@ operation to succeed, otherwise some nodes may be left with an outdated list of
 cluster peers.
 `,
 					ArgsUsage: "<peer ID>",
+					Flags:     []cli.Flag{parseFlag(formatNone)},
 					Action: func(c *cli.Context) error {
 						pid := c.Args().First()
 						_, err := peer.IDB58Decode(pid)
 						checkErr("parsing peer ID", err)
 						resp := request("DELETE", "/peers/"+pid, nil)
-						formatResponse(resp)
+						formatResponse(c, resp)
 						return nil
 					},
 				},
@@ -211,6 +220,7 @@ When the request has succeeded, the command returns the status of the CID
 in the cluster and should be part of the list offered by "pin ls".
 `,
 					ArgsUsage: "<cid>",
+					Flags:     []cli.Flag{parseFlag(formatGPInfo)},
 					Action: func(c *cli.Context) error {
 						cidStr := c.Args().First()
 						_, err := cid.Decode(cidStr)
@@ -218,7 +228,7 @@ in the cluster and should be part of the list offered by "pin ls".
 						request("POST", "/pins/"+cidStr, nil)
 						time.Sleep(500 * time.Millisecond)
 						resp := request("GET", "/pins/"+cidStr, nil)
-						formatResponse(resp)
+						formatResponse(c, resp)
 						return nil
 					},
 				},
@@ -234,6 +244,7 @@ in the cluster. The CID should disappear from the list offered by "pin ls",
 although unpinning operations in the cluster may take longer or fail.
 `,
 					ArgsUsage: "<cid>",
+					Flags:     []cli.Flag{parseFlag(formatGPInfo)},
 					Action: func(c *cli.Context) error {
 						cidStr := c.Args().First()
 						_, err := cid.Decode(cidStr)
@@ -241,7 +252,7 @@ although unpinning operations in the cluster may take longer or fail.
 						request("DELETE", "/pins/"+cidStr, nil)
 						time.Sleep(500 * time.Millisecond)
 						resp := request("GET", "/pins/"+cidStr, nil)
-						formatResponse(resp)
+						formatResponse(c, resp)
 						return nil
 					},
 				},
@@ -254,9 +265,10 @@ list does not include information about tracking status or location, it
 merely represents the list of pins which are part of the global state of
 the cluster. For specific information, use "status".
 `,
+					Flags: []cli.Flag{parseFlag(formatString)},
 					Action: func(c *cli.Context) error {
 						resp := request("GET", "/pinlist", nil)
-						formatResponse(resp)
+						formatResponse(c, resp)
 						return nil
 					},
 				},
@@ -275,6 +287,7 @@ The status of a CID may not be accurate. A manual sync can be triggered
 with "sync".
 `,
 			ArgsUsage: "[cid]",
+			Flags:     []cli.Flag{parseFlag(formatGPInfo)},
 			Action: func(c *cli.Context) error {
 				cidStr := c.Args().First()
 				if cidStr != "" {
@@ -282,7 +295,7 @@ with "sync".
 					checkErr("parsing cid", err)
 				}
 				resp := request("GET", "/pins/"+cidStr, nil)
-				formatResponse(resp)
+				formatResponse(c, resp)
 				return nil
 			},
 		},
@@ -302,6 +315,7 @@ therefore, the output should be empty if no operations were performed.
 CIDs in error state may be manually recovered with "recover".
 `,
 			ArgsUsage: "[cid]",
+			Flags:     []cli.Flag{parseFlag(formatGPInfo)},
 			Action: func(c *cli.Context) error {
 				cidStr := c.Args().First()
 				var resp *http.Response
@@ -312,7 +326,7 @@ CIDs in error state may be manually recovered with "recover".
 				} else {
 					resp = request("POST", "/pins/sync", nil)
 				}
-				formatResponse(resp)
+				formatResponse(c, resp)
 				return nil
 			},
 		},
@@ -327,6 +341,7 @@ The command will wait for any operations to succeed and will return the status
 of the item upon completion.
 `,
 			ArgsUsage: "<cid>",
+			Flags:     []cli.Flag{parseFlag(formatGPInfo)},
 			Action: func(c *cli.Context) error {
 				cidStr := c.Args().First()
 				var resp *http.Response
@@ -334,7 +349,7 @@ of the item upon completion.
 					_, err := cid.Decode(cidStr)
 					checkErr("parsing cid", err)
 					resp = request("POST", "/pins/"+cidStr+"/recover", nil)
-					formatResponse(resp)
+					formatResponse(c, resp)
 
 				} else {
 					return cli.NewExitError("A CID is required", 1)
@@ -349,15 +364,40 @@ of the item upon completion.
 This command retrieves the IPFS Cluster version and can be used
 to check that it matches the CLI version (shown by -v).
 `,
+			Flags: []cli.Flag{parseFlag(formatVersion)},
 			Action: func(c *cli.Context) error {
 				resp := request("GET", "/version", nil)
-				formatResponse(resp)
+				formatResponse(c, resp)
+				return nil
+			},
+		},
+		{
+			Name:   "commands",
+			Usage:  "List all commands",
+			Hidden: true,
+			Action: func(c *cli.Context) error {
+				walkCommands(c.App.Commands)
 				return nil
 			},
 		},
 	}
 
 	app.Run(os.Args)
+}
+
+func parseFlag(t int) cli.IntFlag {
+	return cli.IntFlag{
+		Name:   "parseAs",
+		Value:  t,
+		Hidden: true,
+	}
+}
+
+func walkCommands(cmds []cli.Command) {
+	for _, c := range cmds {
+		fmt.Println(c.HelpName)
+		walkCommands(c.Subcommands)
+	}
 }
 
 func request(method, path string, body io.Reader, args ...string) *http.Response {
@@ -386,26 +426,34 @@ func request(method, path string, body io.Reader, args ...string) *http.Response
 	return resp
 }
 
-func formatResponse(r *http.Response) {
+func formatResponse(c *cli.Context, r *http.Response) {
 	defer r.Body.Close()
 	body, err := ioutil.ReadAll(r.Body)
 	checkErr("reading body", err)
 	logger.Debugf("Body: %s", body)
 
-	if r.StatusCode > 399 {
+	switch {
+	case r.StatusCode > 399:
 		var e errorResp
 		err = json.Unmarshal(body, &e)
 		checkErr("decoding error response", err)
 		out("Error %d: %s", e.Code, e.Message)
-	} else if r.StatusCode == http.StatusAccepted {
-		out("%s", "request accepted")
-	} else if r.StatusCode == http.StatusNoContent {
+	case r.StatusCode == http.StatusAccepted:
+		out("%s", "Request accepted")
+	case r.StatusCode == http.StatusNoContent:
 		out("%s", "Request succeeded\n")
-	} else {
-		var resp interface{}
-		err = json.Unmarshal(body, &resp)
-		checkErr("decoding response", err)
-		prettyPrint(body)
+	default:
+		enc := c.GlobalString("encoding")
+
+		switch enc {
+		case "text":
+			textFormat(body, c.Int("parseAs"))
+		default:
+			var resp interface{}
+			err = json.Unmarshal(body, &resp)
+			checkErr("decoding response", err)
+			prettyPrint(body)
+		}
 	}
 }
 

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -225,9 +225,10 @@ in the cluster and should be part of the list offered by "pin ls".
 						cidStr := c.Args().First()
 						_, err := cid.Decode(cidStr)
 						checkErr("parsing cid", err)
-						request("POST", "/pins/"+cidStr, nil)
+						resp := request("POST", "/pins/"+cidStr, nil)
+						formatResponse(c, resp)
 						time.Sleep(500 * time.Millisecond)
-						resp := request("GET", "/pins/"+cidStr, nil)
+						resp = request("GET", "/pins/"+cidStr, nil)
 						formatResponse(c, resp)
 						return nil
 					},
@@ -260,12 +261,13 @@ although unpinning operations in the cluster may take longer or fail.
 					Name:  "ls",
 					Usage: "List tracked CIDs",
 					UsageText: `
-This command will list the CIDs which are tracked by IPFS Cluster. This
-list does not include information about tracking status or location, it
+This command will list the CIDs which are tracked by IPFS Cluster and to
+which peers they are currently allocated. This list does not include
+any monitoring information about the 
 merely represents the list of pins which are part of the global state of
 the cluster. For specific information, use "status".
 `,
-					Flags: []cli.Flag{parseFlag(formatString)},
+					Flags: []cli.Flag{parseFlag(formatCidArg)},
 					Action: func(c *cli.Context) error {
 						resp := request("GET", "/pinlist", nil)
 						formatResponse(c, resp)

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/urfave/cli"
 
 	ipfscluster "github.com/ipfs/ipfs-cluster"
+	"github.com/ipfs/ipfs-cluster/allocator/numpinalloc"
+	"github.com/ipfs/ipfs-cluster/informer/numpin"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 )
 
@@ -237,12 +239,19 @@ func run(c *cli.Context) error {
 
 	state := mapstate.NewMapState()
 	tracker := ipfscluster.NewMapPinTracker(cfg)
+	mon := ipfscluster.NewStdPeerMonitor(5)
+	informer := numpin.NewInformer()
+	alloc := numpinalloc.NewAllocator()
+
 	cluster, err := ipfscluster.NewCluster(
 		cfg,
 		api,
 		proxy,
 		state,
-		tracker)
+		tracker,
+		mon,
+		alloc,
+		informer)
 	checkErr("starting cluster", err)
 
 	signalChan := make(chan os.Signal, 20)

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/urfave/cli"
 
 	ipfscluster "github.com/ipfs/ipfs-cluster"
+	"github.com/ipfs/ipfs-cluster/state/mapstate"
 )
 
 // ProgramName of this application
@@ -234,7 +235,7 @@ func run(c *cli.Context) error {
 	proxy, err := ipfscluster.NewIPFSHTTPConnector(cfg)
 	checkErr("creating IPFS Connector component", err)
 
-	state := ipfscluster.NewMapState()
+	state := mapstate.NewMapState()
 	tracker := ipfscluster.NewMapPinTracker(cfg)
 	cluster, err := ipfscluster.NewCluster(
 		cfg,

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -214,7 +214,7 @@ func run(c *cli.Context) error {
 
 	if a := c.String("bootstrap"); a != "" {
 		if len(cfg.ClusterPeers) > 0 && !c.Bool("force") {
-			return errors.New("The configuration provides ClusterPeers. Use -f to ignore and proceed bootstrapping")
+			return errors.New("the configuration provides ClusterPeers. Use -f to ignore and proceed bootstrapping")
 		}
 		joinAddr, err := ma.NewMultiaddr(a)
 		if err != nil {

--- a/ipfs_http_connector.go
+++ b/ipfs_http_connector.go
@@ -422,10 +422,10 @@ func (ipfs *IPFSHTTPConnector) Unpin(hash *cid.Cid) error {
 	return nil
 }
 
-// PinLs performs a "pin ls" request against the configured IPFS daemon and
-// returns a map of cid strings and their status.
-func (ipfs *IPFSHTTPConnector) PinLs() (map[string]api.IPFSPinStatus, error) {
-	body, err := ipfs.get("pin/ls")
+// PinLs performs a "pin ls --type typeFilter" request against the configured
+// IPFS daemon and returns a map of cid strings and their status.
+func (ipfs *IPFSHTTPConnector) PinLs(typeFilter string) (map[string]api.IPFSPinStatus, error) {
+	body, err := ipfs.get("pin/ls?type=" + typeFilter)
 
 	// Some error talking to the daemon
 	if err != nil {

--- a/ipfs_http_connector.go
+++ b/ipfs_http_connector.go
@@ -241,7 +241,9 @@ func (ipfs *IPFSHTTPConnector) pinOpHandler(op string, w http.ResponseWriter, r 
 	err = ipfs.rpcClient.Call("",
 		"Cluster",
 		op,
-		api.CidArgSerial{arg},
+		api.CidArgSerial{
+			Cid: arg,
+		},
 		&struct{}{})
 
 	if err != nil {
@@ -270,7 +272,7 @@ func (ipfs *IPFSHTTPConnector) pinLsHandler(w http.ResponseWriter, r *http.Reque
 	pinLs := ipfsPinLsResp{}
 	pinLs.Keys = make(map[string]ipfsPinType)
 
-	var pins []string
+	var pins []api.CidArgSerial
 	err := ipfs.rpcClient.Call("",
 		"Cluster",
 		"PinList",
@@ -283,7 +285,7 @@ func (ipfs *IPFSHTTPConnector) pinLsHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	for _, pin := range pins {
-		pinLs.Keys[pin] = ipfsPinType{
+		pinLs.Keys[pin.Cid] = ipfsPinType{
 			Type: "recursive",
 		}
 	}
@@ -507,8 +509,8 @@ func (ipfs *IPFSHTTPConnector) get(path string) ([]byte, error) {
 			msg = fmt.Sprintf("IPFS unsuccessful: %d: %s",
 				resp.StatusCode, ipfsErr.Message)
 		} else {
-			msg = fmt.Sprintf("IPFS-get unsuccessful: %d: %s",
-				resp.StatusCode, body)
+			msg = fmt.Sprintf("IPFS-get '%s' unsuccessful: %d: %s",
+				path, resp.StatusCode, body)
 		}
 		logger.Warning(msg)
 		return body, errors.New(msg)

--- a/ipfs_http_connector_test.go
+++ b/ipfs_http_connector_test.go
@@ -8,27 +8,28 @@ import (
 	"testing"
 
 	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/test"
 
 	cid "github.com/ipfs/go-cid"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-func testIPFSConnectorConfig(mock *ipfsMock) *Config {
+func testIPFSConnectorConfig(mock *test.IpfsMock) *Config {
 	cfg := testingConfig()
-	addr, _ := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", mock.addr, mock.port))
+	addr, _ := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", mock.Addr, mock.Port))
 	cfg.IPFSNodeAddr = addr
 	return cfg
 }
 
-func testIPFSConnector(t *testing.T) (*IPFSHTTPConnector, *ipfsMock) {
-	mock := newIpfsMock()
+func testIPFSConnector(t *testing.T) (*IPFSHTTPConnector, *test.IpfsMock) {
+	mock := test.NewIpfsMock()
 	cfg := testIPFSConnectorConfig(mock)
 
 	ipfs, err := NewIPFSHTTPConnector(cfg)
 	if err != nil {
 		t.Fatal("creating an IPFSConnector should work: ", err)
 	}
-	ipfs.SetClient(mockRPCClient(t))
+	ipfs.SetClient(test.NewMockRPCClient(t))
 	return ipfs, mock
 }
 
@@ -45,7 +46,7 @@ func TestIPFSID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if id.ID != testPeerID {
+	if id.ID != test.TestPeerID1 {
 		t.Error("expected testPeerID")
 	}
 	if len(id.Addresses) != 1 {
@@ -68,7 +69,7 @@ func TestIPFSPin(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()
 	defer ipfs.Shutdown()
-	c, _ := cid.Decode(testCid)
+	c, _ := cid.Decode(test.TestCid1)
 	err := ipfs.Pin(c)
 	if err != nil {
 		t.Error("expected success pinning cid")
@@ -81,7 +82,7 @@ func TestIPFSPin(t *testing.T) {
 		t.Error("cid should have been pinned")
 	}
 
-	c2, _ := cid.Decode(errorCid)
+	c2, _ := cid.Decode(test.ErrorCid)
 	err = ipfs.Pin(c2)
 	if err == nil {
 		t.Error("expected error pinning cid")
@@ -92,7 +93,7 @@ func TestIPFSUnpin(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()
 	defer ipfs.Shutdown()
-	c, _ := cid.Decode(testCid)
+	c, _ := cid.Decode(test.TestCid1)
 	err := ipfs.Unpin(c)
 	if err != nil {
 		t.Error("expected success unpinning non-pinned cid")
@@ -108,8 +109,8 @@ func TestIPFSPinLsCid(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()
 	defer ipfs.Shutdown()
-	c, _ := cid.Decode(testCid)
-	c2, _ := cid.Decode(testCid2)
+	c, _ := cid.Decode(test.TestCid1)
+	c2, _ := cid.Decode(test.TestCid2)
 
 	ipfs.Pin(c)
 	ips, err := ipfs.PinLsCid(c)
@@ -127,12 +128,12 @@ func TestIPFSPinLs(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()
 	defer ipfs.Shutdown()
-	c, _ := cid.Decode(testCid)
-	c2, _ := cid.Decode(testCid2)
+	c, _ := cid.Decode(test.TestCid1)
+	c2, _ := cid.Decode(test.TestCid2)
 
 	ipfs.Pin(c)
 	ipfs.Pin(c2)
-	ipsMap, err := ipfs.PinLs()
+	ipsMap, err := ipfs.PinLs("")
 	if err != nil {
 		t.Error("should not error")
 	}
@@ -141,7 +142,7 @@ func TestIPFSPinLs(t *testing.T) {
 		t.Fatal("the map does not contain expected keys")
 	}
 
-	if !ipsMap[testCid].IsPinned() || !ipsMap[testCid2].IsPinned() {
+	if !ipsMap[test.TestCid1].IsPinned() || !ipsMap[test.TestCid2].IsPinned() {
 		t.Error("c1 and c2 should appear pinned")
 	}
 }
@@ -193,7 +194,7 @@ func TestIPFSProxyPin(t *testing.T) {
 	res, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/pin/add?arg=%s",
 		host,
 		port,
-		testCid))
+		test.TestCid1))
 	if err != nil {
 		t.Fatal("should have succeeded: ", err)
 	}
@@ -208,7 +209,7 @@ func TestIPFSProxyPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(resp.Pins) != 1 || resp.Pins[0] != testCid {
+	if len(resp.Pins) != 1 || resp.Pins[0] != test.TestCid1 {
 		t.Error("wrong response")
 	}
 	res.Body.Close()
@@ -217,7 +218,7 @@ func TestIPFSProxyPin(t *testing.T) {
 	res, err = http.Get(fmt.Sprintf("http://%s:%s/api/v0/pin/add?arg=%s",
 		host,
 		port,
-		errorCid))
+		test.ErrorCid))
 	if err != nil {
 		t.Fatal("request should work: ", err)
 	}
@@ -232,7 +233,7 @@ func TestIPFSProxyPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if respErr.Message != errBadCid.Error() {
+	if respErr.Message != test.ErrBadCid.Error() {
 		t.Error("wrong response")
 	}
 	res.Body.Close()
@@ -249,7 +250,7 @@ func TestIPFSProxyUnpin(t *testing.T) {
 	res, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/pin/rm?arg=%s",
 		host,
 		port,
-		testCid))
+		test.TestCid1))
 	if err != nil {
 		t.Fatal("should have succeeded: ", err)
 	}
@@ -265,7 +266,7 @@ func TestIPFSProxyUnpin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(resp.Pins) != 1 || resp.Pins[0] != testCid {
+	if len(resp.Pins) != 1 || resp.Pins[0] != test.TestCid1 {
 		t.Error("wrong response")
 	}
 	res.Body.Close()
@@ -274,7 +275,7 @@ func TestIPFSProxyUnpin(t *testing.T) {
 	res, err = http.Get(fmt.Sprintf("http://%s:%s/api/v0/pin/rm?arg=%s",
 		host,
 		port,
-		errorCid))
+		test.ErrorCid))
 	if err != nil {
 		t.Fatal("request should work: ", err)
 	}
@@ -289,7 +290,7 @@ func TestIPFSProxyUnpin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if respErr.Message != errBadCid.Error() {
+	if respErr.Message != test.ErrBadCid.Error() {
 		t.Error("wrong response")
 	}
 	res.Body.Close()
@@ -306,7 +307,7 @@ func TestIPFSProxyPinLs(t *testing.T) {
 	res, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/pin/ls?arg=%s",
 		host,
 		port,
-		testCid))
+		test.TestCid1))
 	if err != nil {
 		t.Fatal("should have succeeded: ", err)
 	}
@@ -322,7 +323,7 @@ func TestIPFSProxyPinLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, ok := resp.Keys[testCid]
+	_, ok := resp.Keys[test.TestCid1]
 	if len(resp.Keys) != 1 || !ok {
 		t.Error("wrong response")
 	}

--- a/ipfs_http_connector_test.go
+++ b/ipfs_http_connector_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ipfs/ipfs-cluster/api"
+
 	cid "github.com/ipfs/go-cid"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -116,7 +118,7 @@ func TestIPFSPinLsCid(t *testing.T) {
 	}
 
 	ips, err = ipfs.PinLsCid(c2)
-	if err != nil || ips != IPFSPinStatusUnpinned {
+	if err != nil || ips != api.IPFSPinStatusUnpinned {
 		t.Error("c2 should appear unpinned")
 	}
 }

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -9,105 +9,16 @@
 package ipfscluster
 
 import (
-	"time"
-
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 	cid "github.com/ipfs/go-cid"
-	crypto "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	protocol "github.com/libp2p/go-libp2p-protocol"
-	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/ipfs/ipfs-cluster/api"
 )
 
 // RPCProtocol is used to send libp2p messages between cluster peers
 var RPCProtocol = protocol.ID("/ipfscluster/" + Version + "/rpc")
-
-// TrackerStatus values
-const (
-	// IPFSStatus should never take this value
-	TrackerStatusBug = iota
-	// The cluster node is offline or not responding
-	TrackerStatusClusterError
-	// An error occurred pinning
-	TrackerStatusPinError
-	// An error occurred unpinning
-	TrackerStatusUnpinError
-	// The IPFS daemon has pinned the item
-	TrackerStatusPinned
-	// The IPFS daemon is currently pinning the item
-	TrackerStatusPinning
-	// The IPFS daemon is currently unpinning the item
-	TrackerStatusUnpinning
-	// The IPFS daemon is not pinning the item
-	TrackerStatusUnpinned
-	// The IPFS deamon is not pinning the item but it is being tracked
-	TrackerStatusRemotePin
-)
-
-// TrackerStatus represents the status of a tracked Cid in the PinTracker
-type TrackerStatus int
-
-// IPFSPinStatus values
-const (
-	IPFSPinStatusBug = iota
-	IPFSPinStatusError
-	IPFSPinStatusDirect
-	IPFSPinStatusRecursive
-	IPFSPinStatusIndirect
-	IPFSPinStatusUnpinned
-)
-
-// IPFSPinStatus represents the status of a pin in IPFS (direct, recursive etc.)
-type IPFSPinStatus int
-
-// IsPinned returns true if the status is Direct or Recursive
-func (ips IPFSPinStatus) IsPinned() bool {
-	return ips == IPFSPinStatusDirect || ips == IPFSPinStatusRecursive
-}
-
-// GlobalPinInfo contains cluster-wide status information about a tracked Cid,
-// indexed by cluster peer.
-type GlobalPinInfo struct {
-	Cid     *cid.Cid
-	PeerMap map[peer.ID]PinInfo
-}
-
-// PinInfo holds information about local pins. PinInfo is
-// serialized when requesting the Global status, therefore
-// we cannot use *cid.Cid.
-type PinInfo struct {
-	CidStr string
-	Peer   peer.ID
-	Status TrackerStatus
-	TS     time.Time
-	Error  string
-}
-
-// String converts an IPFSStatus into a readable string.
-func (st TrackerStatus) String() string {
-	switch st {
-	case TrackerStatusBug:
-		return "bug"
-	case TrackerStatusClusterError:
-		return "cluster_error"
-	case TrackerStatusPinError:
-		return "pin_error"
-	case TrackerStatusUnpinError:
-		return "unpin_error"
-	case TrackerStatusPinned:
-		return "pinned"
-	case TrackerStatusPinning:
-		return "pinning"
-	case TrackerStatusUnpinning:
-		return "unpinning"
-	case TrackerStatusUnpinned:
-		return "unpinned"
-	case TrackerStatusRemotePin:
-		return "remote"
-	default:
-		return ""
-	}
-}
 
 // Component represents a piece of ipfscluster. Cluster components
 // usually run their own goroutines (a http server for example). They
@@ -128,11 +39,11 @@ type API interface {
 // an IPFS daemon. This is a base component.
 type IPFSConnector interface {
 	Component
-	ID() (IPFSID, error)
+	ID() (api.IPFSID, error)
 	Pin(*cid.Cid) error
 	Unpin(*cid.Cid) error
-	PinLsCid(*cid.Cid) (IPFSPinStatus, error)
-	PinLs() (map[string]IPFSPinStatus, error)
+	PinLsCid(*cid.Cid) (api.IPFSPinStatus, error)
+	PinLs() (map[string]api.IPFSPinStatus, error)
 }
 
 // Peered represents a component which needs to be aware of the peers
@@ -170,154 +81,15 @@ type PinTracker interface {
 	// may perform an IPFS unpin operation.
 	Untrack(*cid.Cid) error
 	// StatusAll returns the list of pins with their local status.
-	StatusAll() []PinInfo
+	StatusAll() []api.PinInfo
 	// Status returns the local status of a given Cid.
-	Status(*cid.Cid) PinInfo
+	Status(*cid.Cid) api.PinInfo
 	// SyncAll makes sure that all tracked Cids reflect the real IPFS status.
 	// It returns the list of pins which were updated by the call.
-	SyncAll() ([]PinInfo, error)
+	SyncAll() ([]api.PinInfo, error)
 	// Sync makes sure that the Cid status reflect the real IPFS status.
 	// It returns the local status of the Cid.
-	Sync(*cid.Cid) (PinInfo, error)
+	Sync(*cid.Cid) (api.PinInfo, error)
 	// Recover retriggers a Pin/Unpin operation in Cids with error status.
-	Recover(*cid.Cid) (PinInfo, error)
-}
-
-// IPFSID is used to store information about the underlying IPFS daemon
-type IPFSID struct {
-	ID        peer.ID
-	Addresses []ma.Multiaddr
-	Error     string
-}
-
-// IPFSIDSerial is the serializable IPFSID for RPC requests
-type IPFSIDSerial struct {
-	ID        string
-	Addresses MultiaddrsSerial
-	Error     string
-}
-
-// ToSerial converts IPFSID to a go serializable object
-func (id *IPFSID) ToSerial() IPFSIDSerial {
-	return IPFSIDSerial{
-		ID:        peer.IDB58Encode(id.ID),
-		Addresses: MultiaddrsToSerial(id.Addresses),
-		Error:     id.Error,
-	}
-}
-
-// ToID converts an IPFSIDSerial to IPFSID
-// It will ignore any errors when parsing the fields.
-func (ids *IPFSIDSerial) ToID() IPFSID {
-	id := IPFSID{}
-	if pID, err := peer.IDB58Decode(ids.ID); err == nil {
-		id.ID = pID
-	}
-	id.Addresses = ids.Addresses.ToMultiaddrs()
-	id.Error = ids.Error
-	return id
-}
-
-// ID holds information about the Cluster peer
-type ID struct {
-	ID                 peer.ID
-	PublicKey          crypto.PubKey
-	Addresses          []ma.Multiaddr
-	ClusterPeers       []ma.Multiaddr
-	Version            string
-	Commit             string
-	RPCProtocolVersion protocol.ID
-	Error              string
-	IPFS               IPFSID
-}
-
-// IDSerial is the serializable ID counterpart for RPC requests
-type IDSerial struct {
-	ID                 string
-	PublicKey          []byte
-	Addresses          MultiaddrsSerial
-	ClusterPeers       MultiaddrsSerial
-	Version            string
-	Commit             string
-	RPCProtocolVersion string
-	Error              string
-	IPFS               IPFSIDSerial
-}
-
-// ToSerial converts an ID to its Go-serializable version
-func (id ID) ToSerial() IDSerial {
-	var pkey []byte
-	if id.PublicKey != nil {
-		pkey, _ = id.PublicKey.Bytes()
-	}
-
-	return IDSerial{
-		ID:                 peer.IDB58Encode(id.ID),
-		PublicKey:          pkey,
-		Addresses:          MultiaddrsToSerial(id.Addresses),
-		ClusterPeers:       MultiaddrsToSerial(id.ClusterPeers),
-		Version:            id.Version,
-		Commit:             id.Commit,
-		RPCProtocolVersion: string(id.RPCProtocolVersion),
-		Error:              id.Error,
-		IPFS:               id.IPFS.ToSerial(),
-	}
-}
-
-// ToID converts an IDSerial object to ID.
-// It will ignore any errors when parsing the fields.
-func (ids IDSerial) ToID() ID {
-	id := ID{}
-	if pID, err := peer.IDB58Decode(ids.ID); err == nil {
-		id.ID = pID
-	}
-	if pkey, err := crypto.UnmarshalPublicKey(ids.PublicKey); err == nil {
-		id.PublicKey = pkey
-	}
-
-	id.Addresses = ids.Addresses.ToMultiaddrs()
-	id.ClusterPeers = ids.ClusterPeers.ToMultiaddrs()
-	id.Version = ids.Version
-	id.Commit = ids.Commit
-	id.RPCProtocolVersion = protocol.ID(ids.RPCProtocolVersion)
-	id.Error = ids.Error
-	id.IPFS = ids.IPFS.ToID()
-	return id
-}
-
-// MultiaddrSerial is a Multiaddress in a serializable form
-type MultiaddrSerial []byte
-
-// MultiaddrsSerial is an array of Multiaddresses in serializable form
-type MultiaddrsSerial []MultiaddrSerial
-
-// MultiaddrToSerial converts a Multiaddress to its serializable form
-func MultiaddrToSerial(addr ma.Multiaddr) MultiaddrSerial {
-	return addr.Bytes()
-}
-
-// ToMultiaddr converts a serializable Multiaddress to its original type.
-// All errors are ignored.
-func (addrS MultiaddrSerial) ToMultiaddr() ma.Multiaddr {
-	a, _ := ma.NewMultiaddrBytes(addrS)
-	return a
-}
-
-// MultiaddrsToSerial converts a slice of Multiaddresses to its
-// serializable form.
-func MultiaddrsToSerial(addrs []ma.Multiaddr) MultiaddrsSerial {
-	addrsS := make([]MultiaddrSerial, len(addrs), len(addrs))
-	for i, a := range addrs {
-		addrsS[i] = MultiaddrToSerial(a)
-	}
-	return addrsS
-}
-
-// ToMultiaddrs converts MultiaddrsSerial back to a slice of Multiaddresses
-func (addrsS MultiaddrsSerial) ToMultiaddrs() []ma.Multiaddr {
-	addrs := make([]ma.Multiaddr, len(addrsS), len(addrsS))
-	for i, addrS := range addrsS {
-		addrs[i] = addrS.ToMultiaddr()
-	}
-	return addrs
+	Recover(*cid.Cid) (api.PinInfo, error)
 }

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -43,7 +43,7 @@ type IPFSConnector interface {
 	Pin(*cid.Cid) error
 	Unpin(*cid.Cid) error
 	PinLsCid(*cid.Cid) (api.IPFSPinStatus, error)
-	PinLs() (map[string]api.IPFSPinStatus, error)
+	PinLs(typeFilter string) (map[string]api.IPFSPinStatus, error)
 }
 
 // Peered represents a component which needs to be aware of the peers

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/ipfs-cluster/api"
+
 	cid "github.com/ipfs/go-cid"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -222,8 +224,8 @@ func TestClustersPeers(t *testing.T) {
 		t.Fatal("expected as many peers as clusters")
 	}
 
-	clusterIDMap := make(map[peer.ID]ID)
-	peerIDMap := make(map[peer.ID]ID)
+	clusterIDMap := make(map[peer.ID]api.ID)
+	peerIDMap := make(map[peer.ID]api.ID)
 
 	for _, c := range clusters {
 		id := c.ID()
@@ -239,9 +241,9 @@ func TestClustersPeers(t *testing.T) {
 		if !ok {
 			t.Fatal("expected id in both maps")
 		}
-		if !crypto.KeyEqual(id.PublicKey, id2.PublicKey) {
-			t.Error("expected same public key")
-		}
+		//if !crypto.KeyEqual(id.PublicKey, id2.PublicKey) {
+		//	t.Error("expected same public key")
+		//}
 		if id.IPFS.ID != id2.IPFS.ID {
 			t.Error("expected same ipfs daemon ID")
 		}
@@ -271,9 +273,9 @@ func TestClustersPin(t *testing.T) {
 	fpinned := func(t *testing.T, c *Cluster) {
 		status := c.tracker.StatusAll()
 		for _, v := range status {
-			if v.Status != TrackerStatusPinned {
+			if v.Status != api.TrackerStatusPinned {
 				t.Errorf("%s should have been pinned but it is %s",
-					v.CidStr,
+					v.Cid,
 					v.Status.String())
 			}
 		}
@@ -334,7 +336,7 @@ func TestClustersStatusAll(t *testing.T) {
 			t.Error("bad info in status")
 		}
 
-		if info[c.host.ID()].Status != TrackerStatusPinned {
+		if info[c.host.ID()].Status != api.TrackerStatusPinned {
 			t.Error("the hash should have been pinned")
 		}
 
@@ -348,7 +350,7 @@ func TestClustersStatusAll(t *testing.T) {
 			t.Fatal("Host not in status")
 		}
 
-		if pinfo.Status != TrackerStatusPinned {
+		if pinfo.Status != api.TrackerStatusPinned {
 			t.Error("the status should show the hash as pinned")
 		}
 	}
@@ -375,7 +377,7 @@ func TestClustersSyncAllLocal(t *testing.T) {
 			t.Fatal("expected 1 elem slice")
 		}
 		// Last-known state may still be pinning
-		if infos[0].Status != TrackerStatusPinError && infos[0].Status != TrackerStatusPinning {
+		if infos[0].Status != api.TrackerStatusPinError && infos[0].Status != api.TrackerStatusPinning {
 			t.Error("element should be in Pinning or PinError state")
 		}
 	}
@@ -397,7 +399,7 @@ func TestClustersSyncLocal(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if info.Status != TrackerStatusPinError && info.Status != TrackerStatusPinning {
+		if info.Status != api.TrackerStatusPinError && info.Status != api.TrackerStatusPinning {
 			t.Errorf("element is %s and not PinError", info.Status)
 		}
 
@@ -406,7 +408,7 @@ func TestClustersSyncLocal(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if info.Status != TrackerStatusPinned {
+		if info.Status != api.TrackerStatusPinned {
 			t.Error("element should be in Pinned state")
 		}
 	}
@@ -439,7 +441,7 @@ func TestClustersSyncAll(t *testing.T) {
 		if !ok {
 			t.Fatal("GlobalPinInfo should have this cluster")
 		}
-		if inf.Status != TrackerStatusPinError && inf.Status != TrackerStatusPinning {
+		if inf.Status != api.TrackerStatusPinError && inf.Status != api.TrackerStatusPinning {
 			t.Error("should be PinError in all peers")
 		}
 	}
@@ -480,7 +482,7 @@ func TestClustersSync(t *testing.T) {
 			t.Fatal("GlobalPinInfo should not be empty for this host")
 		}
 
-		if inf.Status != TrackerStatusPinError && inf.Status != TrackerStatusPinning {
+		if inf.Status != api.TrackerStatusPinError && inf.Status != api.TrackerStatusPinning {
 			t.Error("should be PinError or Pinning in all peers")
 		}
 	}
@@ -500,7 +502,7 @@ func TestClustersSync(t *testing.T) {
 		if !ok {
 			t.Fatal("GlobalPinInfo should have this cluster")
 		}
-		if inf.Status != TrackerStatusPinned {
+		if inf.Status != api.TrackerStatusPinned {
 			t.Error("the GlobalPinInfo should show Pinned in all peers")
 		}
 	}
@@ -521,7 +523,7 @@ func TestClustersRecoverLocal(t *testing.T) {
 		if err == nil {
 			t.Error("expected an error recovering")
 		}
-		if info.Status != TrackerStatusPinError {
+		if info.Status != api.TrackerStatusPinError {
 			t.Errorf("element is %s and not PinError", info.Status)
 		}
 
@@ -530,7 +532,7 @@ func TestClustersRecoverLocal(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if info.Status != TrackerStatusPinned {
+		if info.Status != api.TrackerStatusPinned {
 			t.Error("element should be in Pinned state")
 		}
 	}
@@ -566,11 +568,11 @@ func TestClustersRecover(t *testing.T) {
 	for _, c := range clusters {
 		inf, ok := ginfo.PeerMap[c.host.ID()]
 		if !ok {
-			t.Logf("%+v", ginfo)
 			t.Fatal("GlobalPinInfo should not be empty for this host")
 		}
 
-		if inf.Status != TrackerStatusPinError {
+		if inf.Status != api.TrackerStatusPinError {
+			t.Logf("%+v", inf)
 			t.Error("should be PinError in all peers")
 		}
 	}
@@ -590,7 +592,7 @@ func TestClustersRecover(t *testing.T) {
 		if !ok {
 			t.Fatal("GlobalPinInfo should have this cluster")
 		}
-		if inf.Status != TrackerStatusPinned {
+		if inf.Status != api.TrackerStatusPinned {
 			t.Error("the GlobalPinInfo should show Pinned in all peers")
 		}
 	}

--- a/log_op.go
+++ b/log_op.go
@@ -1,0 +1,109 @@
+package ipfscluster
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ipfs/ipfs-cluster/api"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	consensus "github.com/libp2p/go-libp2p-consensus"
+	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// Type of consensus operation
+const (
+	LogOpPin = iota + 1
+	LogOpUnpin
+	LogOpAddPeer
+	LogOpRmPeer
+)
+
+// LogOpType expresses the type of a consensus Operation
+type LogOpType int
+
+// LogOp represents an operation for the OpLogConsensus system.
+// It implements the consensus.Op interface and it is used by the
+// Consensus component.
+type LogOp struct {
+	Cid       api.CidArgSerial
+	Peer      api.MultiaddrSerial
+	Type      LogOpType
+	ctx       context.Context
+	rpcClient *rpc.Client
+}
+
+// ApplyTo applies the operation to the State
+func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
+	state, ok := cstate.(State)
+	var err error
+	if !ok {
+		// Should never be here
+		panic("received unexpected state type")
+	}
+
+	switch op.Type {
+	case LogOpPin:
+		arg := op.Cid.ToCidArg()
+		err = state.Add(arg)
+		if err != nil {
+			goto ROLLBACK
+		}
+		// Async, we let the PinTracker take care of any problems
+		op.rpcClient.Go("",
+			"Cluster",
+			"Track",
+			arg.ToSerial(),
+			&struct{}{},
+			nil)
+	case LogOpUnpin:
+		arg := op.Cid.ToCidArg()
+		err = state.Rm(arg.Cid)
+		if err != nil {
+			goto ROLLBACK
+		}
+		// Async, we let the PinTracker take care of any problems
+		op.rpcClient.Go("",
+			"Cluster",
+			"Untrack",
+			arg.ToSerial(),
+			&struct{}{},
+			nil)
+	case LogOpAddPeer:
+		addr := op.Peer.ToMultiaddr()
+		op.rpcClient.Call("",
+			"Cluster",
+			"PeerManagerAddPeer",
+			api.MultiaddrToSerial(addr),
+			&struct{}{})
+		// TODO rebalance ops
+	case LogOpRmPeer:
+		addr := op.Peer.ToMultiaddr()
+		pidstr, err := addr.ValueForProtocol(ma.P_IPFS)
+		if err != nil {
+			panic("peer badly encoded")
+		}
+		pid, err := peer.IDB58Decode(pidstr)
+		if err != nil {
+			panic("could not decode a PID we ourselves encoded")
+		}
+		op.rpcClient.Call("",
+			"Cluster",
+			"PeerManagerRmPeer",
+			pid,
+			&struct{}{})
+		// TODO rebalance ops
+	default:
+		logger.Error("unknown LogOp type. Ignoring")
+	}
+	return state, nil
+
+ROLLBACK:
+	// We failed to apply the operation to the state
+	// and therefore we need to request a rollback to the
+	// cluster to the previous state. This operation can only be performed
+	// by the cluster leader.
+	logger.Error("Rollbacks are not implemented")
+	return nil, errors.New("a rollback may be necessary. Reason: " + err.Error())
+}

--- a/log_op_test.go
+++ b/log_op_test.go
@@ -1,0 +1,82 @@
+package ipfscluster
+
+import (
+	"context"
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+
+	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/state/mapstate"
+	"github.com/ipfs/ipfs-cluster/test"
+)
+
+func TestApplyToPin(t *testing.T) {
+	op := &LogOp{
+		Cid:       api.CidArgSerial{Cid: test.TestCid1},
+		Type:      LogOpPin,
+		ctx:       context.Background(),
+		rpcClient: test.NewMockRPCClient(t),
+	}
+
+	st := mapstate.NewMapState()
+	op.ApplyTo(st)
+	pins := st.List()
+	if len(pins) != 1 || pins[0].Cid.String() != test.TestCid1 {
+		t.Error("the state was not modified correctly")
+	}
+}
+
+func TestApplyToUnpin(t *testing.T) {
+	op := &LogOp{
+		Cid:       api.CidArgSerial{Cid: test.TestCid1},
+		Type:      LogOpUnpin,
+		ctx:       context.Background(),
+		rpcClient: test.NewMockRPCClient(t),
+	}
+
+	st := mapstate.NewMapState()
+	c, _ := cid.Decode(test.TestCid1)
+	st.Add(api.CidArg{Cid: c, Everywhere: true})
+	op.ApplyTo(st)
+	pins := st.List()
+	if len(pins) != 0 {
+		t.Error("the state was not modified correctly")
+	}
+}
+
+func TestApplyToBadState(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("should have recovered an error")
+		}
+	}()
+
+	op := &LogOp{
+		Cid:       api.CidArgSerial{Cid: test.TestCid1},
+		Type:      LogOpUnpin,
+		ctx:       context.Background(),
+		rpcClient: test.NewMockRPCClient(t),
+	}
+
+	var st interface{}
+	op.ApplyTo(st)
+}
+
+// func TestApplyToBadCid(t *testing.T) {
+// 	defer func() {
+// 		if r := recover(); r == nil {
+// 			t.Error("should have recovered an error")
+// 		}
+// 	}()
+
+// 	op := &LogOp{
+// 		Cid:       api.CidArgSerial{Cid: "agadfaegf"},
+// 		Type:      LogOpPin,
+// 		ctx:       context.Background(),
+// 		rpcClient: test.NewMockRPCClient(t),
+// 	}
+
+// 	st := mapstate.NewMapState()
+// 	op.ApplyTo(st)
+// }

--- a/map_pin_tracker.go
+++ b/map_pin_tracker.go
@@ -261,7 +261,7 @@ func (mpt *MapPinTracker) SyncAll() ([]api.PinInfo, error) {
 	err := mpt.rpcClient.Call("",
 		"Cluster",
 		"IPFSPinLs",
-		struct{}{},
+		"recursive",
 		&ipsMap)
 	if err != nil {
 		mpt.mux.Lock()

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -229,7 +229,7 @@ func TestClustersPeerJoin(t *testing.T) {
 			t.Error("all peers should be connected")
 		}
 		pins := c.Pins()
-		if len(pins) != 1 || !pins[0].Equals(hash) {
+		if len(pins) != 1 || !pins[0].Cid.Equals(hash) {
 			t.Error("all peers should have pinned the cid")
 		}
 	}
@@ -262,7 +262,7 @@ func TestClustersPeerJoinAllAtOnce(t *testing.T) {
 			t.Error("all peers should be connected")
 		}
 		pins := c.Pins()
-		if len(pins) != 1 || !pins[0].Equals(hash) {
+		if len(pins) != 1 || !pins[0].Cid.Equals(hash) {
 			t.Error("all peers should have pinned the cid")
 		}
 	}
@@ -304,7 +304,7 @@ func TestClustersPeerJoinAllAtOnceWithRandomBootstrap(t *testing.T) {
 			t.Error("all peers should be connected")
 		}
 		pins := c.Pins()
-		if len(pins) != 1 || !pins[0].Equals(hash) {
+		if len(pins) != 1 || !pins[0].Cid.Equals(hash) {
 			t.Error("all peers should have pinned the cid")
 		}
 	}

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/ipfs-cluster/test"
+
 	cid "github.com/ipfs/go-cid"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-func peerManagerClusters(t *testing.T) ([]*Cluster, []*ipfsMock) {
+func peerManagerClusters(t *testing.T) ([]*Cluster, []*test.IpfsMock) {
 	cls := make([]*Cluster, nClusters, nClusters)
-	mocks := make([]*ipfsMock, nClusters, nClusters)
+	mocks := make([]*test.IpfsMock, nClusters, nClusters)
 	var wg sync.WaitGroup
 	for i := 0; i < nClusters; i++ {
 		wg.Add(1)
@@ -53,7 +55,7 @@ func TestClustersPeerAdd(t *testing.T) {
 		}
 	}
 
-	h, _ := cid.Decode(testCid)
+	h, _ := cid.Decode(test.TestCid1)
 	err := clusters[1].Pin(h)
 	if err != nil {
 		t.Fatal(err)
@@ -217,7 +219,7 @@ func TestClustersPeerJoin(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	hash, _ := cid.Decode(testCid)
+	hash, _ := cid.Decode(test.TestCid1)
 	clusters[0].Pin(hash)
 	delay()
 
@@ -250,7 +252,7 @@ func TestClustersPeerJoinAllAtOnce(t *testing.T) {
 	}
 	runF(t, clusters[1:], f)
 
-	hash, _ := cid.Decode(testCid)
+	hash, _ := cid.Decode(test.TestCid1)
 	clusters[0].Pin(hash)
 	delay()
 
@@ -292,7 +294,7 @@ func TestClustersPeerJoinAllAtOnceWithRandomBootstrap(t *testing.T) {
 	}
 	runF(t, clusters[2:], f)
 
-	hash, _ := cid.Decode(testCid)
+	hash, _ := cid.Decode(test.TestCid1)
 	clusters[0].Pin(hash)
 	delay()
 

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -160,6 +160,8 @@ func TestClustersPeerRemove(t *testing.T) {
 		t.Error(err)
 	}
 
+	delay()
+
 	f := func(t *testing.T, c *Cluster) {
 		if c.ID().ID == p { //This is the removed cluster
 			_, ok := <-c.Done()

--- a/peer_monitor.go
+++ b/peer_monitor.go
@@ -1,0 +1,220 @@
+package ipfscluster
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	peer "github.com/libp2p/go-libp2p-peer"
+
+	"github.com/ipfs/ipfs-cluster/api"
+)
+
+// AlertChannelCap specifies how much buffer the alerts channel has.
+var AlertChannelCap = 256
+
+// peerMetrics is just a circular queue
+type peerMetrics struct {
+	last   int
+	window []api.Metric
+	//	mux    sync.RWMutex
+}
+
+func newPeerMetrics(windowCap int) *peerMetrics {
+	w := make([]api.Metric, 0, windowCap)
+	return &peerMetrics{0, w}
+}
+
+func (pmets *peerMetrics) add(m api.Metric) {
+	//	pmets.mux.Lock()
+	//	defer pmets.mux.Unlock()
+	if len(pmets.window) < cap(pmets.window) {
+		pmets.window = append(pmets.window, m)
+		pmets.last = len(pmets.window) - 1
+		return
+	}
+
+	// len == cap
+	pmets.last = (pmets.last + 1) % cap(pmets.window)
+	pmets.window[pmets.last] = m
+	return
+}
+
+func (pmets *peerMetrics) latest() (api.Metric, error) {
+	//	pmets.mux.RLock()
+	//	defer pmets.mux.RUnlock()
+	if len(pmets.window) == 0 {
+		return api.Metric{}, errors.New("no metrics")
+	}
+	return pmets.window[pmets.last], nil
+}
+
+// ordered from newest to oldest
+func (pmets *peerMetrics) all() []api.Metric {
+	//	pmets.mux.RLock()
+	//	pmets.mux.RUnlock()
+	wlen := len(pmets.window)
+	res := make([]api.Metric, 0, wlen)
+	if wlen == 0 {
+		return res
+	}
+	for i := pmets.last; i >= 0; i-- {
+		res = append(res, pmets.window[i])
+	}
+	for i := wlen; i > pmets.last; i-- {
+		res = append(res, pmets.window[i])
+	}
+	return res
+}
+
+type metricsByPeer map[peer.ID]*peerMetrics
+
+// StdPeerMonitor is a component in charge of monitoring peers, logging
+// metrics and detecting failures
+type StdPeerMonitor struct {
+	ctx       context.Context
+	cancel    func()
+	rpcClient *rpc.Client
+	rpcReady  chan struct{}
+
+	metrics    map[string]metricsByPeer
+	metricsMux sync.RWMutex
+	windowCap  int
+
+	alerts chan api.Alert
+
+	shutdownLock sync.Mutex
+	shutdown     bool
+	wg           sync.WaitGroup
+}
+
+// NewStdPeerMonitor creates a new monitor.
+func NewStdPeerMonitor(windowCap int) *StdPeerMonitor {
+	if windowCap <= 0 {
+		panic("windowCap too small")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mon := &StdPeerMonitor{
+		ctx:      ctx,
+		cancel:   cancel,
+		rpcReady: make(chan struct{}, 1),
+
+		metrics:   make(map[string]metricsByPeer),
+		windowCap: windowCap,
+		alerts:    make(chan api.Alert),
+	}
+
+	go mon.run()
+	return mon
+}
+
+func (mon *StdPeerMonitor) run() {
+	select {
+	case <-mon.rpcReady:
+		//go mon.Heartbeat()
+	case <-mon.ctx.Done():
+	}
+}
+
+// SetClient saves the given rpc.Client  for later use
+func (mon *StdPeerMonitor) SetClient(c *rpc.Client) {
+	mon.rpcClient = c
+	mon.rpcReady <- struct{}{}
+}
+
+// Shutdown stops the peer monitor. It particular, it will
+// not deliver any alerts.
+func (mon *StdPeerMonitor) Shutdown() error {
+	mon.shutdownLock.Lock()
+	defer mon.shutdownLock.Unlock()
+
+	if mon.shutdown {
+		logger.Warning("StdPeerMonitor already shut down")
+		return nil
+	}
+
+	logger.Info("stopping StdPeerMonitor")
+	close(mon.rpcReady)
+	mon.cancel()
+	mon.wg.Wait()
+	mon.shutdown = true
+	return nil
+}
+
+// LogMetric stores a metric so it can later be retrieved.
+func (mon *StdPeerMonitor) LogMetric(m api.Metric) {
+	mon.metricsMux.Lock()
+	defer mon.metricsMux.Unlock()
+	name := m.Name
+	peer := m.Peer
+	mbyp, ok := mon.metrics[name]
+	if !ok {
+		mbyp = make(metricsByPeer)
+		mon.metrics[name] = mbyp
+	}
+	pmets, ok := mbyp[peer]
+	if !ok {
+		pmets = newPeerMetrics(mon.windowCap)
+		mbyp[peer] = pmets
+	}
+
+	logger.Debugf("logged '%s' metric from '%s'", name, peer)
+	pmets.add(m)
+}
+
+// func (mon *StdPeerMonitor) getLastMetric(name string, p peer.ID) api.Metric {
+// 	mon.metricsMux.RLock()
+// 	defer mon.metricsMux.RUnlock()
+
+// 	emptyMetric := api.Metric{
+// 		Name:  name,
+// 		Peer:  p,
+// 		Valid: false,
+// 	}
+
+// 	mbyp, ok := mon.metrics[name]
+// 	if !ok {
+// 		return emptyMetric
+// 	}
+
+// 	pmets, ok := mbyp[p]
+// 	if !ok {
+// 		return emptyMetric
+// 	}
+// 	metric, err := pmets.latest()
+// 	if err != nil {
+// 		return emptyMetric
+// 	}
+// 	return metric
+// }
+
+// LastMetrics returns last known VALID metrics of a given type
+func (mon *StdPeerMonitor) LastMetrics(name string) []api.Metric {
+	mon.metricsMux.RLock()
+	defer mon.metricsMux.RUnlock()
+
+	mbyp, ok := mon.metrics[name]
+	if !ok {
+		return []api.Metric{}
+	}
+
+	metrics := make([]api.Metric, 0, len(mbyp))
+
+	for _, peerMetrics := range mbyp {
+		last, err := peerMetrics.latest()
+		if err != nil || last.Discard() {
+			continue
+		}
+		metrics = append(metrics, last)
+	}
+	return metrics
+}
+
+// Alerts() returns a channel on which alerts are sent when the
+// monitor detects a failure.
+func (mon *StdPeerMonitor) Alerts() <-chan api.Alert {
+	return mon.alerts
+}

--- a/peer_monitor_test.go
+++ b/peer_monitor_test.go
@@ -1,0 +1,100 @@
+package ipfscluster
+
+import (
+	"fmt"
+	"testing"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+
+	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/test"
+)
+
+var metricCounter = 0
+
+func testPeerMonitor(t *testing.T) *StdPeerMonitor {
+	mock := test.NewMockRPCClient(t)
+	mon := NewStdPeerMonitor(2)
+	mon.SetClient(mock)
+	return mon
+}
+
+func newMetric(n string, p peer.ID) api.Metric {
+	m := api.Metric{
+		Name:  n,
+		Peer:  p,
+		Value: fmt.Sprintf("%d", metricCounter),
+		Valid: true,
+	}
+	m.SetTTL(5)
+	metricCounter++
+	return m
+}
+
+func TestPeerMonitorShutdown(t *testing.T) {
+	pm := testPeerMonitor(t)
+	err := pm.Shutdown()
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = pm.Shutdown()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestPeerMonitorLogMetric(t *testing.T) {
+	pm := testPeerMonitor(t)
+	defer pm.Shutdown()
+	metricCounter = 0
+
+	// dont fill window
+	pm.LogMetric(newMetric("test", test.TestPeerID1))
+	pm.LogMetric(newMetric("test", test.TestPeerID2))
+	pm.LogMetric(newMetric("test", test.TestPeerID3))
+
+	// fill window
+	pm.LogMetric(newMetric("test2", test.TestPeerID3))
+	pm.LogMetric(newMetric("test2", test.TestPeerID3))
+	pm.LogMetric(newMetric("test2", test.TestPeerID3))
+	pm.LogMetric(newMetric("test2", test.TestPeerID3))
+
+	lastMetrics := pm.LastMetrics("testbad")
+	if len(lastMetrics) != 0 {
+		t.Logf("%+v", lastMetrics)
+		t.Error("metrics should be empty")
+	}
+
+	lastMetrics = pm.LastMetrics("test")
+	if len(lastMetrics) != 3 {
+		t.Error("metrics should correspond to 3 hosts")
+	}
+
+	for _, v := range lastMetrics {
+		switch v.Peer {
+		case test.TestPeerID1:
+			if v.Value != "0" {
+				t.Error("bad metric value")
+			}
+		case test.TestPeerID2:
+			if v.Value != "1" {
+				t.Error("bad metric value")
+			}
+		case test.TestPeerID3:
+			if v.Value != "2" {
+				t.Error("bad metric value")
+			}
+		default:
+			t.Error("bad peer")
+		}
+	}
+
+	lastMetrics = pm.LastMetrics("test2")
+	if len(lastMetrics) != 1 {
+		t.Fatal("should only be one metric")
+	}
+	if lastMetrics[0].Value != fmt.Sprintf("%d", metricCounter-1) {
+		t.Error("metric is not last")
+	}
+}

--- a/rest_api.go
+++ b/rest_api.go
@@ -2,7 +2,6 @@ package ipfscluster
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ipfs/ipfs-cluster/api"
 
 	mux "github.com/gorilla/mux"
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
@@ -69,90 +70,6 @@ func (e errorResp) Error() string {
 	return e.Message
 }
 
-type versionResp struct {
-	Version string `json:"version"`
-}
-
-type pinResp struct {
-	Pinned string `json:"pinned"`
-}
-
-type unpinResp struct {
-	Unpinned string `json:"unpinned"`
-}
-
-type statusInfo struct {
-	Status string `json:"status"`
-	Error  string `json:"error,omitempty"`
-}
-
-type statusCidResp struct {
-	Cid     string                `json:"cid"`
-	PeerMap map[string]statusInfo `json:"peer_map"`
-}
-
-type restIPFSIDResp struct {
-	ID        string   `json:"id"`
-	Addresses []string `json:"addresses"`
-	Error     string   `json:"error,omitempty"`
-}
-
-func newRestIPFSIDResp(id IPFSID) *restIPFSIDResp {
-	addrs := make([]string, len(id.Addresses), len(id.Addresses))
-	for i, a := range id.Addresses {
-		addrs[i] = a.String()
-	}
-
-	return &restIPFSIDResp{
-		ID:        id.ID.Pretty(),
-		Addresses: addrs,
-		Error:     id.Error,
-	}
-}
-
-type restIDResp struct {
-	ID                 string          `json:"id"`
-	PublicKey          string          `json:"public_key"`
-	Addresses          []string        `json:"addresses"`
-	ClusterPeers       []string        `json:"cluster_peers"`
-	Version            string          `json:"version"`
-	Commit             string          `json:"commit"`
-	RPCProtocolVersion string          `json:"rpc_protocol_version"`
-	Error              string          `json:"error,omitempty"`
-	IPFS               *restIPFSIDResp `json:"ipfs"`
-}
-
-func newRestIDResp(id ID) *restIDResp {
-	pubKey := ""
-	if id.PublicKey != nil {
-		keyBytes, err := id.PublicKey.Bytes()
-		if err == nil {
-			pubKey = base64.StdEncoding.EncodeToString(keyBytes)
-		}
-	}
-	addrs := make([]string, len(id.Addresses), len(id.Addresses))
-	for i, a := range id.Addresses {
-		addrs[i] = a.String()
-	}
-	peers := make([]string, len(id.ClusterPeers), len(id.ClusterPeers))
-	for i, a := range id.ClusterPeers {
-		peers[i] = a.String()
-	}
-	return &restIDResp{
-		ID:                 id.ID.Pretty(),
-		PublicKey:          pubKey,
-		Addresses:          addrs,
-		ClusterPeers:       peers,
-		Version:            id.Version,
-		Commit:             id.Commit,
-		RPCProtocolVersion: string(id.RPCProtocolVersion),
-		Error:              id.Error,
-		IPFS:               newRestIPFSIDResp(id.IPFS),
-	}
-}
-
-type statusResp []statusCidResp
-
 // NewRESTAPI creates a new object which is ready to be
 // started.
 func NewRESTAPI(cfg *Config) (*RESTAPI, error) {
@@ -209,105 +126,105 @@ func NewRESTAPI(cfg *Config) (*RESTAPI, error) {
 	return api, nil
 }
 
-func (api *RESTAPI) routes() []route {
+func (rest *RESTAPI) routes() []route {
 	return []route{
 		{
 			"ID",
 			"GET",
 			"/id",
-			api.idHandler,
+			rest.idHandler,
 		},
 
 		{
 			"Version",
 			"GET",
 			"/version",
-			api.versionHandler,
+			rest.versionHandler,
 		},
 
 		{
 			"Peers",
 			"GET",
 			"/peers",
-			api.peerListHandler,
+			rest.peerListHandler,
 		},
 		{
 			"PeerAdd",
 			"POST",
 			"/peers",
-			api.peerAddHandler,
+			rest.peerAddHandler,
 		},
 		{
 			"PeerRemove",
 			"DELETE",
 			"/peers/{peer}",
-			api.peerRemoveHandler,
+			rest.peerRemoveHandler,
 		},
 
 		{
 			"Pins",
 			"GET",
 			"/pinlist",
-			api.pinListHandler,
+			rest.pinListHandler,
 		},
 
 		{
 			"StatusAll",
 			"GET",
 			"/pins",
-			api.statusAllHandler,
+			rest.statusAllHandler,
 		},
 		{
 			"SyncAll",
 			"POST",
 			"/pins/sync",
-			api.syncAllHandler,
+			rest.syncAllHandler,
 		},
 		{
 			"Status",
 			"GET",
 			"/pins/{hash}",
-			api.statusHandler,
+			rest.statusHandler,
 		},
 		{
 			"Pin",
 			"POST",
 			"/pins/{hash}",
-			api.pinHandler,
+			rest.pinHandler,
 		},
 		{
 			"Unpin",
 			"DELETE",
 			"/pins/{hash}",
-			api.unpinHandler,
+			rest.unpinHandler,
 		},
 		{
 			"Sync",
 			"POST",
 			"/pins/{hash}/sync",
-			api.syncHandler,
+			rest.syncHandler,
 		},
 		{
 			"Recover",
 			"POST",
 			"/pins/{hash}/recover",
-			api.recoverHandler,
+			rest.recoverHandler,
 		},
 	}
 }
 
-func (api *RESTAPI) run() {
-	api.wg.Add(1)
+func (rest *RESTAPI) run() {
+	rest.wg.Add(1)
 	go func() {
-		defer api.wg.Done()
+		defer rest.wg.Done()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		api.ctx = ctx
+		rest.ctx = ctx
 
-		<-api.rpcReady
+		<-rest.rpcReady
 
-		logger.Infof("REST API: %s", api.apiAddr)
-		err := api.server.Serve(api.listener)
+		logger.Infof("REST API: %s", rest.apiAddr)
+		err := rest.server.Serve(rest.listener)
 		if err != nil && !strings.Contains(err.Error(), "closed network connection") {
 			logger.Error(err)
 		}
@@ -315,79 +232,68 @@ func (api *RESTAPI) run() {
 }
 
 // Shutdown stops any API listeners.
-func (api *RESTAPI) Shutdown() error {
-	api.shutdownLock.Lock()
-	defer api.shutdownLock.Unlock()
+func (rest *RESTAPI) Shutdown() error {
+	rest.shutdownLock.Lock()
+	defer rest.shutdownLock.Unlock()
 
-	if api.shutdown {
+	if rest.shutdown {
 		logger.Debug("already shutdown")
 		return nil
 	}
 
 	logger.Info("stopping Cluster API")
 
-	close(api.rpcReady)
+	close(rest.rpcReady)
 	// Cancel any outstanding ops
-	api.server.SetKeepAlivesEnabled(false)
-	api.listener.Close()
+	rest.server.SetKeepAlivesEnabled(false)
+	rest.listener.Close()
 
-	api.wg.Wait()
-	api.shutdown = true
+	rest.wg.Wait()
+	rest.shutdown = true
 	return nil
 }
 
 // SetClient makes the component ready to perform RPC
 // requests.
-func (api *RESTAPI) SetClient(c *rpc.Client) {
-	api.rpcClient = c
-	api.rpcReady <- struct{}{}
+func (rest *RESTAPI) SetClient(c *rpc.Client) {
+	rest.rpcClient = c
+	rest.rpcReady <- struct{}{}
 }
 
-func (api *RESTAPI) idHandler(w http.ResponseWriter, r *http.Request) {
-	idSerial := IDSerial{}
-	err := api.rpcClient.Call("",
+func (rest *RESTAPI) idHandler(w http.ResponseWriter, r *http.Request) {
+	idSerial := api.IDSerial{}
+	err := rest.rpcClient.Call("",
 		"Cluster",
 		"ID",
 		struct{}{},
 		&idSerial)
-	if checkRPCErr(w, err) {
-		resp := newRestIDResp(idSerial.ToID())
-		sendJSONResponse(w, 200, resp)
-	}
+
+	sendResponse(w, err, idSerial)
 }
 
-func (api *RESTAPI) versionHandler(w http.ResponseWriter, r *http.Request) {
-	var v string
-	err := api.rpcClient.Call("",
+func (rest *RESTAPI) versionHandler(w http.ResponseWriter, r *http.Request) {
+	var v api.Version
+	err := rest.rpcClient.Call("",
 		"Cluster",
 		"Version",
 		struct{}{},
 		&v)
 
-	if checkRPCErr(w, err) {
-		sendJSONResponse(w, 200, versionResp{v})
-	}
+	sendResponse(w, err, v)
 }
 
-func (api *RESTAPI) peerListHandler(w http.ResponseWriter, r *http.Request) {
-	var peersSerial []IDSerial
-	err := api.rpcClient.Call("",
+func (rest *RESTAPI) peerListHandler(w http.ResponseWriter, r *http.Request) {
+	var peersSerial []api.IDSerial
+	err := rest.rpcClient.Call("",
 		"Cluster",
 		"Peers",
 		struct{}{},
 		&peersSerial)
 
-	if checkRPCErr(w, err) {
-		var resp []*restIDResp
-		for _, pS := range peersSerial {
-			p := pS.ToID()
-			resp = append(resp, newRestIDResp(p))
-		}
-		sendJSONResponse(w, 200, resp)
-	}
+	sendResponse(w, err, peersSerial)
 }
 
-func (api *RESTAPI) peerAddHandler(w http.ResponseWriter, r *http.Request) {
+func (rest *RESTAPI) peerAddHandler(w http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
 	defer r.Body.Close()
 
@@ -404,145 +310,123 @@ func (api *RESTAPI) peerAddHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var ids IDSerial
-	err = api.rpcClient.Call("",
+	var ids api.IDSerial
+	err = rest.rpcClient.Call("",
 		"Cluster",
 		"PeerAdd",
-		MultiaddrToSerial(mAddr),
+		api.MultiaddrToSerial(mAddr),
 		&ids)
-	if checkRPCErr(w, err) {
-		resp := newRestIDResp(ids.ToID())
-		sendJSONResponse(w, 200, resp)
-	}
+	sendResponse(w, err, ids)
 }
 
-func (api *RESTAPI) peerRemoveHandler(w http.ResponseWriter, r *http.Request) {
+func (rest *RESTAPI) peerRemoveHandler(w http.ResponseWriter, r *http.Request) {
 	if p := parsePidOrError(w, r); p != "" {
-		err := api.rpcClient.Call("",
+		err := rest.rpcClient.Call("",
 			"Cluster",
 			"PeerRemove",
 			p,
 			&struct{}{})
-		if checkRPCErr(w, err) {
-			sendEmptyResponse(w)
-		}
+		sendEmptyResponse(w, err)
 	}
 }
 
-func (api *RESTAPI) pinHandler(w http.ResponseWriter, r *http.Request) {
-	if c := parseCidOrError(w, r); c != nil {
-		err := api.rpcClient.Call("",
+func (rest *RESTAPI) pinHandler(w http.ResponseWriter, r *http.Request) {
+	if c := parseCidOrError(w, r); c.Cid != "" {
+		err := rest.rpcClient.Call("",
 			"Cluster",
 			"Pin",
 			c,
 			&struct{}{})
-		if checkRPCErr(w, err) {
-			sendAcceptedResponse(w)
-		}
+		sendAcceptedResponse(w, err)
 	}
 }
 
-func (api *RESTAPI) unpinHandler(w http.ResponseWriter, r *http.Request) {
-	if c := parseCidOrError(w, r); c != nil {
-		err := api.rpcClient.Call("",
+func (rest *RESTAPI) unpinHandler(w http.ResponseWriter, r *http.Request) {
+	if c := parseCidOrError(w, r); c.Cid != "" {
+		err := rest.rpcClient.Call("",
 			"Cluster",
 			"Unpin",
 			c,
 			&struct{}{})
-		if checkRPCErr(w, err) {
-			sendAcceptedResponse(w)
-		}
+		sendAcceptedResponse(w, err)
 	}
 }
 
-func (api *RESTAPI) pinListHandler(w http.ResponseWriter, r *http.Request) {
+func (rest *RESTAPI) pinListHandler(w http.ResponseWriter, r *http.Request) {
 	var pins []string
-	err := api.rpcClient.Call("",
+	err := rest.rpcClient.Call("",
 		"Cluster",
 		"PinList",
 		struct{}{},
 		&pins)
-	if checkRPCErr(w, err) {
-		sendJSONResponse(w, 200, pins)
-	}
-
+	sendResponse(w, err, pins)
 }
 
-func (api *RESTAPI) statusAllHandler(w http.ResponseWriter, r *http.Request) {
-	var pinInfos []GlobalPinInfo
-	err := api.rpcClient.Call("",
+func (rest *RESTAPI) statusAllHandler(w http.ResponseWriter, r *http.Request) {
+	var pinInfos []api.GlobalPinInfoSerial
+	err := rest.rpcClient.Call("",
 		"Cluster",
 		"StatusAll",
 		struct{}{},
 		&pinInfos)
-	if checkRPCErr(w, err) {
-		sendStatusResponse(w, http.StatusOK, pinInfos)
-	}
+	sendResponse(w, err, pinInfos)
 }
 
-func (api *RESTAPI) statusHandler(w http.ResponseWriter, r *http.Request) {
-	if c := parseCidOrError(w, r); c != nil {
-		var pinInfo GlobalPinInfo
-		err := api.rpcClient.Call("",
+func (rest *RESTAPI) statusHandler(w http.ResponseWriter, r *http.Request) {
+	if c := parseCidOrError(w, r); c.Cid != "" {
+		var pinInfo api.GlobalPinInfoSerial
+		err := rest.rpcClient.Call("",
 			"Cluster",
 			"Status",
 			c,
 			&pinInfo)
-		if checkRPCErr(w, err) {
-			sendStatusCidResponse(w, http.StatusOK, pinInfo)
-		}
+		sendResponse(w, err, pinInfo)
 	}
 }
 
-func (api *RESTAPI) syncAllHandler(w http.ResponseWriter, r *http.Request) {
-	var pinInfos []GlobalPinInfo
-	err := api.rpcClient.Call("",
+func (rest *RESTAPI) syncAllHandler(w http.ResponseWriter, r *http.Request) {
+	var pinInfos []api.GlobalPinInfoSerial
+	err := rest.rpcClient.Call("",
 		"Cluster",
 		"SyncAll",
 		struct{}{},
 		&pinInfos)
-	if checkRPCErr(w, err) {
-		sendStatusResponse(w, http.StatusAccepted, pinInfos)
-	}
+	sendResponse(w, err, pinInfos)
 }
 
-func (api *RESTAPI) syncHandler(w http.ResponseWriter, r *http.Request) {
-	if c := parseCidOrError(w, r); c != nil {
-		var pinInfo GlobalPinInfo
-		err := api.rpcClient.Call("",
+func (rest *RESTAPI) syncHandler(w http.ResponseWriter, r *http.Request) {
+	if c := parseCidOrError(w, r); c.Cid != "" {
+		var pinInfo api.GlobalPinInfoSerial
+		err := rest.rpcClient.Call("",
 			"Cluster",
 			"Sync",
 			c,
 			&pinInfo)
-		if checkRPCErr(w, err) {
-			sendStatusCidResponse(w, http.StatusOK, pinInfo)
-		}
+		sendResponse(w, err, pinInfo)
 	}
 }
 
-func (api *RESTAPI) recoverHandler(w http.ResponseWriter, r *http.Request) {
-	if c := parseCidOrError(w, r); c != nil {
-		var pinInfo GlobalPinInfo
-		err := api.rpcClient.Call("",
+func (rest *RESTAPI) recoverHandler(w http.ResponseWriter, r *http.Request) {
+	if c := parseCidOrError(w, r); c.Cid != "" {
+		var pinInfo api.GlobalPinInfoSerial
+		err := rest.rpcClient.Call("",
 			"Cluster",
 			"Recover",
 			c,
 			&pinInfo)
-		if checkRPCErr(w, err) {
-			sendStatusCidResponse(w, http.StatusOK, pinInfo)
-		}
+		sendResponse(w, err, pinInfo)
 	}
 }
 
-func parseCidOrError(w http.ResponseWriter, r *http.Request) *CidArg {
+func parseCidOrError(w http.ResponseWriter, r *http.Request) api.CidArgSerial {
 	vars := mux.Vars(r)
 	hash := vars["hash"]
 	_, err := cid.Decode(hash)
 	if err != nil {
 		sendErrorResponse(w, 400, "error decoding Cid: "+err.Error())
-		return nil
+		return api.CidArgSerial{""}
 	}
-	return &CidArg{hash}
+	return api.CidArgSerial{hash}
 }
 
 func parsePidOrError(w http.ResponseWriter, r *http.Request) peer.ID {
@@ -556,6 +440,12 @@ func parsePidOrError(w http.ResponseWriter, r *http.Request) peer.ID {
 	return pid
 }
 
+func sendResponse(w http.ResponseWriter, rpcErr error, resp interface{}) {
+	if checkRPCErr(w, rpcErr) {
+		sendJSONResponse(w, 200, resp)
+	}
+}
+
 // checkRPCErr takes care of returning standard error responses if we
 // pass an error to it. It returns true when everythings OK (no error
 // was handled), or false otherwise.
@@ -567,12 +457,16 @@ func checkRPCErr(w http.ResponseWriter, err error) bool {
 	return true
 }
 
-func sendEmptyResponse(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusNoContent)
+func sendEmptyResponse(w http.ResponseWriter, rpcErr error) {
+	if checkRPCErr(w, rpcErr) {
+		w.WriteHeader(http.StatusNoContent)
+	}
 }
 
-func sendAcceptedResponse(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusAccepted)
+func sendAcceptedResponse(w http.ResponseWriter, rpcErr error) {
+	if checkRPCErr(w, rpcErr) {
+		w.WriteHeader(http.StatusAccepted)
+	}
 }
 
 func sendJSONResponse(w http.ResponseWriter, code int, resp interface{}) {
@@ -586,31 +480,4 @@ func sendErrorResponse(w http.ResponseWriter, code int, msg string) {
 	errorResp := errorResp{code, msg}
 	logger.Errorf("sending error response: %d: %s", code, msg)
 	sendJSONResponse(w, code, errorResp)
-}
-
-func transformPinToStatusCid(p GlobalPinInfo) statusCidResp {
-	s := statusCidResp{}
-	s.Cid = p.Cid.String()
-	s.PeerMap = make(map[string]statusInfo)
-	for k, v := range p.PeerMap {
-		s.PeerMap[k.Pretty()] = statusInfo{
-			Status: v.Status.String(),
-			Error:  v.Error,
-		}
-	}
-	return s
-}
-
-func sendStatusResponse(w http.ResponseWriter, code int, data []GlobalPinInfo) {
-	pins := make(statusResp, 0, len(data))
-
-	for _, d := range data {
-		pins = append(pins, transformPinToStatusCid(d))
-	}
-	sendJSONResponse(w, code, pins)
-}
-
-func sendStatusCidResponse(w http.ResponseWriter, code int, data GlobalPinInfo) {
-	st := transformPinToStatusCid(data)
-	sendJSONResponse(w, code, st)
 }

--- a/rest_api.go
+++ b/rest_api.go
@@ -353,7 +353,7 @@ func (rest *RESTAPI) unpinHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (rest *RESTAPI) pinListHandler(w http.ResponseWriter, r *http.Request) {
-	var pins []string
+	var pins []api.CidArgSerial
 	err := rest.rpcClient.Call("",
 		"Cluster",
 		"PinList",
@@ -424,9 +424,9 @@ func parseCidOrError(w http.ResponseWriter, r *http.Request) api.CidArgSerial {
 	_, err := cid.Decode(hash)
 	if err != nil {
 		sendErrorResponse(w, 400, "error decoding Cid: "+err.Error())
-		return api.CidArgSerial{""}
+		return api.CidArgSerial{Cid: ""}
 	}
-	return api.CidArgSerial{hash}
+	return api.CidArgSerial{Cid: hash}
 }
 
 func parsePidOrError(w http.ResponseWriter, r *http.Request) peer.ID {

--- a/rest_api_test.go
+++ b/rest_api_test.go
@@ -190,11 +190,11 @@ func TestRESTAPIPinListEndpoint(t *testing.T) {
 	rest := testRESTAPI(t)
 	defer rest.Shutdown()
 
-	var resp []string
+	var resp []api.CidArgSerial
 	makeGet(t, "/pinlist", &resp)
 	if len(resp) != 3 ||
-		resp[0] != test.TestCid1 || resp[1] != test.TestCid2 ||
-		resp[2] != test.TestCid3 {
+		resp[0].Cid != test.TestCid1 || resp[1].Cid != test.TestCid2 ||
+		resp[2].Cid != test.TestCid3 {
 		t.Error("unexpected pin list: ", resp)
 	}
 }

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -213,8 +213,8 @@ func (rpcapi *RPCAPI) IPFSPinLsCid(in api.CidArgSerial, out *api.IPFSPinStatus) 
 }
 
 // IPFSPinLs runs IPFSConnector.PinLs().
-func (rpcapi *RPCAPI) IPFSPinLs(in struct{}, out *map[string]api.IPFSPinStatus) error {
-	m, err := rpcapi.c.ipfs.PinLs()
+func (rpcapi *RPCAPI) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) error {
+	m, err := rpcapi.c.ipfs.PinLs(in)
 	*out = m
 	return err
 }

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -43,13 +43,13 @@ func (rpcapi *RPCAPI) Unpin(in api.CidArgSerial, out *struct{}) error {
 }
 
 // PinList runs Cluster.Pins().
-func (rpcapi *RPCAPI) PinList(in struct{}, out *[]string) error {
+func (rpcapi *RPCAPI) PinList(in struct{}, out *[]api.CidArgSerial) error {
 	cidList := rpcapi.c.Pins()
-	cidStrList := make([]string, 0, len(cidList))
+	cidSerialList := make([]api.CidArgSerial, 0, len(cidList))
 	for _, c := range cidList {
-		cidStrList = append(cidStrList, c.String())
+		cidSerialList = append(cidSerialList, c.ToSerial())
 	}
-	*out = cidStrList
+	*out = cidSerialList
 	return nil
 }
 
@@ -156,8 +156,7 @@ func (rpcapi *RPCAPI) Recover(in api.CidArgSerial, out *api.GlobalPinInfoSerial)
 
 // Track runs PinTracker.Track().
 func (rpcapi *RPCAPI) Track(in api.CidArgSerial, out *struct{}) error {
-	c := in.ToCidArg().Cid
-	return rpcapi.c.tracker.Track(c)
+	return rpcapi.c.tracker.Track(in.ToCidArg())
 }
 
 // Untrack runs PinTracker.Untrack().
@@ -225,13 +224,13 @@ func (rpcapi *RPCAPI) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) er
 
 // ConsensusLogPin runs Consensus.LogPin().
 func (rpcapi *RPCAPI) ConsensusLogPin(in api.CidArgSerial, out *struct{}) error {
-	c := in.ToCidArg().Cid
+	c := in.ToCidArg()
 	return rpcapi.c.consensus.LogPin(c)
 }
 
 // ConsensusLogUnpin runs Consensus.LogUnpin().
 func (rpcapi *RPCAPI) ConsensusLogUnpin(in api.CidArgSerial, out *struct{}) error {
-	c := in.ToCidArg().Cid
+	c := in.ToCidArg()
 	return rpcapi.c.consensus.LogUnpin(c)
 }
 
@@ -272,6 +271,28 @@ func (rpcapi *RPCAPI) PeerManagerRmPeerShutdown(in peer.ID, out *struct{}) error
 // PeerManagerRmPeer runs peerManager.rmPeer().
 func (rpcapi *RPCAPI) PeerManagerRmPeer(in peer.ID, out *struct{}) error {
 	return rpcapi.c.peerManager.rmPeer(in, false)
+}
+
+// PeerManagerPeers runs peerManager.peers().
+func (rpcapi *RPCAPI) PeerManagerPeers(in struct{}, out *[]peer.ID) error {
+	*out = rpcapi.c.peerManager.peers()
+	return nil
+}
+
+/*
+   PeerMonitor
+*/
+
+// PeerMonitorLogMetric runs PeerMonitor.LogMetric().
+func (rpcapi *RPCAPI) PeerMonitorLogMetric(in api.Metric, out *struct{}) error {
+	rpcapi.c.monitor.LogMetric(in)
+	return nil
+}
+
+// PeerMonitorLastMetrics runs PeerMonitor.LastMetrics().
+func (rpcapi *RPCAPI) PeerMonitorLastMetrics(in string, out *[]api.Metric) error {
+	*out = rpcapi.c.monitor.LastMetrics(in)
+	return nil
 }
 
 /*

--- a/state/mapstate/map_state.go
+++ b/state/mapstate/map_state.go
@@ -1,4 +1,4 @@
-package ipfscluster
+package mapstate
 
 import (
 	"sync"
@@ -9,17 +9,14 @@ import (
 // MapState is a very simple database to store the state of the system
 // using a Go map. It is thread safe. It implements the State interface.
 type MapState struct {
-	pinMux  sync.RWMutex
-	PinMap  map[string]struct{}
-	peerMux sync.RWMutex
-	PeerMap map[string]string
+	pinMux sync.RWMutex
+	PinMap map[string]struct{}
 }
 
 // NewMapState initializes the internal map and returns a new MapState object.
 func NewMapState() *MapState {
 	return &MapState{
-		PinMap:  make(map[string]struct{}),
-		PeerMap: make(map[string]string),
+		PinMap: make(map[string]struct{}),
 	}
 }
 

--- a/state/mapstate/map_state.go
+++ b/state/mapstate/map_state.go
@@ -3,56 +3,69 @@ package mapstate
 import (
 	"sync"
 
+	"github.com/ipfs/ipfs-cluster/api"
+
 	cid "github.com/ipfs/go-cid"
 )
+
+const Version = 1
 
 // MapState is a very simple database to store the state of the system
 // using a Go map. It is thread safe. It implements the State interface.
 type MapState struct {
-	pinMux sync.RWMutex
-	PinMap map[string]struct{}
+	pinMux  sync.RWMutex
+	PinMap  map[string]api.CidArgSerial
+	Version int
 }
 
 // NewMapState initializes the internal map and returns a new MapState object.
 func NewMapState() *MapState {
 	return &MapState{
-		PinMap: make(map[string]struct{}),
+		PinMap: make(map[string]api.CidArgSerial),
 	}
 }
 
-// AddPin adds a Cid to the internal map.
-func (st *MapState) AddPin(c *cid.Cid) error {
+// Add adds a CidArg to the internal map.
+func (st *MapState) Add(c api.CidArg) error {
 	st.pinMux.Lock()
 	defer st.pinMux.Unlock()
-	var a struct{}
-	st.PinMap[c.String()] = a
+	st.PinMap[c.Cid.String()] = c.ToSerial()
 	return nil
 }
 
-// RmPin removes a Cid from the internal map.
-func (st *MapState) RmPin(c *cid.Cid) error {
+// Rm removes a Cid from the internal map.
+func (st *MapState) Rm(c *cid.Cid) error {
 	st.pinMux.Lock()
 	defer st.pinMux.Unlock()
 	delete(st.PinMap, c.String())
 	return nil
 }
 
-// HasPin returns true if the Cid belongs to the State.
-func (st *MapState) HasPin(c *cid.Cid) bool {
+func (st *MapState) Get(c *cid.Cid) api.CidArg {
+	st.pinMux.RLock()
+	defer st.pinMux.RUnlock()
+	cargs, ok := st.PinMap[c.String()]
+	if !ok { // make sure no panics
+		return api.CidArg{}
+	}
+	return cargs.ToCidArg()
+}
+
+// Has returns true if the Cid belongs to the State.
+func (st *MapState) Has(c *cid.Cid) bool {
 	st.pinMux.RLock()
 	defer st.pinMux.RUnlock()
 	_, ok := st.PinMap[c.String()]
 	return ok
 }
 
-// ListPins provides a list of Cids in the State.
-func (st *MapState) ListPins() []*cid.Cid {
+// List provides the list of tracked CidArgs.
+func (st *MapState) List() []api.CidArg {
 	st.pinMux.RLock()
 	defer st.pinMux.RUnlock()
-	cids := make([]*cid.Cid, 0, len(st.PinMap))
-	for k := range st.PinMap {
-		c, _ := cid.Decode(k)
-		cids = append(cids, c)
+	cids := make([]api.CidArg, 0, len(st.PinMap))
+	for _, v := range st.PinMap {
+		cids = append(cids, v.ToCidArg())
 	}
 	return cids
 }

--- a/state/mapstate/map_state_test.go
+++ b/state/mapstate/map_state_test.go
@@ -1,0 +1,68 @@
+package mapstate
+
+import (
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+
+	"github.com/ipfs/ipfs-cluster/api"
+)
+
+var testCid1, _ = cid.Decode("QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq")
+var testPeerID1, _ = peer.IDB58Decode("QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabc")
+
+var c = api.CidArg{
+	Cid:         testCid1,
+	Allocations: []peer.ID{testPeerID1},
+	Everywhere:  false,
+}
+
+func TestAdd(t *testing.T) {
+	ms := NewMapState()
+	ms.Add(c)
+	if !ms.Has(c.Cid) {
+		t.Error("should have added it")
+	}
+}
+
+func TestRm(t *testing.T) {
+	ms := NewMapState()
+	ms.Add(c)
+	ms.Rm(c.Cid)
+	if ms.Has(c.Cid) {
+		t.Error("should have removed it")
+	}
+}
+
+func TestGet(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("paniced")
+		}
+	}()
+	ms := NewMapState()
+	ms.Add(c)
+	get := ms.Get(c.Cid)
+	if get.Cid.String() != c.Cid.String() ||
+		get.Allocations[0] != c.Allocations[0] ||
+		get.Everywhere != c.Everywhere {
+		t.Error("returned something different")
+	}
+}
+
+func TestList(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("paniced")
+		}
+	}()
+	ms := NewMapState()
+	ms.Add(c)
+	list := ms.List()
+	if list[0].Cid.String() != c.Cid.String() ||
+		list[0].Allocations[0] != c.Allocations[0] ||
+		list[0].Everywhere != c.Everywhere {
+		t.Error("returned something different")
+	}
+}

--- a/test/cids.go
+++ b/test/cids.go
@@ -1,0 +1,13 @@
+package test
+
+import peer "github.com/libp2p/go-libp2p-peer"
+
+var (
+	TestCid1       = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq"
+	TestCid2       = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmma"
+	TestCid3       = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmb"
+	ErrorCid       = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmc"
+	TestPeerID1, _ = peer.IDB58Decode("QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabc")
+	TestPeerID2, _ = peer.IDB58Decode("QmUZ13osndQ5uL4tPWHXe3iBgBgq9gfewcBMSCAuMBsDJ6")
+	TestPeerID3, _ = peer.IDB58Decode("QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa")
+)

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 
 	cid "github.com/ipfs/go-cid"
@@ -92,7 +93,7 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			goto ERROR
 		}
-		m.pinMap.AddPin(c)
+		m.pinMap.Add(api.CidArgCid(c))
 		resp := mockPinResp{
 			Pins: []string{cidStr},
 		}
@@ -109,7 +110,7 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			goto ERROR
 		}
-		m.pinMap.RmPin(c)
+		m.pinMap.Rm(c)
 		resp := mockPinResp{
 			Pins: []string{cidStr},
 		}
@@ -120,9 +121,9 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		arg, ok := query["arg"]
 		if !ok {
 			rMap := make(map[string]mockPinType)
-			pins := m.pinMap.ListPins()
+			pins := m.pinMap.List()
 			for _, p := range pins {
-				rMap[p.String()] = mockPinType{"recursive"}
+				rMap[p.Cid.String()] = mockPinType{"recursive"}
 			}
 			j, _ := json.Marshal(mockPinLsResp{rMap})
 			w.Write(j)
@@ -137,7 +138,7 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			goto ERROR
 		}
-		ok = m.pinMap.HasPin(c)
+		ok = m.pinMap.Has(c)
 		if ok {
 			rMap := make(map[string]mockPinType)
 			rMap[cidStr] = mockPinType{"recursive"}

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -42,8 +42,18 @@ func (mock *mockService) Unpin(in api.CidArgSerial, out *struct{}) error {
 	return nil
 }
 
-func (mock *mockService) PinList(in struct{}, out *[]string) error {
-	*out = []string{TestCid1, TestCid2, TestCid3}
+func (mock *mockService) PinList(in struct{}, out *[]api.CidArgSerial) error {
+	*out = []api.CidArgSerial{
+		{
+			Cid: TestCid1,
+		},
+		{
+			Cid: TestCid2,
+		},
+		{
+			Cid: TestCid3,
+		},
+	}
 	return nil
 }
 
@@ -178,5 +188,10 @@ func (mock *mockService) Track(in api.CidArgSerial, out *struct{}) error {
 }
 
 func (mock *mockService) Untrack(in api.CidArgSerial, out *struct{}) error {
+	return nil
+}
+
+func (mock *mockService) PeerManagerPeers(in struct{}, out *[]peer.ID) error {
+	*out = []peer.ID{TestPeerID1, TestPeerID2, TestPeerID3}
 	return nil
 }

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -1,4 +1,4 @@
-package ipfscluster
+package test
 
 import (
 	"errors"
@@ -12,11 +12,13 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-var errBadCid = errors.New("this is an expected error when using errorCid")
+var ErrBadCid = errors.New("this is an expected error when using ErrorCid")
 
 type mockService struct{}
 
-func mockRPCClient(t *testing.T) *rpc.Client {
+// NewMockRPCClient creates a mock ipfs-cluster RPC server and returns
+// a client to it.
+func NewMockRPCClient(t *testing.T) *rpc.Client {
 	s := rpc.NewServer(nil, "mock")
 	c := rpc.NewClientWithServer(nil, "mock", s)
 	err := s.RegisterName("Cluster", &mockService{})
@@ -27,21 +29,21 @@ func mockRPCClient(t *testing.T) *rpc.Client {
 }
 
 func (mock *mockService) Pin(in api.CidArgSerial, out *struct{}) error {
-	if in.Cid == errorCid {
-		return errBadCid
+	if in.Cid == ErrorCid {
+		return ErrBadCid
 	}
 	return nil
 }
 
 func (mock *mockService) Unpin(in api.CidArgSerial, out *struct{}) error {
-	if in.Cid == errorCid {
-		return errBadCid
+	if in.Cid == ErrorCid {
+		return ErrBadCid
 	}
 	return nil
 }
 
 func (mock *mockService) PinList(in struct{}, out *[]string) error {
-	*out = []string{testCid, testCid2, testCid3}
+	*out = []string{TestCid1, TestCid2, TestCid3}
 	return nil
 }
 
@@ -50,11 +52,11 @@ func (mock *mockService) ID(in struct{}, out *api.IDSerial) error {
 	//	DefaultConfigCrypto,
 	//	DefaultConfigKeyLength)
 	*out = api.ID{
-		ID: testPeerID,
+		ID: TestPeerID1,
 		//PublicKey: pubkey,
 		Version: "0.0.mock",
 		IPFS: api.IPFSID{
-			ID: testPeerID,
+			ID: TestPeerID1,
 		},
 	}.ToSerial()
 	return nil
@@ -84,17 +86,26 @@ func (mock *mockService) PeerRemove(in peer.ID, out *struct{}) error {
 	return nil
 }
 
+// FIXME: dup from util.go
+func globalPinInfoSliceToSerial(gpi []api.GlobalPinInfo) []api.GlobalPinInfoSerial {
+	gpis := make([]api.GlobalPinInfoSerial, len(gpi), len(gpi))
+	for i, v := range gpi {
+		gpis[i] = v.ToSerial()
+	}
+	return gpis
+}
+
 func (mock *mockService) StatusAll(in struct{}, out *[]api.GlobalPinInfoSerial) error {
-	c1, _ := cid.Decode(testCid1)
-	c2, _ := cid.Decode(testCid2)
-	c3, _ := cid.Decode(testCid3)
+	c1, _ := cid.Decode(TestCid1)
+	c2, _ := cid.Decode(TestCid2)
+	c3, _ := cid.Decode(TestCid3)
 	*out = globalPinInfoSliceToSerial([]api.GlobalPinInfo{
 		{
 			Cid: c1,
 			PeerMap: map[peer.ID]api.PinInfo{
-				testPeerID: {
+				TestPeerID1: {
 					Cid:    c1,
-					Peer:   testPeerID,
+					Peer:   TestPeerID1,
 					Status: api.TrackerStatusPinned,
 					TS:     time.Now(),
 				},
@@ -103,9 +114,9 @@ func (mock *mockService) StatusAll(in struct{}, out *[]api.GlobalPinInfoSerial) 
 		{
 			Cid: c2,
 			PeerMap: map[peer.ID]api.PinInfo{
-				testPeerID: {
+				TestPeerID1: {
 					Cid:    c2,
-					Peer:   testPeerID,
+					Peer:   TestPeerID1,
 					Status: api.TrackerStatusPinning,
 					TS:     time.Now(),
 				},
@@ -114,9 +125,9 @@ func (mock *mockService) StatusAll(in struct{}, out *[]api.GlobalPinInfoSerial) 
 		{
 			Cid: c3,
 			PeerMap: map[peer.ID]api.PinInfo{
-				testPeerID: {
+				TestPeerID1: {
 					Cid:    c3,
-					Peer:   testPeerID,
+					Peer:   TestPeerID1,
 					Status: api.TrackerStatusPinError,
 					TS:     time.Now(),
 				},
@@ -127,16 +138,16 @@ func (mock *mockService) StatusAll(in struct{}, out *[]api.GlobalPinInfoSerial) 
 }
 
 func (mock *mockService) Status(in api.CidArgSerial, out *api.GlobalPinInfoSerial) error {
-	if in.Cid == errorCid {
-		return errBadCid
+	if in.Cid == ErrorCid {
+		return ErrBadCid
 	}
-	c1, _ := cid.Decode(testCid1)
+	c1, _ := cid.Decode(TestCid1)
 	*out = api.GlobalPinInfo{
 		Cid: c1,
 		PeerMap: map[peer.ID]api.PinInfo{
-			testPeerID: {
+			TestPeerID1: {
 				Cid:    c1,
-				Peer:   testPeerID,
+				Peer:   TestPeerID1,
 				Status: api.TrackerStatusPinned,
 				TS:     time.Now(),
 			},

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,3 @@
+// Package test offers testing utilities to ipfs-cluster like
+// mocks
+package test

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"reflect"
+	"testing"
+
+	ipfscluster "github.com/ipfs/ipfs-cluster"
+)
+
+func TestIpfsMock(t *testing.T) {
+	ipfsmock := NewIpfsMock()
+	defer ipfsmock.Close()
+}
+
+// Test that our RPC mock resembles the original
+func TestRPCMockValid(t *testing.T) {
+	mock := &mockService{}
+	real := &ipfscluster.RPCAPI{}
+	mockT := reflect.TypeOf(mock)
+	realT := reflect.TypeOf(real)
+
+	// Make sure all the methods we have match the original
+	for i := 0; i < mockT.NumMethod(); i++ {
+		method := mockT.Method(i)
+		name := method.Name
+		origMethod, ok := realT.MethodByName(name)
+		if !ok {
+			t.Fatalf("%s method not found in real RPC", name)
+		}
+
+		mType := method.Type
+		oType := origMethod.Type
+
+		if nout := mType.NumOut(); nout != 1 || nout != oType.NumOut() {
+			t.Errorf("%s: more than 1 out parameter", name)
+		}
+
+		if mType.Out(0).Name() != "error" {
+			t.Errorf("%s out param should be an error", name)
+		}
+
+		if nin := mType.NumIn(); nin != oType.NumIn() || nin != 3 {
+			t.Errorf("%s: num in parameter mismatch: %d vs. %d", name, nin, oType.NumIn())
+		}
+
+		for j := 1; j < 3; j++ {
+			mn := mType.In(j).String()
+			on := oType.In(j).String()
+			if mn != on {
+				t.Errorf("%s: name mismatch: %s vs %s", name, mn, on)
+			}
+		}
+	}
+
+	for i := 0; i < realT.NumMethod(); i++ {
+		name := realT.Method(i).Name
+		_, ok := mockT.MethodByName(name)
+		if !ok {
+			t.Logf("Warning: %s: unimplemented in mock rpc", name)
+		}
+	}
+}

--- a/util.go
+++ b/util.go
@@ -3,8 +3,9 @@ package ipfscluster
 import (
 	"fmt"
 
-	host "github.com/libp2p/go-libp2p-host"
+	"github.com/ipfs/ipfs-cluster/api"
 
+	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -18,7 +19,7 @@ import (
 // 	return ifaces
 // }
 
-func copyIDSerialsToIfaces(in []IDSerial) []interface{} {
+func copyIDSerialsToIfaces(in []api.IDSerial) []interface{} {
 	ifaces := make([]interface{}, len(in), len(in))
 	for i := range in {
 		ifaces[i] = &in[i]
@@ -26,7 +27,7 @@ func copyIDSerialsToIfaces(in []IDSerial) []interface{} {
 	return ifaces
 }
 
-func copyPinInfoToIfaces(in []PinInfo) []interface{} {
+func copyPinInfoSerialToIfaces(in []api.PinInfoSerial) []interface{} {
 	ifaces := make([]interface{}, len(in), len(in))
 	for i := range in {
 		ifaces[i] = &in[i]
@@ -34,7 +35,7 @@ func copyPinInfoToIfaces(in []PinInfo) []interface{} {
 	return ifaces
 }
 
-func copyPinInfoSliceToIfaces(in [][]PinInfo) []interface{} {
+func copyPinInfoSerialSliceToIfaces(in [][]api.PinInfoSerial) []interface{} {
 	ifaces := make([]interface{}, len(in), len(in))
 	for i := range in {
 		ifaces[i] = &in[i]
@@ -119,4 +120,20 @@ func getRemoteMultiaddr(h host.Host, pid peer.ID, addr ma.Multiaddr) ma.Multiadd
 		return multiaddrJoin(conns[0].RemoteMultiaddr(), pid)
 	}
 	return multiaddrJoin(addr, pid)
+}
+
+func pinInfoSliceToSerial(pi []api.PinInfo) []api.PinInfoSerial {
+	pis := make([]api.PinInfoSerial, len(pi), len(pi))
+	for i, v := range pi {
+		pis[i] = v.ToSerial()
+	}
+	return pis
+}
+
+func globalPinInfoSliceToSerial(gpi []api.GlobalPinInfo) []api.GlobalPinInfoSerial {
+	gpis := make([]api.GlobalPinInfoSerial, len(gpi), len(gpi))
+	for i, v := range gpi {
+		gpis[i] = v.ToSerial()
+	}
+	return gpis
 }

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package ipfscluster
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ipfs/ipfs-cluster/api"
@@ -136,4 +137,10 @@ func globalPinInfoSliceToSerial(gpi []api.GlobalPinInfo) []api.GlobalPinInfoSeri
 		gpis[i] = v.ToSerial()
 	}
 	return gpis
+}
+
+func logError(fmtstr string, args ...interface{}) error {
+	msg := fmt.Sprintf(fmtstr, args...)
+	logger.Error(msg)
+	return errors.New(msg)
 }


### PR DESCRIPTION
New PeerManager, Allocator, Informer components have been added along
with a new "replication_factor" configuration option.

First, cluster peers collect and push metrics (Informer) to the Cluster
leader regularly. The Informer is an interface that can be implemented
in custom wayts to support custom metrics.

Second, on a pin operation, using the information from the collected metrics,
an Allocator can provide a list of preferences as to where the new pin
should be assigned. The Allocator is an interface allowing to provide
different allocation strategies.

Both Allocator and Informer are Cluster Componenets, and have access
to the RPC API.

The allocations are kept in the shared state. Cluster peer failure
detection is still missing and re-allocation is still missing (#45), although manually
re-pinning something when a node is down/metrics missing does re-allocate
the pin somewhere else.

Plus: The ipfs-cluster-ctl tool has nicer text output now.

Fixes: #41 