### PR TITLE
`FreeSpace` allocation metric impl

### DIFF
--- a/allocator/ascendalloc/ascendalloc.go
+++ b/allocator/ascendalloc/ascendalloc.go
@@ -5,8 +5,6 @@
 package ascendalloc
 
 import (
-	"sort"
-
 	"github.com/ipfs/ipfs-cluster/allocator/util"
 	"github.com/ipfs/ipfs-cluster/api"
 
@@ -38,7 +36,5 @@ func (alloc AscendAllocator) Shutdown() error { return nil }
 // candidates based on their metric values (smallest to largest).
 func (alloc AscendAllocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
 	// sort our metrics
-	sortable := util.NewMetricSorter(candidates, false)
-	sort.Sort(sortable)
-	return sortable.Peers, nil
+	return util.SortNumeric(candidates, false), nil
 }

--- a/allocator/ascendalloc/ascendalloc.go
+++ b/allocator/ascendalloc/ascendalloc.go
@@ -1,13 +1,13 @@
-// Package ascendalloc implements an ipfscluster.Allocator returns allocations
-// based on sorting the metrics in ascending order. Thus, peers with smallest
-// metrics are first in the list. This allocator can be used with a number
-// of informers, as long as they provide a numeric metric value.
+// Package ascendalloc implements an ipfscluster.PinAllocator, which returns
+// allocations based on sorting the metrics in ascending order. Thus, peers with
+// smallest metrics are first in the list. This allocator can be used with a
+// number of informers, as long as they provide a numeric metric value.
 package ascendalloc
 
 import (
 	"sort"
-	"strconv"
 
+	"github.com/ipfs/ipfs-cluster/allocator/util"
 	"github.com/ipfs/ipfs-cluster/api"
 
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
@@ -18,79 +18,27 @@ import (
 
 var logger = logging.Logger("ascendalloc")
 
-// Allocator implements ipfscluster.Allocate.
-type Allocator struct{}
+// AscendAllocator extends the SimpleAllocator
+type AscendAllocator struct{}
 
-// NewAllocator returns an initialized Allocator
-func NewAllocator() *Allocator {
-	return &Allocator{}
+// NewAscendAllocator returns an initialized AscendAllocator
+func NewAllocator() AscendAllocator {
+	return AscendAllocator{}
 }
 
 // SetClient does nothing in this allocator
-func (alloc *Allocator) SetClient(c *rpc.Client) {}
+func (alloc AscendAllocator) SetClient(c *rpc.Client) {}
 
 // Shutdown does nothing in this allocator
-func (alloc *Allocator) Shutdown() error { return nil }
+func (alloc AscendAllocator) Shutdown() error { return nil }
 
 // Allocate returns where to allocate a pin request based on metrics which
 // carry a numeric value such as "used disk". We do not pay attention to
-// the metrics of the currently allocated peers and we just sort the candidates
-// based on their metric values (from smallest to largest).
-func (alloc *Allocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
+// the metrics of the currently allocated peers and we just sort the
+// candidates based on their metric values (smallest to largest).
+func (alloc AscendAllocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
 	// sort our metrics
-	sortable := newMetricsSorter(candidates)
+	sortable := util.NewMetricSorter(candidates, false)
 	sort.Sort(sortable)
-	return sortable.peers, nil
-}
-
-// metricsSorter attaches sort.Interface methods to our metrics and sorts
-// a slice of peers in the way that interest us
-type metricsSorter struct {
-	peers []peer.ID
-	m     map[peer.ID]int
-}
-
-func newMetricsSorter(m map[peer.ID]api.Metric) *metricsSorter {
-	vMap := make(map[peer.ID]int)
-	peers := make([]peer.ID, 0, len(m))
-	for k, v := range m {
-		if v.Discard() {
-			continue
-		}
-		val, err := strconv.Atoi(v.Value)
-		if err != nil {
-			continue
-		}
-		peers = append(peers, k)
-		vMap[k] = val
-	}
-
-	sorter := &metricsSorter{
-		m:     vMap,
-		peers: peers,
-	}
-	return sorter
-}
-
-// Len returns the number of metrics
-func (s metricsSorter) Len() int {
-	return len(s.peers)
-}
-
-// Less reports if the element in position i is less than the element in j
-func (s metricsSorter) Less(i, j int) bool {
-	peeri := s.peers[i]
-	peerj := s.peers[j]
-
-	x := s.m[peeri]
-	y := s.m[peerj]
-
-	return x < y
-}
-
-// Swap swaps the elements in positions i and j
-func (s metricsSorter) Swap(i, j int) {
-	temp := s.peers[i]
-	s.peers[i] = s.peers[j]
-	s.peers[j] = temp
+	return sortable.Peers, nil
 }

--- a/allocator/ascendalloc/ascendalloc_test.go
+++ b/allocator/ascendalloc/ascendalloc_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/ipfs/ipfs-cluster/api"
-	"github.com/ipfs/ipfs-cluster/informer/numpin"
 
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -31,25 +30,25 @@ var testCases = []testcase{
 	{ // regular sort
 		candidates: map[peer.ID]api.Metric{
 			peer0: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "5",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer1: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "1",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer2: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "3",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer3: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "2",
 				Expire: inAMinute,
 				Valid:  true,
@@ -61,13 +60,13 @@ var testCases = []testcase{
 	{ // filter invalid
 		candidates: map[peer.ID]api.Metric{
 			peer0: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "1",
 				Expire: inAMinute,
 				Valid:  false,
 			},
 			peer1: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "5",
 				Expire: inAMinute,
 				Valid:  true,
@@ -79,13 +78,13 @@ var testCases = []testcase{
 	{ // filter bad value
 		candidates: map[peer.ID]api.Metric{
 			peer0: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "abc",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer1: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "5",
 				Expire: inAMinute,
 				Valid:  true,

--- a/allocator/descendalloc/descendalloc.go
+++ b/allocator/descendalloc/descendalloc.go
@@ -1,0 +1,44 @@
+// Package descendalloc implements an ipfscluster.util.Allocator returns
+// allocations based on sorting the metrics in descending order. Thus, peers
+// with largest metrics are first in the list. This allocator can be used with a
+// number of informers, as long as they provide a numeric metric value.
+package descendalloc
+
+import (
+	"sort"
+
+	"github.com/ipfs/ipfs-cluster/allocator/util"
+	"github.com/ipfs/ipfs-cluster/api"
+
+	rpc "github.com/hsanjuan/go-libp2p-gorpc"
+	cid "github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+var logger = logging.Logger("descendalloc")
+
+// DescendAllocator extends the SimpleAllocator
+type DescendAllocator struct{}
+
+// NewDescendAllocator returns an initialized DescendAllocator
+func NewAllocator() DescendAllocator {
+	return DescendAllocator{}
+}
+
+// SetClient does nothing in this allocator
+func (alloc DescendAllocator) SetClient(c *rpc.Client) {}
+
+// Shutdown does nothing in this allocator
+func (alloc DescendAllocator) Shutdown() error { return nil }
+
+// Allocate returns where to allocate a pin request based on metrics which
+// carry a numeric value such as "used disk". We do not pay attention to
+// the metrics of the currently allocated peers and we just sort the
+// candidates based on their metric values (largest to smallest).
+func (alloc DescendAllocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
+	// sort our metrics
+	sortable := util.NewMetricSorter(candidates, true)
+	sort.Sort(sortable)
+	return sortable.Peers, nil
+}

--- a/allocator/descendalloc/descendalloc.go
+++ b/allocator/descendalloc/descendalloc.go
@@ -5,8 +5,6 @@
 package descendalloc
 
 import (
-	"sort"
-
 	"github.com/ipfs/ipfs-cluster/allocator/util"
 	"github.com/ipfs/ipfs-cluster/api"
 
@@ -38,7 +36,5 @@ func (alloc DescendAllocator) Shutdown() error { return nil }
 // candidates based on their metric values (largest to smallest).
 func (alloc DescendAllocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
 	// sort our metrics
-	sortable := util.NewMetricSorter(candidates, true)
-	sort.Sort(sortable)
-	return sortable.Peers, nil
+	return util.SortNumeric(candidates, true), nil
 }

--- a/allocator/descendalloc/descendalloc_test.go
+++ b/allocator/descendalloc/descendalloc_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/ipfs/ipfs-cluster/api"
-	"github.com/ipfs/ipfs-cluster/informer/numpin"
 
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -31,25 +30,25 @@ var testCases = []testcase{
 	{ // regular sort
 		candidates: map[peer.ID]api.Metric{
 			peer0: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "5",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer1: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "1",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer2: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "3",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer3: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "2",
 				Expire: inAMinute,
 				Valid:  true,
@@ -61,13 +60,13 @@ var testCases = []testcase{
 	{ // filter invalid
 		candidates: map[peer.ID]api.Metric{
 			peer0: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "1",
 				Expire: inAMinute,
 				Valid:  false,
 			},
 			peer1: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "5",
 				Expire: inAMinute,
 				Valid:  true,
@@ -79,13 +78,13 @@ var testCases = []testcase{
 	{ // filter bad value
 		candidates: map[peer.ID]api.Metric{
 			peer0: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "abc",
 				Expire: inAMinute,
 				Valid:  true,
 			},
 			peer1: api.Metric{
-				Name:   numpin.MetricName,
+				Name:   "some-metric",
 				Value:  "5",
 				Expire: inAMinute,
 				Valid:  true,

--- a/allocator/descendalloc/descendalloc_test.go
+++ b/allocator/descendalloc/descendalloc_test.go
@@ -1,4 +1,4 @@
-package ascendalloc
+package descendalloc
 
 import (
 	"testing"
@@ -97,7 +97,7 @@ var testCases = []testcase{
 }
 
 func Test(t *testing.T) {
-	alloc := &AscendAllocator{}
+	alloc := &DescendAllocator{}
 	for i, tc := range testCases {
 		t.Logf("Test case %d", i)
 		res, err := alloc.Allocate(testCid, tc.current, tc.candidates)
@@ -108,7 +108,7 @@ func Test(t *testing.T) {
 			t.Fatal("0 allocations")
 		}
 		for i, r := range res {
-			if e := tc.expected[i]; r != e {
+			if e := tc.expected[len(res)-i-1]; r != e {
 				t.Errorf("Expect r[%d]=%s but got %s", i, r, e)
 			}
 		}

--- a/allocator/util/metricsorter.go
+++ b/allocator/util/metricsorter.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"strconv"
+
+	"github.com/ipfs/ipfs-cluster/api"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type MetricSorter struct {
+	Peers   []peer.ID
+	M       map[peer.ID]int
+	Reverse bool
+}
+
+func NewMetricSorter(m map[peer.ID]api.Metric, reverse bool) *MetricSorter {
+	vMap := make(map[peer.ID]int)
+	peers := make([]peer.ID, 0, len(m))
+	for k, v := range m {
+		if v.Discard() {
+			continue
+		}
+		val, err := strconv.Atoi(v.Value)
+		if err != nil {
+			continue
+		}
+		peers = append(peers, k)
+		vMap[k] = val
+	}
+
+	sorter := &MetricSorter{
+		M:       vMap,
+		Peers:   peers,
+		Reverse: reverse,
+	}
+	return sorter
+}
+
+// Len returns the number of metrics
+func (s MetricSorter) Len() int {
+	return len(s.Peers)
+}
+
+// Swap swaps the elements in positions i and j
+func (s MetricSorter) Swap(i, j int) {
+	temp := s.Peers[i]
+	s.Peers[i] = s.Peers[j]
+	s.Peers[j] = temp
+}
+
+// Less reports if the element in position i is less than the element in j
+// (important to override this)
+func (s MetricSorter) Less(i, j int) bool {
+	peeri := s.Peers[i]
+	peerj := s.Peers[j]
+
+	x := s.M[peeri]
+	y := s.M[peerj]
+
+	if s.Reverse {
+		return x > y
+	}
+	return x < y
+}

--- a/allocator/util/metricsorter.go
+++ b/allocator/util/metricsorter.go
@@ -1,6 +1,11 @@
+// Package allocator.util is a utility package used by the allocator
+// implementations. This package provides the SortNumeric function, which may be
+// used by an allocator to sort peers by their metric values (ascending or
+// descending).
 package util
 
 import (
+	"sort"
 	"strconv"
 
 	"github.com/ipfs/ipfs-cluster/api"
@@ -8,16 +13,13 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-type MetricSorter struct {
-	Peers   []peer.ID
-	M       map[peer.ID]int
-	Reverse bool
-}
-
-func NewMetricSorter(m map[peer.ID]api.Metric, reverse bool) *MetricSorter {
+// SortNumeric returns a list of peers sorted by their metric values. If reverse
+// is false (true), peers will be sorted from smallest to largest (largest to
+// smallest) metric
+func SortNumeric(candidates map[peer.ID]api.Metric, reverse bool) []peer.ID {
 	vMap := make(map[peer.ID]int)
-	peers := make([]peer.ID, 0, len(m))
-	for k, v := range m {
+	peers := make([]peer.ID, 0, len(candidates))
+	for k, v := range candidates {
 		if v.Discard() {
 			continue
 		}
@@ -29,36 +31,44 @@ func NewMetricSorter(m map[peer.ID]api.Metric, reverse bool) *MetricSorter {
 		vMap[k] = val
 	}
 
-	sorter := &MetricSorter{
-		M:       vMap,
-		Peers:   peers,
-		Reverse: reverse,
+	sorter := &metricSorter{
+		m:       vMap,
+		peers:   peers,
+		reverse: reverse,
 	}
-	return sorter
+	sort.Sort(sorter)
+	return sorter.peers
+}
+
+// metricSorter implements the sort.Sort interface
+type metricSorter struct {
+	peers   []peer.ID
+	m       map[peer.ID]int
+	reverse bool
 }
 
 // Len returns the number of metrics
-func (s MetricSorter) Len() int {
-	return len(s.Peers)
+func (s metricSorter) Len() int {
+	return len(s.peers)
 }
 
-// Swap swaps the elements in positions i and j
-func (s MetricSorter) Swap(i, j int) {
-	temp := s.Peers[i]
-	s.Peers[i] = s.Peers[j]
-	s.Peers[j] = temp
+// Swap Swaps the elements in positions i and j
+func (s metricSorter) Swap(i, j int) {
+	temp := s.peers[i]
+	s.peers[i] = s.peers[j]
+	s.peers[j] = temp
 }
 
-// Less reports if the element in position i is less than the element in j
+// Less reports if the element in position i is Less than the element in j
 // (important to override this)
-func (s MetricSorter) Less(i, j int) bool {
-	peeri := s.Peers[i]
-	peerj := s.Peers[j]
+func (s metricSorter) Less(i, j int) bool {
+	peeri := s.peers[i]
+	peerj := s.peers[j]
 
-	x := s.M[peeri]
-	y := s.M[peerj]
+	x := s.m[peeri]
+	y := s.m[peerj]
 
-	if s.Reverse {
+	if s.reverse {
 		return x > y
 	}
 	return x < y

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -79,7 +79,7 @@ func (ipfs *mockConnector) PinLs(filter string) (map[string]api.IPFSPinStatus, e
 
 func (ipfs *mockConnector) ConnectSwarms() error                          { return nil }
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
-func (ipfs *mockConnector) FreeSpace() (int, error)                       { return 0, nil }
+func (ipfs *mockConnector) FreeSpace() (int, error)                       { return 100, nil }
 func (ipfs *mockConnector) RepoSize() (int, error)                        { return 0, nil }
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *maptracker.MapPinTracker) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -79,6 +79,7 @@ func (ipfs *mockConnector) PinLs(filter string) (map[string]api.IPFSPinStatus, e
 
 func (ipfs *mockConnector) ConnectSwarms() error                          { return nil }
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
+func (ipfs *mockConnector) FreeSpace() (int, error)                       { return 0, nil }
 func (ipfs *mockConnector) RepoSize() (int, error)                        { return 0, nil }
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *maptracker.MapPinTracker) {

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -5,6 +5,7 @@
 package disk
 
 import (
+	"errors"
 	"fmt"
 
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
@@ -42,18 +43,17 @@ type Informer struct {
 	rpcName   string
 }
 
-// NewInformer returns an initialized Informer that uses the DefaultMetric. The
-// name argument is meant as a user-facing identifier for the Informer and can
-// be anything.
-func NewInformer(name string) *Informer {
+// NewInformer returns an initialized Informer that uses the DefaultMetric.
+func NewInformer() *Informer {
 	return &Informer{
-		name:    name,
+		name:    "disk-default",
 		rpcName: metricToRPC[DefaultMetric],
 	}
 }
 
 // NewInformerWithMetric returns an Informer that uses the input MetricType. The
-// name argument has the same purpose as in NewInformer.
+// name argument is meant as a user-facing identifier for the Informer and can
+// be anything.
 func NewInformerWithMetric(metric MetricType, name string) (*Informer, error) {
 	// check whether specified metric is supported
 	if rpc, valid := metricToRPC[metric]; valid {
@@ -62,7 +62,7 @@ func NewInformerWithMetric(metric MetricType, name string) (*Informer, error) {
 			rpcName: rpc,
 		}, nil
 	}
-	return nil, fmt.Error("Error creating Informer: invalid MetricType")
+	return nil, errors.New("Error creating Informer: invalid MetricType")
 }
 
 // Name returns the user-facing name of this informer.

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -1,6 +1,7 @@
-// Package disk implements an ipfs-cluster informer which determines
-// the current RepoSize of the ipfs daemon datastore and returns it as an
-// api.Metric.
+// Package disk implements an ipfs-cluster informer which uses a metric (e.g.
+// RepoSize or FreeSpace of the IPFS daemon datastore) and returns it as an
+// api.Metric. The supported metrics are listed as the keys in the nameToRPC
+// map below.
 package disk
 
 import (
@@ -12,17 +13,14 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 )
 
-// TODO: switch default to disk-freespace
-const DefaultMetric = "disk-reposize"
+const DefaultMetric = "disk-freespace"
 
 var logger = logging.Logger("diskinfo")
 
 // MetricTTL specifies how long our reported metric is valid in seconds.
 var MetricTTL = 30
 
-// MetricName specifies the name of our metric
-var MetricName string
-
+// nameToRPC maps from a specified metric name to the corrresponding RPC call
 var nameToRPC = map[string]string{
 	"disk-freespace": "IPFSFreeSpace",
 	"disk-reposize":  "IPFSRepoSize",
@@ -31,20 +29,28 @@ var nameToRPC = map[string]string{
 // Informer is a simple object to implement the ipfscluster.Informer
 // and Component interfaces.
 type Informer struct {
-	rpcClient *rpc.Client
+	metricName string
+	rpcClient  *rpc.Client
 }
 
-// NewInformer returns an initialized Informer.
+// NewInformer returns an initialized Informer that uses the DefaultMetric
 func NewInformer() *Informer {
-	MetricName = DefaultMetric
-	return &Informer{}
+	return &Informer{
+		metricName: DefaultMetric,
+	}
 }
 
-// NewInformer returns an initialized Informer.
+// NewInformerWithMetric returns an initialized Informer with a specified metric
+// name, if that name is valid, or nil. A metric name is valid if it is a key in
+// the nameToRPC map.
 func NewInformerWithMetric(metric string) *Informer {
-	// assume `metric` has been checked already
-	MetricName = metric
-	return &Informer{}
+	// check whether specified metric is supported
+	if _, valid := nameToRPC[metric]; valid {
+		return &Informer{
+			metricName: metric,
+		}
+	}
+	return nil
 }
 
 // SetClient provides us with an rpc.Client which allows
@@ -62,7 +68,7 @@ func (disk *Informer) Shutdown() error {
 
 // Name returns the name of this informer.
 func (disk *Informer) Name() string {
-	return MetricName
+	return disk.metricName
 }
 
 func (disk *Informer) GetMetric() api.Metric {
@@ -76,7 +82,7 @@ func (disk *Informer) GetMetric() api.Metric {
 	valid := true
 	err := disk.rpcClient.Call("",
 		"Cluster",
-		nameToRPC[MetricName],
+		nameToRPC[disk.metricName],
 		struct{}{},
 		&metric)
 	if err != nil {
@@ -85,7 +91,7 @@ func (disk *Informer) GetMetric() api.Metric {
 	}
 
 	m := api.Metric{
-		Name:  MetricName,
+		Name:  disk.metricName,
 		Value: fmt.Sprintf("%d", metric),
 		Valid: valid,
 	}

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -54,15 +54,15 @@ func NewInformer(name string) *Informer {
 
 // NewInformerWithMetric returns an Informer that uses the input MetricType. The
 // name argument has the same purpose as in NewInformer.
-func NewInformerWithMetric(metric MetricType, name string) *Informer {
+func NewInformerWithMetric(metric MetricType, name string) (*Informer, error) {
 	// check whether specified metric is supported
 	if rpc, valid := metricToRPC[metric]; valid {
 		return &Informer{
 			name:    name,
 			rpcName: rpc,
-		}
+		}, nil
 	}
-	return nil
+	return nil, fmt.Error("Error creating Informer: invalid MetricType")
 }
 
 // Name returns the user-facing name of this informer.

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -73,8 +73,8 @@ func Test(t *testing.T) {
 }
 
 func TestFreeSpace(t *testing.T) {
-	inf := NewInformerWithMetric(MetricFreeSpace, "disk-freespace")
-	if inf == nil {
+	inf, err := NewInformerWithMetric(MetricFreeSpace, "disk-freespace")
+	if err != nil {
 		t.Error("informer not initialized properly")
 	}
 	defer inf.Shutdown()
@@ -94,8 +94,8 @@ func TestFreeSpace(t *testing.T) {
 }
 
 func TestRepoSize(t *testing.T) {
-	inf := NewInformerWithMetric(MetricRepoSize, "disk-reposize")
-	if inf == nil {
+	inf, err := NewInformerWithMetric(MetricRepoSize, "disk-reposize")
+	if err != nil {
 		t.Error("informer not initialized properly")
 	}
 	defer inf.Shutdown()

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -52,7 +52,7 @@ func (mock *badRPCService) IPFSRepoSize(in struct{}, out *int) error {
 func Test(t *testing.T) {
 	inf := NewInformer()
 	defer inf.Shutdown()
-	if inf.Name() != "disk" {
+	if inf.Name() != DefaultMetric {
 		t.Error("careful when changing the name of an informer")
 	}
 	m := inf.GetMetric()

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -56,9 +56,9 @@ func (mock *badRPCService) IPFSFreeSpace(in struct{}, out *int) error {
 }
 
 func Test(t *testing.T) {
-	inf := NewInformer()
+	inf := NewInformer("name")
 	defer inf.Shutdown()
-	if inf.Name() != DefaultMetric {
+	if inf.Type != DefaultMetric {
 		t.Error("careful when changing the name of an informer")
 	}
 	m := inf.GetMetric()
@@ -73,7 +73,7 @@ func Test(t *testing.T) {
 }
 
 func TestFreeSpace(t *testing.T) {
-	inf := NewInformerWithMetric("disk-freespace")
+	inf := NewInformerWithMetric(MetricFreeSpace, "disk-freespace")
 	if inf == nil {
 		t.Error("informer not initialized properly")
 	}
@@ -94,7 +94,7 @@ func TestFreeSpace(t *testing.T) {
 }
 
 func TestRepoSize(t *testing.T) {
-	inf := NewInformerWithMetric("disk-reposize")
+	inf := NewInformerWithMetric(MetricRepoSize, "disk-reposize")
 	if inf == nil {
 		t.Error("informer not initialized properly")
 	}
@@ -115,7 +115,7 @@ func TestRepoSize(t *testing.T) {
 }
 
 func TestWithErrors(t *testing.T) {
-	inf := NewInformer()
+	inf := NewInformer("name")
 	defer inf.Shutdown()
 	inf.SetClient(badRPCClient(t))
 	m := inf.GetMetric()

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -49,12 +49,56 @@ func (mock *badRPCService) IPFSRepoSize(in struct{}, out *int) error {
 	return errors.New("fake error")
 }
 
+func (mock *badRPCService) IPFSFreeSpace(in struct{}, out *int) error {
+	*out = 2
+	mock.nthCall++
+	return errors.New("fake error")
+}
+
 func Test(t *testing.T) {
 	inf := NewInformer()
 	defer inf.Shutdown()
 	if inf.Name() != DefaultMetric {
 		t.Error("careful when changing the name of an informer")
 	}
+	m := inf.GetMetric()
+	if m.Valid {
+		t.Error("metric should be invalid")
+	}
+	inf.SetClient(test.NewMockRPCClient(t))
+	m = inf.GetMetric()
+	if !m.Valid {
+		t.Error("metric should be valid")
+	}
+}
+
+func TestFreeSpace(t *testing.T) {
+	inf := NewInformerWithMetric("disk-freespace")
+	if inf == nil {
+		t.Error("informer not initialized properly")
+	}
+	defer inf.Shutdown()
+	m := inf.GetMetric()
+	if m.Valid {
+		t.Error("metric should be invalid")
+	}
+	inf.SetClient(test.NewMockRPCClient(t))
+	m = inf.GetMetric()
+	if !m.Valid {
+		t.Error("metric should be valid")
+	}
+	// The mock client reports 100KB and 2 pins of 1 KB
+	if m.Value != "98000" {
+		t.Error("bad metric value")
+	}
+}
+
+func TestRepoSize(t *testing.T) {
+	inf := NewInformerWithMetric("disk-reposize")
+	if inf == nil {
+		t.Error("informer not initialized properly")
+	}
+	defer inf.Shutdown()
 	m := inf.GetMetric()
 	if m.Valid {
 		t.Error("metric should be invalid")

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -56,7 +56,7 @@ func (mock *badRPCService) IPFSFreeSpace(in struct{}, out *int) error {
 }
 
 func Test(t *testing.T) {
-	inf := NewInformer("name")
+	inf := NewInformer()
 	defer inf.Shutdown()
 	if inf.Type != DefaultMetric {
 		t.Error("careful when changing the name of an informer")
@@ -115,7 +115,7 @@ func TestRepoSize(t *testing.T) {
 }
 
 func TestWithErrors(t *testing.T) {
-	inf := NewInformer("name")
+	inf := NewInformer()
 	defer inf.Shutdown()
 	inf.SetClient(badRPCClient(t))
 	m := inf.GetMetric()

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -19,6 +19,7 @@ import (
 
 	ipfscluster "github.com/ipfs/ipfs-cluster"
 	"github.com/ipfs/ipfs-cluster/allocator/ascendalloc"
+	"github.com/ipfs/ipfs-cluster/allocator/descendalloc"
 	"github.com/ipfs/ipfs-cluster/api/restapi"
 	"github.com/ipfs/ipfs-cluster/informer/disk"
 	"github.com/ipfs/ipfs-cluster/informer/numpin"
@@ -331,6 +332,7 @@ var facilities = []string{
 	"consensus",
 	"pintracker",
 	"ascendalloc",
+	"descendalloc",
 	"diskinfo",
 }
 
@@ -342,10 +344,10 @@ func setupLogging(lvl string) {
 
 func setupAllocation(strategy string) (ipfscluster.Informer, ipfscluster.PinAllocator) {
 	switch strategy {
-	case "disk":
+	case "disk", "disk-freespace":
 		informer := disk.NewInformer()
-		return informer, ascendalloc.NewAllocator()
-	case "disk-freespace", "disk-reposize":
+		return informer, descendalloc.NewAllocator()
+	case "disk-reposize":
 		informer := disk.NewInformerWithMetric(strategy)
 		return informer, ascendalloc.NewAllocator()
 	case "numpin", "pincount":

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -342,8 +342,12 @@ func setupLogging(lvl string) {
 
 func setupAllocation(strategy string) (ipfscluster.Informer, ipfscluster.PinAllocator) {
 	switch strategy {
-	case "disk", "reposize":
-		return disk.NewInformer(), ascendalloc.NewAllocator()
+	case "disk":
+		informer := disk.NewInformer()
+		return informer, ascendalloc.NewAllocator()
+	case "disk-freespace", "disk-reposize":
+		informer := disk.NewInformerWithMetric(strategy)
+		return informer, ascendalloc.NewAllocator()
 	case "numpin", "pincount":
 		return numpin.NewInformer(), ascendalloc.NewAllocator()
 	default:

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -349,10 +349,12 @@ func setupAllocation(name string) (ipfscluster.Informer, ipfscluster.PinAllocato
 		name = "disk-freespace"
 		fallthrough
 	case "disk-freespace":
-		informer := disk.NewInformerWithMetric(disk.MetricFreeSpace, name)
+		informer, err := disk.NewInformerWithMetric(disk.MetricFreeSpace, name)
+		checkErr("Setting up allocation strategy", err)
 		return informer, descendalloc.NewAllocator()
 	case "disk-reposize":
-		informer := disk.NewInformerWithMetric(disk.MetricRepoSize, name)
+		informer, err := disk.NewInformerWithMetric(disk.MetricRepoSize, name)
+		checkErr("Setting up allocation strategy", err)
 		return informer, ascendalloc.NewAllocator()
 	case "numpin", "pincount":
 		informer := numpin.NewInformer()

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -342,16 +342,21 @@ func setupLogging(lvl string) {
 	}
 }
 
-func setupAllocation(strategy string) (ipfscluster.Informer, ipfscluster.PinAllocator) {
-	switch strategy {
-	case "disk", "disk-freespace":
-		informer := disk.NewInformer()
+func setupAllocation(name string) (ipfscluster.Informer, ipfscluster.PinAllocator) {
+	switch name {
+	case "disk":
+		// set strategy to default for disk, continue through cases
+		name = "disk-freespace"
+		fallthrough
+	case "disk-freespace":
+		informer := disk.NewInformerWithMetric(disk.MetricFreeSpace, name)
 		return informer, descendalloc.NewAllocator()
 	case "disk-reposize":
-		informer := disk.NewInformerWithMetric(strategy)
+		informer := disk.NewInformerWithMetric(disk.MetricRepoSize, name)
 		return informer, ascendalloc.NewAllocator()
 	case "numpin", "pincount":
-		return numpin.NewInformer(), ascendalloc.NewAllocator()
+		informer := numpin.NewInformer()
+		return informer, ascendalloc.NewAllocator()
 	default:
 		err := errors.New("unknown allocation strategy")
 		checkErr("", err)

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -77,6 +77,9 @@ type IPFSConnector interface {
 	// ConfigKey returns the value for a configuration key.
 	// Subobjects are reached with keypaths as "Parent/Child/GrandChild...".
 	ConfigKey(keypath string) (interface{}, error)
+	// FreeSpace returns the amount of remaining space on the repo, calculated from
+	//"repo stat"
+	FreeSpace() (int, error)
 	// RepoSize returns the current repository size as expressed
 	// by "repo stat".
 	RepoSize() (int, error)

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/ipfs-cluster/allocator/ascendalloc"
+	"github.com/ipfs/ipfs-cluster/allocator/descendalloc"
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/api/restapi"
 	"github.com/ipfs/ipfs-cluster/informer/disk"
@@ -94,9 +94,9 @@ func createComponents(t *testing.T, i int, clusterSecret []byte) (*Config, API, 
 	state := mapstate.NewMapState()
 	tracker := maptracker.NewMapPinTracker(cfg.ID)
 	mon := basic.NewStdPeerMonitor(cfg.MonitoringIntervalSeconds)
-	alloc := ascendalloc.NewAllocator()
+	alloc := descendalloc.NewAllocator()
 	disk.MetricTTL = 1 // second
-	inf := disk.NewInformer("name")
+	inf := disk.NewInformer("freespace")
 
 	return cfg, api, ipfs, state, tracker, mon, alloc, inf, mock
 }

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -96,7 +96,7 @@ func createComponents(t *testing.T, i int, clusterSecret []byte) (*Config, API, 
 	mon := basic.NewStdPeerMonitor(cfg.MonitoringIntervalSeconds)
 	alloc := ascendalloc.NewAllocator()
 	disk.MetricTTL = 1 // second
-	inf := disk.NewInformer()
+	inf := disk.NewInformer("name")
 
 	return cfg, api, ipfs, state, tracker, mon, alloc, inf, mock
 }

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -96,7 +96,7 @@ func createComponents(t *testing.T, i int, clusterSecret []byte) (*Config, API, 
 	mon := basic.NewStdPeerMonitor(cfg.MonitoringIntervalSeconds)
 	alloc := descendalloc.NewAllocator()
 	disk.MetricTTL = 1 // second
-	inf := disk.NewInformer("freespace")
+	inf := disk.NewInformer()
 
 	return cfg, api, ipfs, state, tracker, mon, alloc, inf, mock
 }

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -101,6 +101,7 @@ type ipfsIDResp struct {
 
 type ipfsRepoStatResp struct {
 	RepoSize   int
+	StorageMax int
 	NumObjects int
 }
 
@@ -809,6 +810,25 @@ func getConfigValue(path []string, cfg map[string]interface{}) (interface{}, err
 	default:
 		return nil, errors.New("invalid path")
 	}
+}
+
+// FreeSpace returns the amount of unused space in the ipfs repository. This
+// value is derived from the RepoSize and StorageMax values given by "repo
+// stats". The value is in bytes.
+func (ipfs *Connector) FreeSpace() (int, error) {
+	res, err := ipfs.get("repo/stat")
+	if err != nil {
+		logger.Error(err)
+		return 0, err
+	}
+
+	var stats ipfsRepoStatResp
+	err = json.Unmarshal(res, &stats)
+	if err != nil {
+		logger.Error(err)
+		return 0, err
+	}
+	return stats.StorageMax - stats.RepoSize, nil
 }
 
 // RepoSize returns the current repository size of the ipfs daemon as

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -254,7 +254,7 @@ func TestClusterPeerRemoveReallocsPins(t *testing.T) {
 
 	if len(interestingCids) != nClusters-1 {
 		//t.Fatal("The number of allocated Cids is not expected")
-		t.Fatal("Expected %d allocated CIDs but got %d", nClusters-1,
+		t.Fatalf("Expected %d allocated CIDs but got %d", nClusters-1,
 			len(interestingCids))
 	}
 

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -253,7 +253,9 @@ func TestClusterPeerRemoveReallocsPins(t *testing.T) {
 	}
 
 	if len(interestingCids) != nClusters-1 {
-		t.Fatal("The number of allocated Cids is not expected")
+		//t.Fatal("The number of allocated Cids is not expected")
+		t.Fatal("Expected %d allocated CIDs but got %d", nClusters-1,
+			len(interestingCids))
 	}
 
 	// Now remove cluster peer

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -242,6 +242,13 @@ func (rpcapi *RPCAPI) IPFSConfigKey(in string, out *interface{}) error {
 	return err
 }
 
+// IPFSFreeSpace runs IPFSConnector.FreeSpace().
+func (rpcapi *RPCAPI) IPFSFreeSpace(in struct{}, out *int) error {
+	res, err := rpcapi.c.ipfs.FreeSpace()
+	*out = res
+	return err
+}
+
 // IPFSRepoSize runs IPFSConnector.RepoSize().
 func (rpcapi *RPCAPI) IPFSRepoSize(in struct{}, out *int) error {
 	res, err := rpcapi.c.ipfs.RepoSize()

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -268,3 +268,9 @@ func (mock *mockService) IPFSRepoSize(in struct{}, out *int) error {
 	*out = 2000
 	return nil
 }
+
+func (mock *mockService) IPFSFreeSpace(in struct{}, out *int) error {
+	// RepoSize is 2KB, StorageMax is 100KB
+	*out = 98000
+	return nil
+}


### PR DESCRIPTION
Currently a WIP, but looking for feedback on implementation. I've added a `disk.NewInformerWithMetric(metric string)` function that supports `"disk-reposize"` and `"disk-freespace"` metrics (values checked in `setupAllocation()`, may want to check in `disk.NewInformerWithMetric()` instead). I think the disk Informer impl is fairly clean and makes it easy to add new metrics (simply by adding an entry to the `nameToRPC` map), but let me know what you think @hsanjuan.

TODO:
- [x] implement `descendalloc`
- [x] Tests for freespace metric