### PR TITLE
Re-allocate pins on peer removal

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1112,8 +1112,8 @@ func (c *Cluster) allocate(hash *cid.Cid, repl int, blacklist []peer.ID) ([]peer
 		return validAllocations[0 : len(validAllocations)+needed], nil
 	case candidatesValid < needed:
 		err = logError(
-			"not enough candidates to allocate %s. Needed: %d. Got: %s",
-			hash, needed, candidates)
+			"not enough candidates to allocate %s. Needed: %d. Got: %d (%s)",
+			hash, needed, candidatesValid, candidates)
 		return nil, err
 	default:
 		// this will return candidate peers in order of
@@ -1126,10 +1126,10 @@ func (c *Cluster) allocate(hash *cid.Cid, repl int, blacklist []peer.ID) ([]peer
 		logger.Debugf("allocate: candidate allocations: %s", candidateAllocs)
 
 		// we don't have enough peers to pin
-		if len(candidateAllocs) < needed {
+		if got := len(candidateAllocs); got < needed {
 			err = logError(
-				"cannot find enough allocations for %s. Needed: %d. Got: %s",
-				hash, needed, candidateAllocs)
+				"cannot find enough allocations for %s. Needed: %d. Got: %d (%s)",
+				hash, needed, got, candidateAllocs)
 			return nil, err
 		}
 

--- a/cluster.go
+++ b/cluster.go
@@ -1112,8 +1112,8 @@ func (c *Cluster) allocate(hash *cid.Cid, repl int, blacklist []peer.ID) ([]peer
 		return validAllocations[0 : len(validAllocations)+needed], nil
 	case candidatesValid < needed:
 		err = logError(
-			"not enough candidates to allocate %s. Needed: %d. Got: %d",
-			hash, needed, candidatesValid)
+			"not enough candidates to allocate %s. Needed: %d. Got: %s",
+			hash, needed, candidates)
 		return nil, err
 	default:
 		// this will return candidate peers in order of
@@ -1128,7 +1128,7 @@ func (c *Cluster) allocate(hash *cid.Cid, repl int, blacklist []peer.ID) ([]peer
 		// we don't have enough peers to pin
 		if len(candidateAllocs) < needed {
 			err = logError(
-				"cannot find enough allocations for %s. Needed: %d. Got: %d",
+				"cannot find enough allocations for %s. Needed: %d. Got: %s",
 				hash, needed, candidateAllocs)
 			return nil, err
 		}

--- a/cluster.go
+++ b/cluster.go
@@ -1112,7 +1112,7 @@ func (c *Cluster) allocate(hash *cid.Cid, repl int, blacklist []peer.ID) ([]peer
 		return validAllocations[0 : len(validAllocations)+needed], nil
 	case candidatesValid < needed:
 		err = logError(
-			"not enough candidates to allocate %s. Needed: %d. Got: %s",
+			"not enough candidates to allocate %s. Needed: %d. Got: %d",
 			hash, needed, candidatesValid)
 		return nil, err
 	default:
@@ -1128,7 +1128,7 @@ func (c *Cluster) allocate(hash *cid.Cid, repl int, blacklist []peer.ID) ([]peer
 		// we don't have enough peers to pin
 		if len(candidateAllocs) < needed {
 			err = logError(
-				"cannot find enough allocations for %s. Needed: %d. Got: %s",
+				"cannot find enough allocations for %s. Needed: %d. Got: %d",
 				hash, needed, candidateAllocs)
 			return nil, err
 		}

--- a/docs/ipfs-cluster-guide.md
+++ b/docs/ipfs-cluster-guide.md
@@ -126,9 +126,8 @@ Static clusters expect every member peer to be up and responding. Otherwise, the
 
 We call a dynamic cluster, that in which the set of `cluster_peers` changes. Nodes are bootstrapped to existing cluster peers, the "peer add" and "peer rm" operations are used and/or the `leave_on_shutdown` configuration option is enabled. This option allows a node to abandon the consensus membership when shutting down. Thus reducing the cluster size by one.
 
-Dynamic clusters allow greater flexibility at the cost of stablity. Join and leave operations are tricky as they change the consensus membership and they are likely to create bad situations in unhealthy clusters.
+Dynamic clusters allow greater flexibility at the cost of stablity. Join and leave operations are tricky as they change the consensus membership and they are likely to create bad situations in unhealthy clusters. Also, bear in mind than removing a peer from the cluster will trigger a re-allocation of the pins that were associated to it. If the replication factor was 1, it is recommended to keep the ipfs daemon running so the content can actually be copied out to a daemon managed by a different peer.
 
-Also, *currently*, pins allocated to a peer that left the cluster are not re-allocated to new peers.
 
 The best way to diagnose and fix a broken cluster membership issue is to:
 
@@ -140,6 +139,8 @@ The best way to diagnose and fix a broken cluster membership issue is to:
 wrong peer count, stop them, fix `cluster_peers` manually and restart them.
 * `ipfs-cluster-ctl --enc=json peers ls` provides additional useful information, like the list of peers for every responding peer.
 * In cases were no Leader can be elected, then manual stop and editing of `cluster_peers` is necessary.
+
+
 
 
 ## Pinning an item

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -937,7 +937,7 @@ func TestClustersReplicationNotEnoughPeers(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if !strings.Contains(err.Error(), "enough allocations") {
+	if !strings.Contains(err.Error(), "not enough candidates") {
 		t.Error("different error than expected")
 		t.Error(err)
 	}

--- a/util.go
+++ b/util.go
@@ -144,3 +144,12 @@ func logError(fmtstr string, args ...interface{}) error {
 	logger.Error(msg)
 	return errors.New(msg)
 }
+
+func containsPeer(list []peer.ID, peer peer.ID) bool {
+	for _, p := range list {
+		if p == peer {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
PeerRm now triggers re-pinning of all the Cids allocated to
the removed peer.

#86 

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>