### PR TITLE
Private Network impl

### DIFF
--- a/allocator/ascendalloc/ascendalloc.go
+++ b/allocator/ascendalloc/ascendalloc.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	peer "github.com/libp2p/go-libp2p-peer"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 var logger = logging.Logger("ascendalloc")

--- a/allocator/ascendalloc/ascendalloc_test.go
+++ b/allocator/ascendalloc/ascendalloc_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/informer/numpin"
 
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 type testcase struct {

--- a/api/restapi/restapi.go
+++ b/api/restapi/restapi.go
@@ -14,13 +14,13 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	mux "github.com/gorilla/mux"
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr-net"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	manet "gx/ipfs/QmVCNGTyD4EkvNYaAp253uMQ9Rjsjy2oGMvcdJJUoVRfja/go-multiaddr-net"
+	mux "gx/ipfs/QmVrBjGjskzhW7HRfC56f4mT3nmNBHj2WWnEXr39G7Y6w8/mux"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 var logger = logging.Logger("restapi")

--- a/api/restapi/restapi_test.go
+++ b/api/restapi/restapi_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"
 
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
 )
 
 var (

--- a/api/types.go
+++ b/api/types.go
@@ -11,10 +11,10 @@ package api
 import (
 	"time"
 
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
-	protocol "github.com/libp2p/go-libp2p-protocol"
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 // TrackerStatus values

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 var testTime = time.Date(2017, 12, 31, 15, 45, 50, 0, time.UTC)

--- a/cluster.go
+++ b/cluster.go
@@ -13,19 +13,17 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/consensus/raft"
 	"github.com/ipfs/ipfs-cluster/state"
+	pnet "github.com/libp2p/go-libp2p-pnet"
 
 	peerstore "gx/ipfs/QmQMQ2RUjnaEEX8ybmrhuFFGhAwPjyL1Eo6ZoJGD7aAccM/go-libp2p-peerstore"
 	basichost "gx/ipfs/QmSNJRX4uphb3Eyp69uYbpRVvgqjPxfjnJmjcdMWkDH5Pn/go-libp2p/p2p/host/basic"
 	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	ipnet "gx/ipfs/QmUxRRPqCRmjgZajYGDhUt4MNZFvT8sgry7YkA4ap7qLUP/go-libp2p-interface-pnet"
 	swarm "gx/ipfs/QmY8hduizbuACvYmL4aZQbpFeKhEQJ1Nom2jY6kv6rL8Gf/go-libp2p-swarm"
 	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
 	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 	host "gx/ipfs/QmbzbRyd22gcW92U1rA2yKagB3myMYhk45XBknJ49F9XWJ/go-libp2p-host"
 	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
-
-	//pnet "github.com/libp2p/go-libp2p-pnet"
-	pnet "github.com/libp2p/go-libp2p-pnet"
-	ipnet "gx/ipfs/QmUxRRPqCRmjgZajYGDhUt4MNZFvT8sgry7YkA4ap7qLUP/go-libp2p-interface-pnet"
 )
 
 // Cluster is the main IPFS cluster component. It provides
@@ -878,7 +876,7 @@ func makeHost(ctx context.Context, cfg *Config) (host.Host, error) {
 			return nil, err
 		}
 		cfg.PNetFingerprint = protec.Fingerprint()
-		/* this is in go-ipfs, not sure whether we want it here */
+		// this is in go-ipfs, not sure whether we want something like it here
 		/* go func() {
 			t := time.NewTicker(30 * time.Second)
 			<-t.C // swallow one tick

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 	"github.com/ipfs/ipfs-cluster/test"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	cid "github.com/ipfs/go-cid"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 type mockComponent struct {

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -11,13 +11,13 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/state"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	logging "github.com/ipfs/go-log"
-	consensus "github.com/libp2p/go-libp2p-consensus"
-	host "github.com/libp2p/go-libp2p-host"
-	peer "github.com/libp2p/go-libp2p-peer"
-	libp2praft "github.com/libp2p/go-libp2p-raft"
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	libp2praft "gx/ipfs/QmW92B7boZiW7qBEUE2aT8vi3WNLWpk6on4mxg1CpEzLpB/go-libp2p-raft"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	consensus "gx/ipfs/QmZ88KbrvZMJpXaNwAGffswcYKz8EbeafzAFGMCA6MEZKt/go-libp2p-consensus"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	host "gx/ipfs/QmbzbRyd22gcW92U1rA2yKagB3myMYhk45XBknJ49F9XWJ/go-libp2p-host"
 )
 
 var logger = logging.Logger("consensus")

--- a/consensus/raft/consensus_test.go
+++ b/consensus/raft/consensus_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 	"github.com/ipfs/ipfs-cluster/test"
 
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	crypto "github.com/libp2p/go-libp2p-crypto"
-	host "github.com/libp2p/go-libp2p-host"
-	peer "github.com/libp2p/go-libp2p-peer"
-	peerstore "github.com/libp2p/go-libp2p-peerstore"
-	swarm "github.com/libp2p/go-libp2p-swarm"
-	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
-	ma "github.com/multiformats/go-multiaddr"
+	crypto "gx/ipfs/QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuUi/go-libp2p-crypto"
+	peerstore "gx/ipfs/QmQMQ2RUjnaEEX8ybmrhuFFGhAwPjyL1Eo6ZoJGD7aAccM/go-libp2p-peerstore"
+	basichost "gx/ipfs/QmSNJRX4uphb3Eyp69uYbpRVvgqjPxfjnJmjcdMWkDH5Pn/go-libp2p/p2p/host/basic"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	swarm "gx/ipfs/QmY8hduizbuACvYmL4aZQbpFeKhEQJ1Nom2jY6kv6rL8Gf/go-libp2p-swarm"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	host "gx/ipfs/QmbzbRyd22gcW92U1rA2yKagB3myMYhk45XBknJ49F9XWJ/go-libp2p-host"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 var p2pPort = 10000

--- a/consensus/raft/log_op.go
+++ b/consensus/raft/log_op.go
@@ -7,10 +7,10 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/state"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	consensus "github.com/libp2p/go-libp2p-consensus"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	consensus "gx/ipfs/QmZ88KbrvZMJpXaNwAGffswcYKz8EbeafzAFGMCA6MEZKt/go-libp2p-consensus"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 )
 
 // Type of consensus operation

--- a/consensus/raft/log_op_test.go
+++ b/consensus/raft/log_op_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	cid "github.com/ipfs/go-cid"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"time"
 
-	hashiraft "github.com/hashicorp/raft"
-	raftboltdb "github.com/hashicorp/raft-boltdb"
-	logging "github.com/ipfs/go-log"
-	host "github.com/libp2p/go-libp2p-host"
-	peer "github.com/libp2p/go-libp2p-peer"
-	libp2praft "github.com/libp2p/go-libp2p-raft"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	raftboltdb "gx/ipfs/QmUDCcPkPMPJ149YBpfFLWJtRFeqace5GNdBPD2cW4Z8E6/raft-boltdb"
+	libp2praft "gx/ipfs/QmW92B7boZiW7qBEUE2aT8vi3WNLWpk6on4mxg1CpEzLpB/go-libp2p-raft"
+	hashiraft "gx/ipfs/QmWRzh5sntXhuZaxmGDEjjBhg1nX7DgaMdhBeik42LZdEv/raft"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	host "gx/ipfs/QmbzbRyd22gcW92U1rA2yKagB3myMYhk45XBknJ49F9XWJ/go-libp2p-host"
 )
 
 // DefaultRaftConfig allows to tweak Raft configuration used by Cluster from

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -6,8 +6,8 @@ package disk
 import (
 	"fmt"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	logging "github.com/ipfs/go-log"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
 
 	"github.com/ipfs/ipfs-cluster/api"
 )

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
 
 	"github.com/ipfs/ipfs-cluster/test"
 )

--- a/informer/numpin/numpin.go
+++ b/informer/numpin/numpin.go
@@ -5,7 +5,7 @@ package numpin
 import (
 	"fmt"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
 
 	"github.com/ipfs/ipfs-cluster/api"
 )

--- a/informer/numpin/numpin_test.go
+++ b/informer/numpin/numpin_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
 )
 
 type mockService struct{}

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
-	cli "github.com/urfave/cli"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cli "gx/ipfs/Qmc1AtgBdoUHP8oYSqU81NRYdzohmF45t5XNwVMvhCxsBA/cli"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 const programName = `ipfs-cluster-ctl`

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -11,9 +11,9 @@ import (
 
 	//	_ "net/http/pprof"
 
-	logging "github.com/ipfs/go-log"
-	ma "github.com/multiformats/go-multiaddr"
-	"github.com/urfave/cli"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	"gx/ipfs/Qmc1AtgBdoUHP8oYSqU81NRYdzohmF45t5XNwVMvhCxsBA/cli"
 
 	ipfscluster "github.com/ipfs/ipfs-cluster"
 	"github.com/ipfs/ipfs-cluster/allocator/ascendalloc"
@@ -104,11 +104,14 @@ var (
 	DefaultConfigFile = "service.json"
 	// The name of the data folder inside DefaultPath
 	DefaultDataFolder = "data"
+	// The name of the swarm key for pnets inside of DefaultPath
+	DefaultSwarmKeyFile = "swarm.key"
 )
 
 var (
-	configPath string
-	dataPath   string
+	configPath   string
+	dataPath     string
+	swarmKeyPath string
 )
 
 func init() {
@@ -210,6 +213,7 @@ func main() {
 
 		configPath = filepath.Join(absPath, DefaultConfigFile)
 		dataPath = filepath.Join(absPath, DefaultDataFolder)
+		swarmKeyPath = filepath.Join(absPath, DefaultSwarmKeyFile)
 
 		setupLogging(c.String("loglevel"))
 		if c.Bool("debug") {
@@ -354,4 +358,8 @@ func initConfig(force bool) {
 
 func loadConfig() (*ipfscluster.Config, error) {
 	return ipfscluster.LoadConfig(configPath)
+}
+
+func loadSwarmKey() ([]byte, error) {
+	return ipfscluster.LoadSwarmKey(swarmKeyPath)
 }

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -12,11 +12,11 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/state"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
-	protocol "github.com/libp2p/go-libp2p-protocol"
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 // RPCProtocol is used to send libp2p messages between cluster peers

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 	"github.com/ipfs/ipfs-cluster/test"
 
-	cid "github.com/ipfs/go-cid"
-	crypto "github.com/libp2p/go-libp2p-crypto"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
+	crypto "gx/ipfs/QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuUi/go-libp2p-crypto"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 //TestClusters*

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -20,12 +20,12 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr-net"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	manet "gx/ipfs/QmVCNGTyD4EkvNYaAp253uMQ9Rjsjy2oGMvcdJJUoVRfja/go-multiaddr-net"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 var logger = logging.Logger("ipfshttp")

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"
 
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr-net"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	manet "gx/ipfs/QmVCNGTyD4EkvNYaAp253uMQ9Rjsjy2oGMvcdJJUoVRfja/go-multiaddr-net"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 func init() {

--- a/logging.go
+++ b/logging.go
@@ -1,6 +1,6 @@
 package ipfscluster
 
-import logging "github.com/ipfs/go-log"
+import logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 
 var logger = logging.Logger("cluster")
 

--- a/monitor/basic/peer_monitor.go
+++ b/monitor/basic/peer_monitor.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	logging "github.com/ipfs/go-log"
-	peer "github.com/libp2p/go-libp2p-peer"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 
 	"github.com/ipfs/ipfs-cluster/api"
 )

--- a/monitor/basic/peer_monitor_test.go
+++ b/monitor/basic/peer_monitor_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -4,9 +4,9 @@ import (
 	"sync"
 	"time"
 
-	peer "github.com/libp2p/go-libp2p-peer"
-	peerstore "github.com/libp2p/go-libp2p-peerstore"
-	ma "github.com/multiformats/go-multiaddr"
+	peerstore "gx/ipfs/QmQMQ2RUjnaEEX8ybmrhuFFGhAwPjyL1Eo6ZoJGD7aAccM/go-libp2p-peerstore"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 )
 
 // peerManager is our own local peerstore

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"
 
-	cid "github.com/ipfs/go-cid"
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 func peerManagerClusters(t *testing.T) ([]*Cluster, []*test.IpfsMock) {

--- a/pintracker/maptracker/maptracker.go
+++ b/pintracker/maptracker/maptracker.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	peer "github.com/libp2p/go-libp2p-peer"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 var logger = logging.Logger("pintracker")

--- a/pintracker/maptracker/maptracker_test.go
+++ b/pintracker/maptracker/maptracker_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -3,7 +3,7 @@ package ipfscluster
 import (
 	"errors"
 
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 
 	"github.com/ipfs/ipfs-cluster/api"
 )

--- a/state/interface.go
+++ b/state/interface.go
@@ -6,8 +6,8 @@ package state
 import (
 	"io"
 
-	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/ipfs-cluster/api"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 // State is used by the Consensus component to keep track of

--- a/state/mapstate/map_state.go
+++ b/state/mapstate/map_state.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	cid "github.com/ipfs/go-cid"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 // Version is the map state Version. States with old versions should

--- a/state/mapstate/map_state_test.go
+++ b/state/mapstate/map_state_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 
 	"github.com/ipfs/ipfs-cluster/api"
 )

--- a/test/cids.go
+++ b/test/cids.go
@@ -1,6 +1,6 @@
 package test
 
-import peer "github.com/libp2p/go-libp2p-peer"
+import peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 
 // Common variables used all arround tests.
 var (

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 
-	cid "github.com/ipfs/go-cid"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 // IpfsMock is an ipfs daemon mock which should sustain the functionality used by ipfscluster.

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	rpc "github.com/hsanjuan/go-libp2p-gorpc"
-	cid "github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-peer"
+	rpc "gx/ipfs/QmYqnvVzUjjVddWPLGMAErUjNBqnyjoeeCgZUZFsAJeGHr/go-libp2p-gorpc"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 // ErrBadCid is returned when using ErrorCid. Operations with that CID always

--- a/util.go
+++ b/util.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
-	host "github.com/libp2p/go-libp2p-host"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	host "gx/ipfs/QmbzbRyd22gcW92U1rA2yKagB3myMYhk45XBknJ49F9XWJ/go-libp2p-host"
 )
 
 // The copy functions below are used in calls to Cluste.multiRPC()


### PR DESCRIPTION
Currently working through dependency issues -- here's a write-up on that as requested by @hsanjuan (also tagging @Kubuxu and @whyrusleeping in case they have any immediate suggestions):

1. I included the imports for `go-libp2p-pnet` and `go-libp2p-interface-pnet` as:

```go
import (
    ...
    pnet "github.com/libp2p/go-libp2p-pnet"
    ipnet "github.com/libp2p/go-libp2p-interface-pnet"
    ...
)
```

Then ran `gx-go rewrite --fix && gx-go rewrite`. `go-libp2p-interface-pnet` resolved to a hash, but `go-libp2p-pnet` did not:

```go
import (
    ...
    pnet "github.com/libp2p/go-libp2p-pnet"
    ipnet "gx/ipfs/QmUxRRPqCRmjgZajYGDhUt4MNZFvT8sgry7YkA4ap7qLUP/go-libp2p-interface-pnet"
    ...
)
```

2. I tried to `go build` at this point, but I got the error:

```go
# github.com/ipfs/ipfs-cluster
./cluster.go:874: cannot assign "github.com/libp2p/go-libp2p-interface-pnet".Protector to protec (type "gx/ipfs/QmUxRRPqCRmjgZajYGDhUt4MNZFvT8sgry7YkA4ap7qLUP/go-libp2p-interface-pnet".Protector) in multiple assignment:
	"github.com/libp2p/go-libp2p-interface-pnet".Protector does not implement "gx/ipfs/QmUxRRPqCRmjgZajYGDhUt4MNZFvT8sgry7YkA4ap7qLUP/go-libp2p-interface-pnet".Protector (wrong type for Protect method)
		have Protect("github.com/libp2p/go-libp2p-transport".Conn) ("github.com/libp2p/go-libp2p-transport".Conn, error)
		want Protect("gx/ipfs/QmcYnysCkyGezY6k6MQ1yHHdrRiZaU9x3M9Y1tE9qZ5hD2/go-libp2p-interface-conn".Conn) ("gx/ipfs/QmcYnysCkyGezY6k6MQ1yHHdrRiZaU9x3M9Y1tE9qZ5hD2/go-libp2p-interface-conn".Conn, error)
```

I think (based on my very incomplete understanding of `go` and `gx`) that the issue is with [this import in `go-libp2p-pnet`](https://github.com/libp2p/go-libp2p-pnet/blob/master/protector.go#L6), which doesn't use the `gx` hash to import `go-libp2p-interface-pnet`.

3. I tried various fixes from here, but I now think they were quite ill-informed and probably not too helpful to write-up. I think one way to fix this would be to remove all of the `gx` imports from this project and make them `github.com/<repo>/<project>` imports, as they were before. Another solution might be to change the import in the `go-libp2p-pnet` project that I mentioned above to be the corresponding `gx` import rather than the `github.com/libp2p/go-libp2p-interface-pnet` import (but this might be a rabbit hole into doing this for other repos as well -- maybe it's preferred to get them all changed to `gx` imports anyway, and this would be a good time to do it?).