### PR TITLE
Allow empty cluster secret, update test to reflect this.

### DIFF
--- a/config.go
+++ b/config.go
@@ -440,11 +440,15 @@ func DecodeClusterSecret(hexSecret string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	secretLen := len(secret)
-	if secretLen != 32 {
+	switch secretLen := len(secret); secretLen {
+	case 0:
+		logger.Warning("Cluster secret is empty, cluster will start on unprotected network.")
+		return nil, nil
+	case 32:
+		return secret, nil
+	default:
 		return nil, fmt.Errorf("Input secret is %d bytes, cluster secret should be 32.", secretLen)
 	}
-	return secret, nil
 }
 
 // EncodeClusterSecret converts a byte slice to its hex string representation.

--- a/pnet_test.go
+++ b/pnet_test.go
@@ -2,27 +2,32 @@ package ipfscluster
 
 import "testing"
 
-func TestClusterKeyFormat(t *testing.T) {
-    goodKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+func TestClusterSecretFormat(t *testing.T) {
+    goodSecret := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    emptySecret := ""
     tooShort := "0123456789abcdef"
     tooLong := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
     unsupportedChars := "0123456789abcdef0123456789!!!!!!0123456789abcdef0123456789abcdef"
 
-	_, err := DecodeClusterSecret(goodKey)
+	_, err := DecodeClusterSecret(goodSecret)
 	if err != nil {
-        t.Fatal("Failed to decode well-formatted key.")
+        t.Fatal("Failed to decode well-formatted secret.")
+	}
+	decodedEmptySecret, err := DecodeClusterSecret(emptySecret)
+	if decodedEmptySecret != nil || err != nil {
+        t.Fatal("Unsuspected output of decoding empty secret.")
 	}
 	_, err = DecodeClusterSecret(tooShort)
 	if err == nil {
-        t.Fatal("Successfully decoded key that should haved failed (too short).")
+        t.Fatal("Successfully decoded secret that should haved failed (too short).")
 	}
 	_, err = DecodeClusterSecret(tooLong)
 	if err == nil {
-        t.Fatal("Successfully decoded key that should haved failed (too long).")
+        t.Fatal("Successfully decoded secret that should haved failed (too long).")
 	}
 	_, err = DecodeClusterSecret(unsupportedChars)
 	if err == nil {
-        t.Fatal("Successfully decoded key that should haved failed (unsupported chars).")
+        t.Fatal("Successfully decoded secret that should haved failed (unsupported chars).")
 	}
 }
 


### PR DESCRIPTION
Small update to allow empty cluster secret for starting cluster on unprotected network.