### PR TITLE
Fix #154: Update Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,38 @@
-FROM ipfs/go-ipfs:release
+FROM golang:1.9-stretch AS builder
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
+
+# This build state just builds the cluster binaries
+
+ENV GOPATH     /go
+ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
+
+COPY . $SRC_PATH
+WORKDIR $SRC_PATH
+RUN make install
+
+#------------------------------------------------------
+FROM ipfs/go-ipfs
+MAINTAINER Hector Sanjuan <hector@protocol.ai>
+
+# This is the container which just puts the previously
+# built binaries on the go-ipfs-container.
+
+ENV GOPATH     /go
+ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
+ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
 
 EXPOSE 9094
 EXPOSE 9095
 EXPOSE 9096
 
-ENV GOPATH     /go
-ENV PATH       /go/bin:$PATH
-ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
-ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
+COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-service
+COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-ctl
+COPY --from=builder $SRC_PATH/docker/entrypoint.sh /usr/local/bin/start-daemons.sh
+
+RUN mkdir -p $IPFS_CLUSTER_PATH && \
+    chown 1000:100 $IPFS_CLUSTER_PATH
 
 VOLUME $IPFS_CLUSTER_PATH
-
-COPY . $SRC_PATH
-
-RUN apk add --no-cache --virtual cluster-deps make musl-dev go git \
-    && apk add --no-cache jq \
-    && go get -u github.com/whyrusleeping/gx \
-    && go get -u github.com/whyrusleeping/gx-go \
-    && cd $SRC_PATH \
-    && gx install --global \
-    && gx-go rewrite \
-    && go build \
-    && make -C ipfs-cluster-service install \
-    && make -C ipfs-cluster-ctl install \
-    && cp docker/entrypoint.sh /usr/local/bin/start-daemons.sh \
-    && chmod +x /usr/local/bin/start-daemons.sh \
-    && apk del --purge cluster-deps \
-    && cd / && rm -rf /go/src /go/bin/gx /go/bin/gx-go
-
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start-daemons.sh"]
 
 CMD ["$IPFS_CLUSTER_OPTS"]

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,42 +1,68 @@
 FROM golang:1.9-stretch AS builder
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
 
-# This build state just builds the cluster binaries
+# The testing container needs bash, so we use alpine rather than
+# busybox. That means we need to mimic the whole ipfs-dockerfile rather
+# than just re-use it.
 
 ENV GOPATH     /go
 ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
 
+# Install IPFS, su-exec
+ENV SUEXEC_VERSION v0.2
+RUN go get github.com/ipfs/ipfs-update \
+    && ipfs-update install latest \
+    && cd /tmp \
+    && git clone https://github.com/ncopa/su-exec.git \
+    && cd su-exec \
+    && git checkout -q $SUEXEC_VERSION \
+    && make
+
+# install cluster
 COPY . $SRC_PATH
 WORKDIR $SRC_PATH
 RUN make install
-
 #------------------------------------------------------
-FROM ipfs/go-ipfs
+FROM debian:stretch-slim
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
-
-# This is the container which just puts the previously
-# built binaries on the go-ipfs-container.
 
 ENV GOPATH     /go
 ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
+ENV IPFS_PATH  /data/ipfs
 ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
+
+RUN mkdir -p $IPFS_CLUSTER_PATH && \
+    mkdir -p $IPFS_PATH && \
+    useradd -d $IPFS_PATH -u 1000 -g users ipfs && \
+    chown ipfs:users $IPFS_PATH && \
+    chown ipfs:users $IPFS_CLUSTER_PATH
+
+RUN apt-get update && apt-get install -y jq procps
 
 EXPOSE 9094
 EXPOSE 9095
 EXPOSE 9096
+EXPOSE 4001
+EXPOSE 4002/udp
+EXPOSE 5001
+EXPOSE 8080
+EXPOSE 8081
 
-COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-service
-COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-ctl
 COPY --from=builder $SRC_PATH/docker/test-entrypoint.sh /usr/local/bin/start-daemons.sh
 COPY --from=builder $SRC_PATH/docker/random-stopper.sh /usr/local/bin/random-stopper.sh
 COPY --from=builder $SRC_PATH/docker/random-killer.sh /usr/local/bin/random-killer.sh
 COPY --from=builder $SRC_PATH/docker/wait-killer-stopper.sh /usr/local/bin/wait-killer-stopper.sh
 COPY --from=builder $SRC_PATH/docker/cluster-restart.sh /usr/local/bin/cluster-restart.sh
+COPY --from=builder $GOPATH/bin/ipfs /usr/local/bin/ipfs
+COPY --from=builder /tmp/su-exec/su-exec /sbin/su-exec
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-service
+COPY --from=builder $GOPATH/bin/ipfs-cluster-ctl /usr/local/bin/ipfs-cluster-ctl
 
-RUN mkdir -p $IPFS_CLUSTER_PATH && \
-    chown 1000:100 $IPFS_CLUSTER_PATH
-
+VOLUME $IPFS_PATH
 VOLUME $IPFS_CLUSTER_PATH
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start-daemons.sh"]
 
+ENV IPFS_LOGGING ""
+
+ENTRYPOINT ["/usr/local/bin/start-daemons.sh"]
 CMD ["$IPFS_CLUSTER_OPTS"]

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,38 +1,42 @@
-FROM ipfs/go-ipfs:release
+FROM golang:1.9-stretch AS builder
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
+
+# This build state just builds the cluster binaries
+
+ENV GOPATH     /go
+ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
+
+COPY . $SRC_PATH
+WORKDIR $SRC_PATH
+RUN make install
+
+#------------------------------------------------------
+FROM ipfs/go-ipfs
+MAINTAINER Hector Sanjuan <hector@protocol.ai>
+
+# This is the container which just puts the previously
+# built binaries on the go-ipfs-container.
+
+ENV GOPATH     /go
+ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
+ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
 
 EXPOSE 9094
 EXPOSE 9095
 EXPOSE 9096
 
-ENV GOPATH     /go
-ENV PATH       /go/bin:$PATH
-ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
-ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
+COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-service
+COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-ctl
+COPY --from=builder $SRC_PATH/docker/test-entrypoint.sh /usr/local/bin/start-daemons.sh
+COPY --from=builder $SRC_PATH/docker/random-stopper.sh /usr/local/bin/random-stopper.sh
+COPY --from=builder $SRC_PATH/docker/random-killer.sh /usr/local/bin/random-killer.sh
+COPY --from=builder $SRC_PATH/docker/wait-killer-stopper.sh /usr/local/bin/wait-killer-stopper.sh
+COPY --from=builder $SRC_PATH/docker/cluster-restart.sh /usr/local/bin/cluster-restart.sh
+
+RUN mkdir -p $IPFS_CLUSTER_PATH && \
+    chown 1000:100 $IPFS_CLUSTER_PATH
 
 VOLUME $IPFS_CLUSTER_PATH
-
-COPY . $SRC_PATH
-
-RUN apk add --no-cache --virtual cluster-deps make musl-dev go git \
-    && apk add --no-cache jq \
-    && go get -u github.com/whyrusleeping/gx \
-    && go get -u github.com/whyrusleeping/gx-go \
-    && cd $SRC_PATH \
-    && gx install --global \
-    && gx-go rewrite \
-    && go build \
-    && make -C ipfs-cluster-service install \
-    && make -C ipfs-cluster-ctl install \
-    && cp docker/test-entrypoint.sh /usr/local/bin/start-daemons.sh \
-    && cp docker/random-stopper.sh /usr/local/bin/random-stopper.sh \
-    && cp docker/random-killer.sh /usr/local/bin/random-killer.sh \
-    && cp docker/wait-killer-stopper.sh /usr/local/bin/wait-killer-stopper.sh \
-    && cp docker/cluster-restart.sh /usr/local/bin/cluster-restart.sh \
-    && chmod +x /usr/local/bin/start-daemons.sh \
-    && apk del --purge cluster-deps \
-    && cd / && rm -rf /go/src /go/bin/gx /go/bin/gx-go
-
-ENTRYPOINT ["/usr/local/bin/start-daemons.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start-daemons.sh"]
 
 CMD ["$IPFS_CLUSTER_OPTS"]

