### PR TITLE
WIP: HTTPS API endpoint support

### DIFF
--- a/api/restapi/restapi.go
+++ b/api/restapi/restapi.go
@@ -4,6 +4,7 @@ package restapi
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -77,7 +78,25 @@ func NewRESTAPI(apiMAddr ma.Multiaddr) (*RESTAPI, error) {
 	if err != nil {
 		return nil, err
 	}
+	return newRESTAPI(apiMAddr, l)
+}
 
+// NewTlsRESTAPI creates a new REST API component that uses TLS for security
+// (authentication, encryption). It receives the multiaddress on which the API
+// listens, as well as paths to certificate and private key files
+func NewTLSRESTAPI(apiMAddr ma.Multiaddr, tlsCfg *tls.Config) (*RESTAPI, error) {
+	n, addr, err := manet.DialArgs(apiMAddr)
+	if err != nil {
+		return nil, err
+	}
+	l, err := tls.Listen(n, addr, tlsCfg)
+	if err != nil {
+		return nil, err
+	}
+	return newRESTAPI(apiMAddr, l)
+}
+
+func newRESTAPI(apiMAddr ma.Multiaddr, l net.Listener) (*RESTAPI, error) {
 	router := mux.NewRouter().StrictSlash(true)
 	s := &http.Server{
 		ReadTimeout:  RESTAPIServerReadTimeout,

--- a/api/restapi/restapi_test.go
+++ b/api/restapi/restapi_test.go
@@ -15,9 +15,7 @@ import (
 )
 
 var (
-	apiHost            = "http://127.0.0.1:10002" // should match testingConfig()
-	testingTLSCertFile = "test-tls/server.crt"
-	testingTLSKeyFile  = "test-tls/server.key"
+	apiHost = "http://127.0.0.1:10002" // should match testingConfig()
 )
 
 func testRESTAPI(t *testing.T) *RESTAPI {

--- a/api/restapi/restapi_test.go
+++ b/api/restapi/restapi_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 var (
-	apiHost = "http://127.0.0.1:10002" // should match testingConfig()
+	apiHost            = "http://127.0.0.1:10002" // should match testingConfig()
+	testingTLSCertFile = "test-tls/server.crt"
+	testingTLSKeyFile  = "test-tls/server.key"
 )
 
 func testRESTAPI(t *testing.T) *RESTAPI {

--- a/config.go
+++ b/config.go
@@ -66,6 +66,18 @@ type Config struct {
 	// Listen parameters for the the Cluster HTTP API component.
 	APIAddr ma.Multiaddr
 
+	// TLSCertFile is a path to a certificate file used for identifying the
+	// Cluster's HTTP(S) API. TLSKeyFile must also be set in order to establish
+	// a TLS server. If both this and TLSKeyFile are empty, then HTTP (without
+	// TLS) will be used
+	TLSCertFile string
+
+	// TLSKeyFile is a path to a private key used for setting up TLS sessions for
+	// the HTTP(S) API. TLSCertFile must also be set in order to establish a TLS
+	// server. If both this and TLSCertFile are empty, then HTTP (without
+	// TLS) will be used
+	TLSKeyFile string
+
 	// Listen parameters for the IPFS Proxy. Used by the IPFS
 	// connector component.
 	IPFSProxyAddr ma.Multiaddr
@@ -137,10 +149,22 @@ type JSONConfig struct {
 	// interal RPC and Consensus communications between cluster peers.
 	ClusterListenMultiaddress string `json:"cluster_multiaddress"`
 
-	// Listen address for the the Cluster HTTP API component.
+	// Listen address for the the Cluster HTTP(S) API component.
 	// Tools like ipfs-cluster-ctl will connect to his endpoint to
 	// manage cluster.
 	APIListenMultiaddress string `json:"api_listen_multiaddress"`
+
+	// TLSCertFile is a path to a certificate file used for identifying the
+	// Cluster's HTTP(S) API. TLSKeyFile must also be set in order to establish
+	// a TLS server. If both this and TLSKeyFile are empty, then HTTP (without
+	// TLS) will be used
+	TLSCertFile string
+
+	// TLSKeyFile is a path to a private key used for setting up TLS sessions for
+	// the HTTP(S) API. TLSCertFile must also be set in order to establish a TLS
+	// server. If both this and TLSCertFile are empty, then HTTP (without
+	// TLS) will be used
+	TLSKeyFile string
 
 	// Listen address for the IPFS Proxy, which forwards requests to
 	// an IPFS daemon.
@@ -216,6 +240,8 @@ func (cfg *Config) ToJSONConfig() (j *JSONConfig, err error) {
 		LeaveOnShutdown:             cfg.LeaveOnShutdown,
 		ClusterListenMultiaddress:   cfg.ClusterAddr.String(),
 		APIListenMultiaddress:       cfg.APIAddr.String(),
+		TLSCertFile:                 cfg.TLSCertFile,
+		TLSKeyFile:                  cfg.TLSKeyFile,
 		IPFSProxyListenMultiaddress: cfg.IPFSProxyAddr.String(),
 		IPFSNodeMultiaddress:        cfg.IPFSNodeAddr.String(),
 		ConsensusDataFolder:         cfg.ConsensusDataFolder,
@@ -327,6 +353,8 @@ func (jcfg *JSONConfig) ToConfig() (c *Config, err error) {
 		LeaveOnShutdown:           jcfg.LeaveOnShutdown,
 		ClusterAddr:               clusterAddr,
 		APIAddr:                   apiAddr,
+		TLSCertFile:               jcfg.TLSCertFile,
+		TLSKeyFile:                jcfg.TLSKeyFile,
 		IPFSProxyAddr:             ipfsProxyAddr,
 		IPFSNodeAddr:              ipfsNodeAddr,
 		ConsensusDataFolder:       jcfg.ConsensusDataFolder,


### PR DESCRIPTION
This PR addresses the issue https://github.com/ipfs/ipfs-cluster/issues/120. The current implementation builds, but has not yet been tested. The default TLS configuration used was copied from https://github.com/denji/golang-tls#perfect-ssl-labs-score-with-go and has not yet been verified outside of that source.