### PR TITLE
Fix #182: Check request error in cluster-ctl

### DIFF
--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -474,7 +474,7 @@ func request(method, path string, body io.Reader, args ...string) *http.Response
 
 	client := &http.Client{Transport: defaultTransport}
 	resp, err := client.Do(r)
-
+	checkErr(fmt.Sprintf("performing request to %s", defaultHost), err)
 	return resp
 }
 


### PR DESCRIPTION
An error check is missing and this triggers panics when a response is nil