### PR TITLE
Sharness/basic auth

### DIFF
--- a/sharness/config/basic_auth/service.json
+++ b/sharness/config/basic_auth/service.json
@@ -8,7 +8,8 @@
     "cluster_multiaddress": "/ip4/0.0.0.0/tcp/9096",
     "api_listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
     "basic_auth_credentials": {
-        "testuser": "testpass"
+        "testuser": "testpass",
+        "userwithoutpass": ""
     },
     "ipfs_proxy_listen_multiaddress": "/ip4/127.0.0.1/tcp/9095",
     "ipfs_node_multiaddress": "/ip4/127.0.0.1/tcp/5001",

--- a/sharness/config/ssl-basic_auth/service.json
+++ b/sharness/config/ssl-basic_auth/service.json
@@ -9,7 +9,10 @@
     "api_listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
     "ssl_cert_file": "test-config/server.crt",
     "ssl_key_file": "test-config/server.key",
-    "basic_auth_credentials": { "testuser" : "testpass" },
+    "basic_auth_credentials": {
+        "testuser" : "testpass",
+        "userwithoutpass": ""
+    },
     "ipfs_proxy_listen_multiaddress": "/ip4/127.0.0.1/tcp/9095",
     "ipfs_node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
     "state_sync_seconds": 60,

--- a/sharness/t0042-basic-auth.sh
+++ b/sharness/t0042-basic-auth.sh
@@ -22,13 +22,16 @@ test_expect_success "BasicAuth fails without credentials" '
 
 test_expect_success "BasicAuth fails with bad credentials" '
     id=`cluster_id`
-    { test_must_fail ipfs-cluster-ctl --basic-auth "testuser:badpass" --force-http id; } | grep -A1 "401" | grep "Unauthorized"
-    { test_must_fail ipfs-cluster-ctl --basic-auth "baduser:testpass" --force-http id; } | grep -A1 "401" | grep "Unauthorized"
+    { test_must_fail ipfs-cluster-ctl --basic-auth "userwithoutpass:pass" --force-http id; } | grep -A1 "401" | grep "Unauthorized" &&
+    { test_must_fail ipfs-cluster-ctl --basic-auth "testuser" --force-http id; } | grep -A1 "401" | grep "Unauthorized" &&
+    { test_must_fail ipfs-cluster-ctl --basic-auth "testuser:badpass" --force-http id; } | grep -A1 "401" | grep "Unauthorized" &&
+    { test_must_fail ipfs-cluster-ctl --basic-auth "baduser:testpass" --force-http id; } | grep -A1 "401" | grep "Unauthorized" &&
     { test_must_fail ipfs-cluster-ctl --basic-auth "baduser:badpass" --force-http id; } | grep -A1 "401" | grep "Unauthorized"
 '
 
 test_expect_success "BasicAuth over HTTP succeeds with CLI flag credentials" '
     id=`cluster_id`
+    ipfs-cluster-ctl --basic-auth "userwithoutpass" --force-http id | grep -q "$id" &&
     ipfs-cluster-ctl --basic-auth "testuser:testpass" --force-http id | grep -q "$id"
 '
 

--- a/sharness/t0043-ssl-basic-auth.sh
+++ b/sharness/t0043-ssl-basic-auth.sh
@@ -15,8 +15,14 @@ test_expect_success "prerequisites" '
     test_have_prereq IPFS && test_have_prereq CLUSTER
 '
 
+test_expect_success "ssl interaction fails with bad credentials" '
+    id=`cluster_id`
+    { test_must_fail ipfs-cluster-ctl --no-check-certificate --basic-auth "testuser:badpass" id; } | grep -A1 "401" | grep "Unauthorized"
+'
+
 test_expect_success "ssl interaction succeeds" '
     id=`cluster_id`
+    ipfs-cluster-ctl --no-check-certificate --basic-auth "userwithoutpass" id | egrep -q "$id" &&
     ipfs-cluster-ctl --no-check-certificate --basic-auth "testuser:testpass" id | egrep -q "$id"
 '
 


### PR DESCRIPTION
Fixes the existing BasicAuth sharness tests (I forgot to chain the commands within certain tests together with `&&`, e.g. [here](https://github.com/ipfs/ipfs-cluster/blob/3ca7f54b773467494f01262531653261aecaafd5/sharness/t0042-basic-auth.sh#L25)) and adds a few more for completeness.