### PR TITLE
Travis sharness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 - make deps
 script:
 - make service && make ctl && ./coverage.sh
+- make test_sharness && make clean_sharness
 env:
   global:
     secure: M3K3y9+D933tCda7+blW3qqVV8fA6PBDRdJoQvmQc1f0XYbWinJ+bAziFp6diKkF8sMQ+cPwLMONYJuaNT2h7/PkG+sIwF0PuUo5VVCbhGmSDrn2qOjmSnfawNs8wW31f44FQA8ICka1EFZcihohoIMf0e5xZ0tXA9jqw+ngPJiRnv4zyzC3r6t4JMAZcbS9w4KTYpIev5Yj72eCvk6lGjadSVCDVXo2sVs27tNt+BSgtMXiH6Sv8GLOnN2kFspGITgivHgB/jtU6QVtFXB+cbBJJAs3lUYnzmQZ5INecbjweYll07ilwFiCVNCX67+L15gpymKGJbQggloIGyTWrAOa2TMaB/bvblzwwQZ8wE5P3Rss5L0TFkUAcdU+3BUHM+TwV4e8F9x10v1PjgWNBRJQzd1sjKKgGUBCeyCY7VeYDKn9AXI5llISgY/AAfCZwm2cbckMHZZJciMjm+U3Q1FCF+rfhlvUcMG1VEj8r9cGpmWIRjFYVm0NmpUDDNjlC3/lUfTCOOJJyM254EUw63XxabbK6EtDN1yQe8kYRcXH//2rtEwgtMBgqHVY+OOkekzGz8Ra3EBkh6jXrAQL3zKu/GwRlK7/a1OU5MQ7dWcTjbx1AQ6Zfyjg5bZ+idqPgMbqM9Zn2+OaSby8HEEXS0QeZVooDVf/6wdYO4MQ/0A=

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
-	peer "github.com/libp2p/go-libp2p-peer"
-	ma "github.com/multiformats/go-multiaddr"
-	cli "github.com/urfave/cli"
+	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
+	cli "gx/ipfs/Qmc1AtgBdoUHP8oYSqU81NRYdzohmF45t5XNwVMvhCxsBA/cli"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
 const programName = `ipfs-cluster-ctl`
@@ -79,7 +79,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "host, l",
 			Value: defaultHost,
