### PR TITLE
Fixes #16: trigger ipfs swarm connect to other ipfs nodes in the cluster

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -535,6 +535,16 @@ func (c *Cluster) PeerAdd(addr ma.Multiaddr) (api.ID, error) {
 		logger.Error(err)
 	}
 
+	// Ask the new peer to connect its IPFS daemon to the rest
+	err = c.rpcClient.Call(pid,
+		"Cluster",
+		"IPFSConnectSwarms",
+		struct{}{},
+		&struct{}{})
+	if err != nil {
+		logger.Error(err)
+	}
+
 	id, err := c.getIDForPeer(pid)
 	return id, nil
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -77,6 +77,8 @@ func (ipfs *mockConnector) PinLs(filter string) (map[string]api.IPFSPinStatus, e
 	return m, nil
 }
 
+func (ipfs *mockConnector) ConnectSwarms() {}
+
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *maptracker.MapPinTracker) {
 	api := &mockAPI{}
 	ipfs := &mockConnector{}

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ -z $COVERALLS_TOKEN ]
-then
-    exit 1
-fi
-
 echo "mode: count" > fullcov.out
 dirs=$(find ./* -maxdepth 10 -type d )
 dirs=". $dirs"
@@ -23,6 +18,10 @@ do
             fi
         fi
 done
-$HOME/gopath/bin/goveralls -coverprofile=fullcov.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+
+if [ -n $COVERALLS_TOKEN ];
+then
+    $HOME/gopath/bin/goveralls -coverprofile=fullcov.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+fi
 rm -rf ./profile.out
 rm -rf ./fullcov.out

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -71,6 +71,9 @@ type IPFSConnector interface {
 	Unpin(*cid.Cid) error
 	PinLsCid(*cid.Cid) (api.IPFSPinStatus, error)
 	PinLs(typeFilter string) (map[string]api.IPFSPinStatus, error)
+	// ConnectSwarms make sure this peer's IPFS daemon is connected to
+	// other peers IPFS daemons.
+	ConnectSwarms()
 }
 
 // Peered represents a component which needs to be aware of the peers

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -681,7 +681,7 @@ func TestClustersReplication(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		time.Sleep(time.Second / 2)
+		time.Sleep(time.Second)
 
 		// check that it is held by exactly nClusters -1 peers
 		gpi, err := clusters[j].Status(h)

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -6,14 +6,21 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"
 
 	cid "github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 )
+
+func init() {
+	_ = logging.Logger
+	ConnectSwarmsDelay = 0
+}
 
 func testIPFSConnector(t *testing.T) (*Connector, *test.IpfsMock) {
 	mock := test.NewIpfsMock()
@@ -324,6 +331,18 @@ func TestIPFSShutdown(t *testing.T) {
 	if err := ipfs.Shutdown(); err != nil {
 		t.Error("expected a second clean shutdown")
 	}
+}
+
+func TestConnectSwarms(t *testing.T) {
+	// In order to interactively test uncomment the following.
+	// Otherwise there is no good way to test this with the
+	// ipfs mock
+	// logging.SetDebugLogging()
+
+	ipfs, mock := testIPFSConnector(t)
+	defer mock.Close()
+	defer ipfs.Shutdown()
+	time.Sleep(time.Second)
 }
 
 func proxyURL(c *Connector) string {

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -219,6 +219,12 @@ func (rpcapi *RPCAPI) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) er
 	return err
 }
 
+// ConnectSwarms runs IPFSConnector.ConnectSwarms().
+func (rpcapi *RPCAPI) ConnectSwarms(in struct{}, out *struct{}) error {
+	rpcapi.c.ipfs.ConnectSwarms()
+	return nil
+}
+
 /*
    Consensus component methods
 */

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -150,6 +150,22 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 			j, _ := json.Marshal(resp)
 			w.Write(j)
 		}
+	case "swarm/connect":
+		query := r.URL.Query()
+		arg, ok := query["arg"]
+		if !ok {
+			goto ERROR
+		}
+		addr := arg[0]
+		splits := strings.Split(addr, "/")
+		pid := splits[len(splits)-1]
+		resp := struct {
+			Strings []string
+		}{
+			Strings: []string{fmt.Sprintf("connect %s success", pid)},
+		}
+		j, _ := json.Marshal(resp)
+		w.Write(j)
 	case "version":
 		w.Write([]byte("{\"Version\":\"m.o.c.k\"}"))
 	default:

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -63,14 +63,17 @@ func (mock *mockService) ID(in struct{}, out *api.IDSerial) error {
 	//_, pubkey, _ := crypto.GenerateKeyPair(
 	//	DefaultConfigCrypto,
 	//	DefaultConfigKeyLength)
-	*out = api.ID{
-		ID: TestPeerID1,
+	*out = api.IDSerial{
+		ID: TestPeerID1.Pretty(),
 		//PublicKey: pubkey,
 		Version: "0.0.mock",
-		IPFS: api.IPFSID{
-			ID: TestPeerID1,
+		IPFS: api.IPFSIDSerial{
+			ID: TestPeerID1.Pretty(),
+			Addresses: api.MultiaddrsSerial{
+				api.MultiaddrSerial("/ip4/127.0.0.1/tcp/4001/ipfs/" + TestPeerID1.Pretty()),
+			},
 		},
-	}.ToSerial()
+	}
 	return nil
 }
 
@@ -235,5 +238,9 @@ func (mock *mockService) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus)
 		TestCid3: api.IPFSPinStatusRecursive,
 	}
 	*out = m
+	return nil
+}
+
+func (mock *mockService) ConnectSwarms(in struct{}, out *struct{}) error {
 	return nil
 }


### PR DESCRIPTION
This runs ipfs swarm connect to the reported ipfs daemon addresses for all peers in the cluster, every time a cluster node comes up. It ignores any errors (which will happen).