### PR TITLE
Fix #49: Add disk informer

### DIFF
--- a/allocator/ascendalloc/ascendalloc_test.go
+++ b/allocator/ascendalloc/ascendalloc_test.go
@@ -1,4 +1,4 @@
-package numpinalloc
+package ascendalloc
 
 import (
 	"testing"
@@ -65,24 +65,6 @@ var testCases = []testcase{
 				Value:  "1",
 				Expire: inAMinute,
 				Valid:  false,
-			},
-			peer1: api.Metric{
-				Name:   numpin.MetricName,
-				Value:  "5",
-				Expire: inAMinute,
-				Valid:  true,
-			},
-		},
-		current:  map[peer.ID]api.Metric{},
-		expected: []peer.ID{peer1},
-	},
-	{ // filter bad metric name
-		candidates: map[peer.ID]api.Metric{
-			peer0: api.Metric{
-				Name:   "lalala",
-				Value:  "1",
-				Expire: inAMinute,
-				Valid:  true,
 			},
 			peer1: api.Metric{
 				Name:   numpin.MetricName,

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ipfs/ipfs-cluster/allocator/numpinalloc"
+	"github.com/ipfs/ipfs-cluster/allocator/ascendalloc"
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/informer/numpin"
 	"github.com/ipfs/ipfs-cluster/monitor/basic"
@@ -77,7 +77,9 @@ func (ipfs *mockConnector) PinLs(filter string) (map[string]api.IPFSPinStatus, e
 	return m, nil
 }
 
-func (ipfs *mockConnector) ConnectSwarms() {}
+func (ipfs *mockConnector) ConnectSwarms() error                          { return nil }
+func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
+func (ipfs *mockConnector) RepoSize() (int, error)                        { return 0, nil }
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *maptracker.MapPinTracker) {
 	api := &mockAPI{}
@@ -86,7 +88,7 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate
 	st := mapstate.NewMapState()
 	tracker := maptracker.NewMapPinTracker(cfg.ID)
 	mon := basic.NewStdPeerMonitor(2)
-	alloc := numpinalloc.NewAllocator()
+	alloc := ascendalloc.NewAllocator()
 	inf := numpin.NewInformer()
 
 	cl, err := NewCluster(
@@ -106,7 +108,7 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate
 }
 
 func cleanRaft() {
-	os.RemoveAll(".raftFolderFromTests")
+	os.RemoveAll("raftFolderFromTests")
 }
 
 func testClusterShutdown(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -77,6 +77,10 @@ type Config struct {
 	// pass before a peer can be detected as down.
 	MonitoringIntervalSeconds int
 
+	// AllocationStrategy is used to decide on the
+	// Informer/Allocator implementation to use.
+	AllocationStrategy string
+
 	// if a config has been loaded from disk, track the path
 	// so it can be saved to the same place.
 	path string
@@ -143,6 +147,11 @@ type JSONConfig struct {
 	// Number of seconds between monitoring checks which detect
 	// if a peer is down and consenquently trigger a rebalance
 	MonitoringIntervalSeconds int `json:"monitoring_interval_seconds"`
+
+	// AllocationStrategy is used to set how pins are allocated to
+	// different Cluster peers. Currently supports "reposize" and "pincount"
+	// values.
+	AllocationStrategy string `json:"allocation_strategy"`
 }
 
 // ToJSONConfig converts a Config object to its JSON representation which
@@ -184,6 +193,7 @@ func (cfg *Config) ToJSONConfig() (j *JSONConfig, err error) {
 		StateSyncSeconds:            cfg.StateSyncSeconds,
 		ReplicationFactor:           cfg.ReplicationFactor,
 		MonitoringIntervalSeconds:   cfg.MonitoringIntervalSeconds,
+		AllocationStrategy:          cfg.AllocationStrategy,
 	}
 	return
 }
@@ -265,6 +275,10 @@ func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
 		jcfg.MonitoringIntervalSeconds = DefaultMonitoringIntervalSeconds
 	}
 
+	if jcfg.AllocationStrategy == "" {
+		jcfg.AllocationStrategy = "reposize"
+	}
+
 	c = &Config{
 		ID:                        id,
 		PrivateKey:                pKey,
@@ -279,6 +293,7 @@ func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
 		StateSyncSeconds:          jcfg.StateSyncSeconds,
 		ReplicationFactor:         jcfg.ReplicationFactor,
 		MonitoringIntervalSeconds: jcfg.MonitoringIntervalSeconds,
+		AllocationStrategy:        jcfg.AllocationStrategy,
 	}
 	return
 }

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ func testingConfig() *Config {
 		ClusterListenMultiaddress:   "/ip4/127.0.0.1/tcp/10000",
 		APIListenMultiaddress:       "/ip4/127.0.0.1/tcp/10002",
 		IPFSProxyListenMultiaddress: "/ip4/127.0.0.1/tcp/10001",
-		ConsensusDataFolder:         "./raftFolderFromTests",
+		ConsensusDataFolder:         "raftFolderFromTests",
 		LeaveOnShutdown:             true,
 		MonitoringIntervalSeconds:   2,
 	}

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -1,0 +1,81 @@
+// Package disk implements an ipfs-cluster informer which determines
+// the current RepoSize of the ipfs daemon datastore and returns it as an
+// api.Metric.
+package disk
+
+import (
+	"fmt"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	logging "github.com/ipfs/go-log"
+
+	"github.com/ipfs/ipfs-cluster/api"
+)
+
+var logger = logging.Logger("diskinfo")
+
+// MetricTTL specifies how long our reported metric is valid in seconds.
+var MetricTTL = 30
+
+// MetricName specifies the name of our metric
+var MetricName = "disk"
+
+// Informer is a simple object to implement the ipfscluster.Informer
+// and Component interfaces.
+type Informer struct {
+	rpcClient *rpc.Client
+}
+
+// NewInformer returns an initialized Informer.
+func NewInformer() *Informer {
+	return &Informer{}
+}
+
+// SetClient provides us with an rpc.Client which allows
+// contacting other components in the cluster.
+func (disk *Informer) SetClient(c *rpc.Client) {
+	disk.rpcClient = c
+}
+
+// Shutdown is called on cluster shutdown. We just invalidate
+// any metrics from this point.
+func (disk *Informer) Shutdown() error {
+	disk.rpcClient = nil
+	return nil
+}
+
+// Name returns the name of this informer.
+func (disk *Informer) Name() string {
+	return MetricName
+}
+
+// GetMetric uses the IPFSConnector the current
+// repository size and returns it in a metric.
+func (disk *Informer) GetMetric() api.Metric {
+	if disk.rpcClient == nil {
+		return api.Metric{
+			Valid: false,
+		}
+	}
+
+	var repoSize int
+	valid := true
+	err := disk.rpcClient.Call("",
+		"Cluster",
+		"IPFSRepoSize",
+		struct{}{},
+		&repoSize)
+	if err != nil {
+		logger.Error(err)
+		valid = false
+	}
+
+	m := api.Metric{
+		Name:  MetricName,
+		Value: fmt.Sprintf("%d", repoSize),
+		Valid: valid,
+	}
+
+	m.SetTTL(MetricTTL)
+	return m
+}

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -1,0 +1,81 @@
+package disk
+
+import (
+	"errors"
+	"testing"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+
+	"github.com/ipfs/ipfs-cluster/test"
+)
+
+type badRPCService struct {
+	nthCall int
+}
+
+func badRPCClient(t *testing.T) *rpc.Client {
+	s := rpc.NewServer(nil, "mock")
+	c := rpc.NewClientWithServer(nil, "mock", s)
+	err := s.RegisterName("Cluster", &badRPCService{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// func (mock *badRPCService) IPFSConfigKey(in string, out *interface{}) error {
+// 	mock.nthCall++
+// 	switch mock.nthCall {
+// 	case 1:
+// 		return errors.New("fake error the first time you use this mock")
+// 	case 2:
+// 		// don't set out
+// 		return nil
+// 	case 3:
+// 		// don't set to string
+// 		*out = 3
+// 	case 4:
+// 		// non parseable string
+// 		*out = "abc"
+// 	default:
+// 		*out = "10KB"
+// 	}
+// 	return nil
+// }
+
+func (mock *badRPCService) IPFSRepoSize(in struct{}, out *int) error {
+	*out = 2
+	mock.nthCall++
+	return errors.New("fake error")
+}
+
+func Test(t *testing.T) {
+	inf := NewInformer()
+	defer inf.Shutdown()
+	if inf.Name() != "disk" {
+		t.Error("careful when changing the name of an informer")
+	}
+	m := inf.GetMetric()
+	if m.Valid {
+		t.Error("metric should be invalid")
+	}
+	inf.SetClient(test.NewMockRPCClient(t))
+	m = inf.GetMetric()
+	if !m.Valid {
+		t.Error("metric should be valid")
+	}
+	// The mock client reports 100KB and 2 pins of 1 KB
+	if m.Value != "2000" {
+		t.Error("bad metric value")
+	}
+}
+
+func TestWithErrors(t *testing.T) {
+	inf := NewInformer()
+	defer inf.Shutdown()
+	inf.SetClient(badRPCClient(t))
+	m := inf.GetMetric()
+	if m.Valid {
+		t.Errorf("metric should be invalid")
+	}
+}

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -73,7 +73,13 @@ type IPFSConnector interface {
 	PinLs(typeFilter string) (map[string]api.IPFSPinStatus, error)
 	// ConnectSwarms make sure this peer's IPFS daemon is connected to
 	// other peers IPFS daemons.
-	ConnectSwarms()
+	ConnectSwarms() error
+	// ConfigKey returns the value for a configuration key.
+	// Subobjects are reached with keypaths as "Parent/Child/GrandChild...".
+	ConfigKey(keypath string) (interface{}, error)
+	// RepoSize returns the current repository size as expressed
+	// by "repo stat".
+	RepoSize() (int, error)
 }
 
 // Peered represents a component which needs to be aware of the peers

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/ipfs-cluster/allocator/numpinalloc"
+	"github.com/ipfs/ipfs-cluster/allocator/ascendalloc"
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/api/restapi"
-	"github.com/ipfs/ipfs-cluster/informer/numpin"
+	"github.com/ipfs/ipfs-cluster/informer/disk"
 	"github.com/ipfs/ipfs-cluster/ipfsconn/ipfshttp"
 	"github.com/ipfs/ipfs-cluster/monitor/basic"
 	"github.com/ipfs/ipfs-cluster/pintracker/maptracker"
@@ -93,9 +93,9 @@ func createComponents(t *testing.T, i int) (*Config, API, IPFSConnector, state.S
 	state := mapstate.NewMapState()
 	tracker := maptracker.NewMapPinTracker(cfg.ID)
 	mon := basic.NewStdPeerMonitor(cfg.MonitoringIntervalSeconds)
-	alloc := numpinalloc.NewAllocator()
-	numpin.MetricTTL = 1 // second
-	inf := numpin.NewInformer()
+	alloc := ascendalloc.NewAllocator()
+	disk.MetricTTL = 1 // second
+	inf := disk.NewInformer()
 
 	return cfg, api, ipfs, state, tracker, mon, alloc, inf, mock
 }
@@ -664,8 +664,7 @@ func TestClustersReplication(t *testing.T) {
 
 	// Why is replication factor nClusters - 1?
 	// Because that way we know that pinning nCluster
-	// pins with an strategy like numpins (which tries
-	// to make everyone pin the same number of things),
+	// pins with an strategy like numpins/disk
 	// will result in each peer holding locally exactly
 	// nCluster pins.
 

--- a/logging.go
+++ b/logging.go
@@ -12,6 +12,8 @@ var facilities = []string{
 	"consensus",
 	"raft",
 	"pintracker",
+	"ascendalloc",
+	"diskinfo",
 }
 
 // SetFacilityLogLevel sets the log level for a given module

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -219,10 +219,24 @@ func (rpcapi *RPCAPI) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) er
 	return err
 }
 
-// ConnectSwarms runs IPFSConnector.ConnectSwarms().
-func (rpcapi *RPCAPI) ConnectSwarms(in struct{}, out *struct{}) error {
-	rpcapi.c.ipfs.ConnectSwarms()
-	return nil
+// IPFSConnectSwarms runs IPFSConnector.ConnectSwarms().
+func (rpcapi *RPCAPI) IPFSConnectSwarms(in struct{}, out *struct{}) error {
+	err := rpcapi.c.ipfs.ConnectSwarms()
+	return err
+}
+
+// IPFSConfigKey runs IPFSConnector.ConfigKey().
+func (rpcapi *RPCAPI) IPFSConfigKey(in string, out *interface{}) error {
+	res, err := rpcapi.c.ipfs.ConfigKey(in)
+	*out = res
+	return err
+}
+
+// IPFSRepoSize runs IPFSConnector.RepoSize().
+func (rpcapi *RPCAPI) IPFSRepoSize(in struct{}, out *int) error {
+	res, err := rpcapi.c.ipfs.RepoSize()
+	*out = res
+	return err
 }
 
 /*

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -45,6 +45,17 @@ type idResp struct {
 	Addresses []string
 }
 
+type repoStatResp struct {
+	RepoSize  int
+	RepoCount int
+}
+
+type configResp struct {
+	Datastore struct {
+		StorageMax string
+	}
+}
+
 // NewIpfsMock returns a new mock.
 func NewIpfsMock() *IpfsMock {
 	st := mapstate.NewMapState()
@@ -163,6 +174,24 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 			Strings []string
 		}{
 			Strings: []string{fmt.Sprintf("connect %s success", pid)},
+		}
+		j, _ := json.Marshal(resp)
+		w.Write(j)
+	case "repo/stat":
+		len := len(m.pinMap.List())
+		resp := repoStatResp{
+			RepoSize:  len * 1000,
+			RepoCount: len,
+		}
+		j, _ := json.Marshal(resp)
+		w.Write(j)
+	case "config/show":
+		resp := configResp{
+			Datastore: struct {
+				StorageMax string
+			}{
+				StorageMax: "10G",
+			},
 		}
 		j, _ := json.Marshal(resp)
 		w.Write(j)

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -241,6 +241,22 @@ func (mock *mockService) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus)
 	return nil
 }
 
-func (mock *mockService) ConnectSwarms(in struct{}, out *struct{}) error {
+func (mock *mockService) IPFSConnectSwarms(in struct{}, out *struct{}) error {
+	return nil
+}
+
+func (mock *mockService) IPFSConfigKey(in string, out *interface{}) error {
+	switch in {
+	case "Datastore/StorageMax":
+		*out = "100KB"
+	default:
+		return errors.New("configuration key not found")
+	}
+	return nil
+}
+
+func (mock *mockService) IPFSRepoSize(in struct{}, out *int) error {
+	// since we have two pins. Assume each is 1KB.
+	*out = 2000
 	return nil
 }


### PR DESCRIPTION
The disk informer uses "ipfs repo stat" to fetch the RepoSize value and
uses it as a metric.

The numpinalloc allocator is now a generalized ascendalloc which
sorts metrics in ascending order and return the ones with lowest
values.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>