### PR TITLE
Issue #45: Detect expired metrics and trigger re-pins

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -80,7 +80,7 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate
 	cfg := testingConfig()
 	st := mapstate.NewMapState()
 	tracker := NewMapPinTracker(cfg)
-	mon := NewStdPeerMonitor(5)
+	mon := NewStdPeerMonitor(cfg)
 	alloc := numpinalloc.NewAllocator()
 	inf := numpin.NewInformer()
 

--- a/config_test.go
+++ b/config_test.go
@@ -12,6 +12,7 @@ func testingConfig() *Config {
 		IPFSProxyListenMultiaddress: "/ip4/127.0.0.1/tcp/10001",
 		ConsensusDataFolder:         "./raftFolderFromTests",
 		LeaveOnShutdown:             true,
+		MonitoringIntervalSeconds:   2,
 	}
 
 	cfg, _ := jcfg.ToConfig()

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -239,7 +239,7 @@ func run(c *cli.Context) error {
 
 	state := mapstate.NewMapState()
 	tracker := ipfscluster.NewMapPinTracker(cfg)
-	mon := ipfscluster.NewStdPeerMonitor(5)
+	mon := ipfscluster.NewStdPeerMonitor(cfg)
 	informer := numpin.NewInformer()
 	alloc := numpinalloc.NewAllocator()
 


### PR DESCRIPTION
An initial, simple approach to this. The PeerMonitor will
check its metrics, compare to the current set of peers and put
an alert in the alerts channel if the metrics for a peer have expired.

Cluster reads this channel looking for "ping" alerts. The leader
(because that's the monitor here metrics are pushed from everywhere)
then reads the alerts and triggers repins in all the Cids allocated to
a given peer.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>