### PR TITLE
Issue #51: Save a backup on shutdown

### DIFF
--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -9,6 +9,8 @@
 package ipfscluster
 
 import (
+	"io"
+
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -68,6 +70,10 @@ type State interface {
 	Has(*cid.Cid) bool
 	// Get returns the information attacthed to this pin
 	Get(*cid.Cid) api.Pin
+	// Snapshot writes a snapshot of the state to a writer
+	Snapshot(w io.Writer) error
+	// Restore restores a snapshot from a reader
+	Restore(r io.Reader) error
 }
 
 // PinTracker represents a component which tracks the status of

--- a/state/mapstate/migrate.go
+++ b/state/mapstate/migrate.go
@@ -1,0 +1,34 @@
+package mapstate
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/ipfs/ipfs-cluster/api"
+)
+
+type mapStateV1 struct {
+	Version int
+	PinMap  map[string]struct{}
+}
+
+func (st *MapState) migrateFrom(version int, snap []byte) error {
+	switch version {
+	case 1:
+		var mstv1 mapStateV1
+		err := json.Unmarshal(snap, &mstv1)
+		if err != nil {
+			return err
+		}
+		for k := range mstv1.PinMap {
+			st.PinMap[k] = api.PinSerial{
+				Cid:               k,
+				Allocations:       []string{},
+				ReplicationFactor: -1,
+			}
+		}
+		return nil
+	default:
+		return errors.New("version migration not supported")
+	}
+}


### PR DESCRIPTION
This adds snapshot and restore methods to state and uses the snapshot
one to save a copy of the state when shutting down. This is WIP on migrations but adds
at least a user-readable view of the state.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>