### PR TITLE
Fix #97: Assume default DataFolder as subfolder to config folder when empty

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -159,10 +159,15 @@ func (c *Cluster) setupConsensus() error {
 		startPeers = peersFromMultiaddrs(c.config.Bootstrap)
 	}
 
+	dataFolder := c.config.ConsensusDataFolder
+	if dataFolder == "" {
+		dataFolder = filepath.Join(filepath.Dir(c.config.path), DefaultDataFolder)
+	}
+
 	consensus, err := raft.NewConsensus(
 		append(startPeers, c.id),
 		c.host,
-		c.config.ConsensusDataFolder,
+		dataFolder,
 		c.state)
 	if err != nil {
 		logger.Errorf("error creating consensus: %s", err)

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ const (
 	DefaultStateSyncSeconds          = 60
 	DefaultIPFSSyncSeconds           = 130
 	DefaultMonitoringIntervalSeconds = 15
+	DefaultDataFolder                = "ipfs-cluster-data"
 )
 
 // Config represents an ipfs-cluster configuration. It is used by
@@ -73,7 +74,7 @@ type Config struct {
 	IPFSNodeAddr ma.Multiaddr
 
 	// Storage folder for snapshots, log store etc. Used by
-	// the Consensus component.
+	// the Consensus component. The folder should exist.
 	ConsensusDataFolder string
 
 	// Number of seconds between automatic calls to StateSync().
@@ -149,8 +150,10 @@ type JSONConfig struct {
 	IPFSNodeMultiaddress string `json:"ipfs_node_multiaddress"`
 
 	// Storage folder for snapshots, log store etc. Used by
-	// the Consensus component.
-	ConsensusDataFolder string `json:"consensus_data_folder"`
+	// the Consensus component. When empty, it defaults to an
+	// "ipfs-cluster-data" subfolder from which the configuration
+	// file was read. Otherwise, it uses the value specified.
+	ConsensusDataFolder string `json:"consensus_data_folder,omitempty"`
 
 	// Number of seconds between syncs of the consensus state to the
 	// tracker state. Normally states are synced anyway, but this helps
@@ -486,7 +489,7 @@ func NewDefaultConfig() (*Config, error) {
 		APIAddr:                   apiAddr,
 		IPFSProxyAddr:             ipfsProxyAddr,
 		IPFSNodeAddr:              ipfsNodeAddr,
-		ConsensusDataFolder:       "ipfscluster-data",
+		ConsensusDataFolder:       "",
 		StateSyncSeconds:          DefaultStateSyncSeconds,
 		IPFSSyncSeconds:           DefaultIPFSSyncSeconds,
 		ReplicationFactor:         -1,

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -102,6 +103,12 @@ func NewRaft(peers []peer.ID, host host.Host, dataFolder string, fsm hashiraft.F
 	pstore.SetPeers(peersStr)
 
 	logger.Debug("creating file snapshot store")
+	err = os.MkdirAll(dataFolder, 0700)
+	if err != nil {
+		logger.Errorf("creating cosensus data folder (%s): %s",
+			dataFolder, err)
+		return nil, err
+	}
 	snapshots, err := hashiraft.NewFileSnapshotStoreWithLogger(dataFolder, RaftMaxSnapshots, raftStdLogger)
 	if err != nil {
 		logger.Error("creating file snapshot store: ", err)

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -103,18 +103,16 @@ var (
 	DefaultPath = ".ipfs-cluster"
 	// The name of the configuration file inside DefaultPath
 	DefaultConfigFile = "service.json"
-	// The name of the data folder inside DefaultPath
-	DefaultDataFolder = "data"
 )
 
 var (
 	configPath string
-	dataPath   string
 )
 
 func init() {
-	// The only way I could make this work
+	// Set the right commit. The only way I could make this work
 	ipfscluster.Commit = commit
+
 	usr, err := user.Current()
 	if err != nil {
 		panic("cannot guess the current user")
@@ -222,7 +220,6 @@ func main() {
 		}
 
 		configPath = filepath.Join(absPath, DefaultConfigFile)
-		dataPath = filepath.Join(absPath, DefaultDataFolder)
 
 		setupLogging(c.String("loglevel"))
 		if c.Bool("debug") {
@@ -371,7 +368,6 @@ func initConfig(force bool, generateSecret bool, envSecret string) {
 		checkErr("parsing cluster secret", err)
 	}
 
-	cfg.ConsensusDataFolder = dataPath
 	err = os.MkdirAll(filepath.Dir(configPath), 0700)
 	err = cfg.Save(configPath)
 	checkErr("saving new configuration", err)


### PR DESCRIPTION
We no longer set ConsensusDataFolder. We leave it empty (and ommited from the
configuration). When not set, it will take the path from which the configuration
file was read and use an "ipfs-cluster-data" subfolder in that path.

When set, the behaviour is just as before (ensures backwards compatiblity).

This will facilitate re-use of configuration files, for example, when mounting
them inside docker.

#97 

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>