--- a/Dockerfile-test-busybox
+++ b/Dockerfile-test-busybox
@@ -1,0 +1,49 @@
+FROM golang:1.9-stretch AS builder
+MAINTAINER Hector Sanjuan <hector@protocol.ai>
+
+# This build state just builds the cluster binaries
+
+ENV GOPATH     /go
+ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
+
+COPY . $SRC_PATH
+WORKDIR $SRC_PATH
+RUN make install
+
+RUN cd /tmp && \
+    wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
+    chmod +x jq-linux64
+    
+
+#------------------------------------------------------
+FROM ipfs/go-ipfs
+MAINTAINER Hector Sanjuan <hector@protocol.ai>
+
+# This is the container which just puts the previously
+# built binaries on the go-ipfs-container.
+
+ENV GOPATH     /go
+ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
+ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
+
+EXPOSE 9094
+EXPOSE 9095
+EXPOSE 9096
+
+COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-service
+COPY --from=builder $GOPATH/bin/ipfs-cluster-ctl /usr/local/bin/ipfs-cluster-ctl
+COPY --from=builder $SRC_PATH/docker/test-entrypoint.sh /usr/local/bin/start-daemons.sh
+COPY --from=builder $SRC_PATH/docker/random-stopper.sh /usr/local/bin/random-stopper.sh
+COPY --from=builder $SRC_PATH/docker/random-killer.sh /usr/local/bin/random-killer.sh
+COPY --from=builder $SRC_PATH/docker/wait-killer-stopper.sh /usr/local/bin/wait-killer-stopper.sh
+COPY --from=builder $SRC_PATH/docker/cluster-restart.sh /usr/local/bin/cluster-restart.sh
+COPY --from=builder /tmp/jq-linux64 /usr/local/bin/jq
+
+
+RUN mkdir -p $IPFS_CLUSTER_PATH && \
+    chown 1000:100 $IPFS_CLUSTER_PATH
+
+VOLUME $IPFS_CLUSTER_PATH
+ENTRYPOINT ["/usr/local/bin/start-daemons.sh"]
+
+CMD ["$IPFS_CLUSTER_OPTS"]

--- a/cluster_config.go
+++ b/cluster_config.go
@@ -159,10 +159,6 @@ func (cfg *Config) Validate() error {
 		return errors.New("No cluster.private_key set")
 	}
 
-	if cfg.Secret == nil {
-		return errors.New("cluster.secret not initialized")
-	}
-
 	if cfg.Peers == nil {
 		return errors.New("cluster.peers is undefined")
 	}

--- a/docker/cluster-restart.sh
+++ b/docker/cluster-restart.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 # Restart the cluster process
 sleep 4

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,20 +2,20 @@
 
 set -e
 user=ipfs
-repo="$IPFS_PATH"
 
 if [ `id -u` -eq 0 ]; then
+    echo "Changing user to $user"
     # ensure directories are writable
-    su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
-    su-exec "$user" test -w "$IPFS_CLUSTER_PATH" || chown -R -- "$user" "$IPFS_CLUSTER_PATH"
+    su-exec "$user" test -w "${IPFS_PATH}" || chown -R -- "$user" "${IPFS_PATH}"
+    su-exec "$user" test -w "${IPFS_CLUSTER_PATH}" || chown -R -- "$user" "${IPFS_CLUSTER_PATH}"
     exec su-exec "$user" "$0" "$@"
 fi
 
 # Second invocation with regular user
 ipfs version
 
-if [ -e "$repo/config" ]; then
-  echo "Found IPFS fs-repo at $repo"
+if [ -e "${IPFS_PATH}/config" ]; then
+  echo "Found IPFS fs-repo at ${IPFS_PATH}"
 else
   ipfs init
   ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
@@ -27,12 +27,12 @@ sleep 3
 
 ipfs-cluster-service --version
 
-if [ -e "$IPFS_CLUSTER_PATH/service.json" ]; then
-    echo "Found IPFS cluster configuration at $IPFS_CLUSTER_PATH"
+if [ -e "${IPFS_CLUSTER_PATH}/service.json" ]; then
+    echo "Found IPFS cluster configuration at ${IPFS_CLUSTER_PATH}"
 else
     ipfs-cluster-service init
