### PR TITLE
Sharness Test Fix: Moving exec call to sh as bash is deprecated in go-ipfs

### DIFF
--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -27,7 +27,7 @@ test_ipfs_init() {
         echo "Docker not found"
         exit 1
     fi
-    if docker ps --format '{{.Names}}' | egrep -q '^ipfs$'; then
+    if docker ps -a --format '{{.Names}}' | egrep -q '^ipfs$'; then
         echo "ipfs container already running"
     else
         docker run --name ipfs -d -p 127.0.0.1:5001:5001 ipfs/go-ipfs > /dev/null 2>&1

--- a/sharness/t0020-service-basic-commands.sh
+++ b/sharness/t0020-service-basic-commands.sh
@@ -3,7 +3,6 @@
 test_description="Test service startup and init functionality"
 
 . lib/test-lib.sh
-
 test_ipfs_init
 cleanup test_clean_ipfs
 test_cluster_init

--- a/sharness/t0030-ctl-pin.sh
+++ b/sharness/t0030-ctl-pin.sh
@@ -9,9 +9,8 @@ cleanup test_clean_ipfs
 test_cluster_init
 cleanup test_clean_cluster
 
-
 test_expect_success IPFS,CLUSTER "pin data to cluster with ctl" '
-    cid=`docker exec ipfs bash -c "echo test | ipfs add -q"`
+    cid=`docker exec ipfs sh -c "echo test | ipfs add -q"`
     ipfs-cluster-ctl pin add "$cid" &> test4 &&
     ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED"


### PR DESCRIPTION
Additionally I found that my system need `ps -a` in order to register that ipfs container was already running and prevent an initialization failure.