### PR TITLE
Small fixes

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -170,7 +170,7 @@ func (pi PinInfo) ToSerial() PinInfoSerial {
 		Cid:    pi.Cid.String(),
 		Peer:   peer.IDB58Encode(pi.Peer),
 		Status: pi.Status.String(),
-		TS:     pi.TS.Format(time.RFC1123),
+		TS:     pi.TS.UTC().Format(time.RFC1123),
 		Error:  pi.Error,
 	}
 }
@@ -398,7 +398,7 @@ type Metric struct {
 // SetTTL sets Metric to expire after the given seconds
 func (m *Metric) SetTTL(seconds int) {
 	exp := time.Now().Add(time.Duration(seconds) * time.Second)
-	m.Expire = exp.Format(time.RFC1123)
+	m.Expire = exp.UTC().Format(time.RFC1123)
 }
 
 // GetTTL returns the time left before the Metric expires

--- a/cluster.go
+++ b/cluster.go
@@ -353,7 +353,13 @@ func (c *Cluster) ID() api.ID {
 	// ignore error since it is included in response object
 	ipfsID, _ := c.ipfs.ID()
 	var addrs []ma.Multiaddr
+
+	addrsSet := make(map[string]struct{}) // to filter dups
 	for _, addr := range c.host.Addrs() {
+		addrsSet[addr.String()] = struct{}{}
+	}
+	for k := range addrsSet {
+		addr, _ := ma.NewMultiaddr(k)
 		addrs = append(addrs, multiaddrJoin(addr, c.id))
 	}
 


### PR DESCRIPTION
This fixes two small issues I watched during the demo the other day, mostly cosmetic:

  * duplicate listen multiaddresses in the peer information
  * timestamps shown in different timezones in the pin status information

Just checking that tests pass