### PR TITLE
Fixes #100: EOF responses when cluster peer is not responding

### DIFF
--- a/api/restapi/restapi.go
+++ b/api/restapi/restapi.go
@@ -28,12 +28,12 @@ var logger = logging.Logger("restapi")
 // Server settings
 var (
 	// maximum duration before timing out read of the request
-	RESTAPIServerReadTimeout = 5 * time.Second
+	RESTAPIServerReadTimeout = 30 * time.Second
 	// maximum duration before timing out write of the response
-	RESTAPIServerWriteTimeout = 10 * time.Second
+	RESTAPIServerWriteTimeout = 60 * time.Second
 	// server-side the amount of time a Keep-Alive connection will be
 	// kept idle before being reused
-	RESTAPIServerIdleTimeout = 60 * time.Second
+	RESTAPIServerIdleTimeout = 120 * time.Second
 )
 
 // RESTAPI implements an API and aims to provides

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -97,10 +97,10 @@ func textFormatPrintIDSerial(obj *api.IDSerial) {
 }
 
 func textFormatPrintGPinfo(obj *api.GlobalPinInfoSerial) {
-	fmt.Printf("%s:\n", obj.Cid)
+	fmt.Printf("%s :\n", obj.Cid)
 	for k, v := range obj.PeerMap {
 		if v.Error != "" {
-			fmt.Printf("  > Peer %s: ERROR | %s\n", k, v.Error)
+			fmt.Printf("    > Peer %s: ERROR | %s\n", k, v.Error)
 			continue
 		}
 		fmt.Printf("    > Peer %s: %s | %s\n", k, strings.ToUpper(v.Status), v.TS)


### PR DESCRIPTION
The ReadTimeout for the API was the same as for RPC. So the error
did not have time to be correctly returned to the client.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>