### PR TITLE
Use "pin ls --type=recursive $pin" when checking if a pin exists

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -431,10 +431,10 @@ func (ipfs *Connector) PinLs(typeFilter string) (map[string]api.IPFSPinStatus, e
 	return statusMap, nil
 }
 
-// PinLsCid performs a "pin ls <hash> "request and returns IPFSPinStatus for
-// that hash.
+// PinLsCid performs a "pin ls --type=recursive <hash> "request and returns
+// an api.IPFSPinStatus for that hash.
 func (ipfs *Connector) PinLsCid(hash *cid.Cid) (api.IPFSPinStatus, error) {
-	lsPath := fmt.Sprintf("pin/ls?arg=%s", hash)
+	lsPath := fmt.Sprintf("pin/ls?arg=%s&type=recursive", hash)
 	body, err := ipfs.get(lsPath)
 
 	// Network error, daemon down

--- a/pintracker/maptracker/maptracker.go
+++ b/pintracker/maptracker/maptracker.go
@@ -224,6 +224,7 @@ func (mpt *MapPinTracker) pin(c api.Pin) error {
 
 func (mpt *MapPinTracker) unpin(c api.Pin) error {
 	logger.Debugf("issuing unpin call for %s", c.Cid)
+	mpt.set(c.Cid, api.TrackerStatusUnpinning)
 	err := mpt.rpcClient.Call("",
 		"Cluster",
 		"IPFSUnpin",

--- a/pintracker/maptracker/maptracker_test.go
+++ b/pintracker/maptracker/maptracker_test.go
@@ -108,6 +108,8 @@ func TestUntrack(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	time.Sleep(time.Second / 2)
+
 	err = mpt.Untrack(h2)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +123,7 @@ func TestUntrack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(400 * time.Millisecond)
+	time.Sleep(time.Second / 2)
 
 	st := mpt.Status(h1)
 	if st.Status != api.TrackerStatusUnpinned {


### PR DESCRIPTION
This is significantly faster for pins that don't exist.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>