-    sed -i 's/127\.0\.0\.1\/tcp\/9094/0.0.0.0\/tcp\/9094/' "$IPFS_CLUSTER_PATH/service.json"
-    sed -i 's/127\.0\.0\.1\/tcp\/9095/0.0.0.0\/tcp\/9095/' "$IPFS_CLUSTER_PATH/service.json"
+    sed -i 's/127\.0\.0\.1\/tcp\/9094/0.0.0.0\/tcp\/9094/' "${IPFS_CLUSTER_PATH}/service.json"
+    sed -i 's/127\.0\.0\.1\/tcp\/9095/0.0.0.0\/tcp\/9095/' "${IPFS_CLUSTER_PATH}/service.json"
 fi
 
 exec ipfs-cluster-service $@

--- a/docker/random-killer.sh
+++ b/docker/random-killer.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 # $1=sleep time, $2=first command, $3=second command
 # Loop forever

--- a/docker/random-stopper.sh
+++ b/docker/random-stopper.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 # $1=sleep time, $2=first command, $3=second command
 # Loop forever

--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -2,31 +2,19 @@
 
 set -e
 user=ipfs
-repo="$IPFS_PATH"
-echo "Version 0.4"
 
 if [ `id -u` -eq 0 ]; then
-    # ensure folders are writeable
-    su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
-    su-exec "$user" test -w "$IPFS_CLUSTER_PATH" || chown -R -- "$user" "$IPFS_CLUSTER_PATH"
-    # restart script with new privileges
-    exec su-exec "$user" "$0" "$@"
-fi
-
-# Second invocation with regular user
-echo "Second invocation"
-
-if [ `id -u` -eq 0 ]; then
+    echo "Changing user to $user"
     # ensure directories are writable
-    su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
-    su-exec "$user" test -w "$IPFS_CLUSTER_PATH" || chown -R -- "$user" "$IPFS_CLUSTER_PATH"
+    su-exec "$user" test -w "${IPFS_PATH}" || chown -R -- "$user" "${IPFS_PATH}"
+    su-exec "$user" test -w "${IPFS_CLUSTER_PATH}" || chown -R -- "$user" "${IPFS_CLUSTER_PATH}"
     exec su-exec "$user" "$0" "$@"
 fi
 
 ipfs version
 
-if [ -e "$repo/config" ]; then
-    echo "Found IPFS fs-repo at $repo"
+if [ -e "${IPFS_PATH}/config" ]; then
+  echo "Found IPFS fs-repo at ${IPFS_PATH}"
 else
     ipfs init
     ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
@@ -46,6 +34,7 @@ else
     sed -i 's/127\.0\.0\.1\/tcp\/9094/0.0.0.0\/tcp\/9094/' "$IPFS_CLUSTER_PATH/service.json"
     sed -i 's/127\.0\.0\.1\/tcp\/9095/0.0.0.0\/tcp\/9095/' "$IPFS_CLUSTER_PATH/service.json"
 fi
+
 ipfs-cluster-service --debug $@ &
 # Testing scripts that spawn background processes are spawned and stopped here
 /usr/local/bin/random-stopper.sh &
@@ -57,5 +46,6 @@ echo $! > /data/ipfs-cluster/random-killer-pid
 /usr/local/bin/cluster-restart.sh &
 kill -STOP $!
 echo $! > /data/ipfs-cluster/cluster-restart-pid
+
 echo "Daemons launched"
 exec tail -f /dev/null

--- a/docker/wait-killer-stopper.sh
+++ b/docker/wait-killer-stopper.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 ## Wait for cluster service process to exist and the stop the
 ## killer


### PR DESCRIPTION
After changes on how the final docker image for go-ipfs is generated,
our Dockerfiles failed to build.

The new version is inspired on go-ipfs Dockerfile. It takes advantage
of docker >= v17.06 which allows multi-stage Dockerfiles with
several FROM directives and COPY --from. This allows build freely on a
first stage, without thinking of cleaning up, and then just copy the
final artifacts to a second, minimal image.

The Dockerfile-test is similarly updated. Minor changes have been
applied to the entrypoints.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>