### PR TITLE
Updated links to cluster secret info in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ This will install `ipfs-cluster-service` and `ipfs-cluster-ctl` in your `$GOPATH
 
 **`ipfs-cluster-service`** runs an ipfs-cluster peer:
 
-* Initialize with `ipfs-cluster-service init`
-    * You will be asked to enter a cluster secret. For more on this, see [the Cluster secret section of the `ipfs-cluster-service` * README](ipfs-cluster-service/dist/README.md#cluster-secret).
-* Run with `ipfs-cluster-service`. Check `--help` for options
+-   Initialize with `ipfs-cluster-service init`
+    -   You will be asked to enter a cluster secret. For more on this, see [the
+        **Initialization** section of the `ipfs-cluster-service`
+        README](ipfs-cluster-service/dist/README.md#initialization).
+-   Run with `ipfs-cluster-service`. Check `--help` for options
 
 For more information see the [`ipfs-cluster-service` README](ipfs-cluster-service/dist/README.md). Also, read [A guide to running IPFS Cluster](docs/ipfs-cluster-guide.md) for full a full overview of how cluster works.
 

--- a/docs/HOWTO_build_and_update_a_cluster.md
+++ b/docs/HOWTO_build_and_update_a_cluster.md
@@ -4,7 +4,9 @@
 
 This step creates a single-node IPFS Cluster.
 
-First initialize the configuration (see [the Cluster secret section of the `ipfs-cluster-service` README](ipfs-cluster-service/dist/README.md#cluster-secret) for more info on entering a cluster secret):
+First initialize the configuration (see [the **Initialization** section of the
+`ipfs-cluster-service` README](../ipfs-cluster-service/dist/README.md#initialization)
+for more info on entering a cluster secret):
 
 ```
 node0 $ ipfs-cluster-service init


### PR DESCRIPTION
Fixed links in documentation to cluster secret initialization info.

Thanks for pointing this out @ZenGround0!