### PR TITLE
Address randomly failing tests. Improve metrics broadcasts.

### DIFF
--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -885,7 +885,7 @@ func TestClustersReplicationNotEnoughPeers(t *testing.T) {
 		t.Error("different error than expected")
 		t.Error(err)
 	}
-	t.Log(err)
+	//t.Log(err)
 }
 
 func TestClustersRebalanceOnPeerDown(t *testing.T) {
@@ -904,7 +904,7 @@ func TestClustersRebalanceOnPeerDown(t *testing.T) {
 	// pin something
 	h, _ := cid.Decode(test.TestCid1)
 	clusters[0].Pin(api.PinCid(h))
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 	pinLocal := 0
 	pinRemote := 0
 	var localPinner peer.ID


### PR DESCRIPTION
This is a better approach than broadcasting everything all the time
(see 6ee0f3bead62ffe69f5343540db3771bf4be35ac). A couple of delays
have been touched in order to make tests less likely to fail randomly.
(Issue #65).

I have manually run the travis tests for the branch 5 times and got it green everytime. Finger crossed.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>