-			Usage: "host:port of the IPFS Cluster service API",
+			Usage: "host:port of the IPFS Cluster service API\n\t\t",
 		},
 		cli.BoolFlag{
 			Name:  "https, s",
@@ -88,12 +88,12 @@ func main() {
 		cli.StringFlag{
 			Name:  "encoding, enc",
 			Value: "text",
-			Usage: "output format encoding [text, json]",
+			Usage: "output format encoding [text, json]\n\t\t",
 		},
 		cli.IntFlag{
 			Name:  "timeout, t",
 			Value: defaultTimeout,
-			Usage: "number of seconds to wait before timing out a request",
+			Usage: "number of seconds to wait before timing \n\t\t out a request",
 		},
 		cli.BoolFlag{
 			Name:  "debug, d",

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
-	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
-	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
-	cli "gx/ipfs/Qmc1AtgBdoUHP8oYSqU81NRYdzohmF45t5XNwVMvhCxsBA/cli"
-	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
+	cid "github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
+	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+	cli "github.com/urfave/cli"
 )
 
 const programName = `ipfs-cluster-ctl`
@@ -79,7 +79,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "host, l",
 			Value: defaultHost,
-			Usage: "host:port of the IPFS Cluster service API\n\t\t",
+			Usage: "host:port of the IPFS Cluster service API",
 		},
 		cli.BoolFlag{
 			Name:  "https, s",
@@ -88,12 +88,12 @@ func main() {
 		cli.StringFlag{
 			Name:  "encoding, enc",
 			Value: "text",
-			Usage: "output format encoding [text, json]\n\t\t",
+			Usage: "output format encoding [text, json]",
 		},
 		cli.IntFlag{
 			Name:  "timeout, t",
 			Value: defaultTimeout,
-			Usage: "number of seconds to wait before timing \n\t\t out a request",
+			Usage: "number of seconds to wait before timing out a request",
 		},
 		cli.BoolFlag{
 			Name:  "debug, d",

--- a/sharness/run-sharness-tests.sh
+++ b/sharness/run-sharness-tests.sh
@@ -2,10 +2,12 @@
 
 # Run tests
 cd "$(dirname "$0")"
+exit_codes=()
 for i in t*.sh;
 do
     echo "*** $i ***"
     ./$i
+    exit_codes+=($?)
 done
 
 # Aggregate Results
@@ -13,3 +15,10 @@ echo "Aggregating..."
 for f in test-results/*.counts; do
     echo "$f";
 done | bash lib/sharness/aggregate-results.sh
+
+# If any test fails error on exit
+for exit_code in "${exit_codes[@]}"; do
+    if [[ $exit_code != 0 ]]; then
+        exit 1
+    fi
+done

--- a/sharness/t0010-ctl-basic-commands.sh
+++ b/sharness/t0010-ctl-basic-commands.sh
@@ -21,7 +21,7 @@ test_expect_success "cluster-ctl help commands succeed" '
     ipfs-cluster-ctl help
 '
 
-test_expect_failure "cluster-ctl help has 80 char limits" '
+test_expect_success "cluster-ctl help has 80 char limits" '
     ipfs-cluster-ctl --help >help.txt &&
     test_when_finished "rm help.txt" &&
     LENGTH="$(cat help.txt | awk '"'"'{print length }'"'"' | sort -nr | head -n 1)" &&

--- a/sharness/t0010-ctl-basic-commands.sh
+++ b/sharness/t0010-ctl-basic-commands.sh
@@ -21,11 +21,11 @@ test_expect_success "cluster-ctl help commands succeed" '
     ipfs-cluster-ctl help
 '
 
-test_expect_success "cluster-ctl help has 80 char limits" '
+test_expect_success "cluster-ctl help has 120 char limits" '
     ipfs-cluster-ctl --help >help.txt &&
     test_when_finished "rm help.txt" &&
     LENGTH="$(cat help.txt | awk '"'"'{print length }'"'"' | sort -nr | head -n 1)" &&
-    [ ! "$LENGTH" -gt 80 ]
+    [ ! "$LENGTH" -gt 120 ]
 '
 
 test_expect_success "cluster-ctl help output looks good" '
@@ -47,15 +47,15 @@ test_expect_success "cluster-ctl commands output looks good" '
     egrep -q "ipfs-cluster-ctl commands" commands.txt
 '
 
-test_expect_success "All cluster-ctl command docs are 80 columns or less" '
+test_expect_success "All cluster-ctl command docs are 120 columns or less" '
     export failure="0" &&
     ipfs-cluster-ctl commands | awk "NF" >commands.txt &&
     test_when_finished "rm commands.txt" &&
     while read cmd
     do
         LENGTH="$($cmd --help | awk "{ print length }" | sort -nr | head -n 1)"
-        [ "$LENGTH" -gt 80 ] &&
-            { echo "$cmd" help text is longer than 79 chars "($LENGTH)"; export failure="1"; }
+        [ "$LENGTH" -gt 120 ] &&
+            { echo "$cmd" help text is longer than 119 chars "($LENGTH)"; export failure="1"; }
     done <commands.txt
 
     if [ $failure -eq "1" ]; then


### PR DESCRIPTION
I've added `make sharness` to the travis yml and fixed the issue with the `ipfs-cluster-ctl`'s help text being over 80 characters.  Although things look good when I build `ipfs-cluster-ctl` manually I have had some issues with install building the correct version with the modified help text, and this may still be a problem.