### PR TITLE
Fix/raft rejoin errors

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -423,9 +423,8 @@ func (c *Cluster) Shutdown() error {
 		} else {
 			time.Sleep(2 * time.Second)
 		}
-		/* set c.Config.Bootstrap to current peers */
+		c.config.unshadow()
 		c.config.Bootstrap = c.peerManager.peersAddrs()
-		c.config.Shadow()
 		c.config.Save("")
 		c.peerManager.resetPeers()
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -423,6 +423,9 @@ func (c *Cluster) Shutdown() error {
 		} else {
 			time.Sleep(2 * time.Second)
 		}
+		/* set c.Config.Bootstrap to current peers */
+		c.config.Bootstrap = c.peerManager.peersAddrs()
+		c.config.Save("")
 		c.peerManager.resetPeers()
 	}
 

--- a/cluster.go
+++ b/cluster.go
@@ -425,6 +425,7 @@ func (c *Cluster) Shutdown() error {
 		}
 		/* set c.Config.Bootstrap to current peers */
 		c.config.Bootstrap = c.peerManager.peersAddrs()
+		c.config.Shadow()
 		c.config.Save("")
 		c.peerManager.resetPeers()
 	}

--- a/docker/cluster-restart.sh
+++ b/docker/cluster-restart.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Restart the cluster process
+sleep 2
+while true; do
+  pgrep ipfs-cluster-service || ipfs-cluster-service -f init; echo "CLUSTER RESTARTED"; ipfs-cluster-service --debug &
+  sleep 10
+done

--- a/docker/cluster-restart.sh
+++ b/docker/cluster-restart.sh
@@ -1,9 +1,9 @@
 #! /bin/bash
 
 # Restart the cluster process
-sleep 2
+sleep 4
 while true; do
   export CLUSTER_SECRET=""
-  pgrep ipfs-cluster-service || echo "CLUSTER RESTARTED"; ipfs-cluster-service --debug &
+  pgrep ipfs-cluster-service || echo "CLUSTER RESTARTING"; ipfs-cluster-service --debug &
   sleep 10
 done

--- a/docker/cluster-restart.sh
+++ b/docker/cluster-restart.sh
@@ -4,6 +4,6 @@
 sleep 2
 while true; do
   export CLUSTER_SECRET=""
-  pgrep ipfs-cluster-service || ipfs-cluster-service -f init; echo "CLUSTER RESTARTED"; ipfs-cluster-service --debug &
+  pgrep ipfs-cluster-service || echo "CLUSTER RESTARTED"; ipfs-cluster-service --debug &
   sleep 10
 done

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -66,8 +66,8 @@ func (pm *peerManager) rmPeer(pid peer.ID, selfShutdown bool) error {
 			go func() {
 				time.Sleep(1 * time.Second)
 				pm.cluster.consensus.Shutdown()
+				pm.cluster.config.unshadow()
 				pm.cluster.config.Bootstrap = pm.peersAddrs()
-				pm.cluster.config.Shadow()
 				pm.cluster.config.Save("")
 				pm.resetPeers()
 				time.Sleep(4 * time.Second)

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -67,6 +67,7 @@ func (pm *peerManager) rmPeer(pid peer.ID, selfShutdown bool) error {
 				time.Sleep(1 * time.Second)
 				pm.cluster.consensus.Shutdown()
 				pm.cluster.config.Bootstrap = pm.peersAddrs()
+				pm.cluster.config.Shadow()
 				pm.cluster.config.Save("")
 				pm.resetPeers()
 				time.Sleep(4 * time.Second)

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -66,6 +66,8 @@ func (pm *peerManager) rmPeer(pid peer.ID, selfShutdown bool) error {
 			go func() {
 				time.Sleep(1 * time.Second)
 				pm.cluster.consensus.Shutdown()
+				pm.cluster.config.Bootstrap = pm.peersAddrs()
+				pm.cluster.config.Save("")
 				pm.resetPeers()
 				time.Sleep(4 * time.Second)
 				pm.cluster.Shutdown()


### PR DESCRIPTION
Addresses #112 by storing peers as bootstrappers when a node is shutdown.  This makes rejoining the cluster pain-free (no chance for bad raft state to error during rejoin) for the departing node.  This strengthens the implicit assumption that departing nodes will rejoin a cluster by default, as starting the departing node in its own cluster will now require modifying the config.

@hsanjuan I may be using `Shadow` in an unconventional way, feedback is welcome.

This PR exposed a flaw in the tests that is still a WIP.  Specifically in k8s-ipfs restarting the cluster is currently handled by reinitializing ipfs-cluster-service before starting the daemon.  This clears listeners bound to sockets that are left behind by the old daemon.  Using the saved config between restarts means reinitializing is not an option, and the network state needs to be cleaned up elsewhere.  I will comment when this is resolved and the full k8s test suite correctly preserves configs.

**edit** 
Upon further inspection it looks like this is just a timing consideration (the re-init just gave more time for system to clean things up).  Newest commit doubles restart timing buffer to help with this.