### PR TITLE
Fix #139: Update cluster to Raft 1.0.0

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -145,9 +145,9 @@ func (c *Cluster) setupPeerManager() {
 	c.peerManager = pm
 
 	if len(c.config.Peers) > 0 {
-		c.peerManager.addFromMultiaddrs(c.config.Peers, false)
+		c.peerManager.setFromMultiaddrs(c.config.Peers, false)
 	} else {
-		c.peerManager.addFromMultiaddrs(c.config.Bootstrap, false)
+		c.peerManager.setFromMultiaddrs(c.config.Bootstrap, false)
 	}
 
 }
@@ -588,7 +588,7 @@ func (c *Cluster) PeerAdd(addr ma.Multiaddr) (api.ID, error) {
 		addrSerial.ToMultiaddr())
 	err = c.rpcClient.Call(pid,
 		"Cluster",
-		"PeerManagerAddFromMultiaddrs",
+		"PeerManagerSetFromMultiaddrs",
 		api.MultiaddrsToSerial(clusterPeers),
 		&struct{}{})
 	if err != nil {

--- a/cluster.go
+++ b/cluster.go
@@ -423,7 +423,7 @@ func (c *Cluster) Shutdown() error {
 
 	logger.Info("shutting down IPFS Cluster")
 
-	if c.config.LeaveOnShutdown {
+	if c.config.LeaveOnShutdown && c.consensus != nil {
 		// best effort
 		logger.Warning("Attempting to leave Cluster. This may take some seconds")
 		err := c.consensus.LogRmPeer(c.id)

--- a/cluster.go
+++ b/cluster.go
@@ -1230,10 +1230,11 @@ func (c *Cluster) backupState() {
 		logger.Error(err)
 		return
 	}
+	defer f.Close()
+
 	err = c.state.Snapshot(f)
 	if err != nil {
 		logger.Error(err)
 		return
 	}
-	defer f.Close()
 }

--- a/cluster.go
+++ b/cluster.go
@@ -451,8 +451,11 @@ func (c *Cluster) Shutdown() error {
 		}
 	}
 
-	c.peerManager.savePeers()
-	c.backupState()
+	// Do not save anything if we were not ready
+	if c.readyB {
+		c.peerManager.savePeers()
+		c.backupState()
+	}
 
 	if err := c.monitor.Shutdown(); err != nil {
 		logger.Errorf("error stopping monitor: %s", err)

--- a/config/util.go
+++ b/config/util.go
@@ -14,14 +14,14 @@ type Saver struct {
 // NotifySave signals the SaveCh() channel in a non-blocking fashion.
 func (sv *Saver) NotifySave() {
 	if sv.save == nil {
-		sv.save = make(chan struct{})
+		sv.save = make(chan struct{}, 10)
 	}
 
 	// Non blocking, in case no one's listening
 	select {
 	case sv.save <- struct{}{}:
 	default:
-		logger.Warning("configuration will not be saved")
+		logger.Warning("configuration save channel full")
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -27,6 +27,10 @@ var testingClusterCfg = []byte(`{
 
 var testingRaftCfg = []byte(`{
     "data_folder": "raftFolderFromTests",
+    "wait_for_leader_timeout": "15s",
+    "commit_retries": 1,
+    "commit_retry_delay": "1s",
+    "network_timeout": "2s",
     "heartbeat_timeout": "1s",
     "election_timeout": "1s",
     "commit_timeout": "50ms",

--- a/consensus/raft/config.go
+++ b/consensus/raft/config.go
@@ -227,14 +227,7 @@ func (cfg *Config) Default() error {
 	cfg.RaftConfig = hraft.DefaultConfig()
 
 	// These options are imposed over any Default Raft Config.
-	// Changing them causes cluster peers to show
-	// difficult-to-understand behaviours,
-	// usually around the add/remove of peers.
-	// That means that changing them will make users wonder why something
-	// does not work the way it is expected to.
-	// i.e. ShutdownOnRemove will cause that no snapshot will be taken
-	// when trying to shutdown a peer after removing it from a cluster.
-	cfg.RaftConfig.ShutdownOnRemove = false
+	// cfg.RaftConfig.ShutdownOnRemove = false
 	cfg.RaftConfig.LocalID = "will_be_set_automatically"
 
 	// Set up logging

--- a/consensus/raft/config.go
+++ b/consensus/raft/config.go
@@ -8,15 +8,21 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/config"
 
-	hashiraft "github.com/hashicorp/raft"
+	hraft "github.com/hashicorp/raft"
 )
 
 // ConfigKey is the default configuration key for holding this component's
 // configuration section.
 var configKey = "raft"
 
-// DefaultDataSubFolder is the default subfolder in which Raft's data is stored.
-var DefaultDataSubFolder = "ipfs-cluster-data"
+// Configuration defaults
+var (
+	DefaultDataSubFolder        = "ipfs-cluster-data"
+	DefaultWaitForLeaderTimeout = 15 * time.Second
+	DefaultCommitRetries        = 1
+	DefaultNetworkTimeout       = 10 * time.Second
+	DefaultCommitRetryDelay     = 200 * time.Millisecond
+)
 
 // Config allows to configure the Raft Consensus component for ipfs-cluster.
 // The component's configuration section is represented by ConfigJSON.
@@ -25,9 +31,20 @@ type Config struct {
 	config.Saver
 
 	// A Hashicorp Raft's configuration object.
-	HashiraftCfg *hashiraft.Config
+	RaftConfig *hraft.Config
 	// A folder to store Raft's data.
 	DataFolder string
+	// LeaderTimeout specifies how long to wait for a leader before
+	// failing an operation.
+	WaitForLeaderTimeout time.Duration
+	// NetworkTimeout specifies how long before a Raft network
+	// operation is timed out
+	NetworkTimeout time.Duration
+	// CommitRetries specifies how many times we retry a failed commit until
+	// we give up.
+	CommitRetries int
+	// How long to wait between retries
+	CommitRetryDelay time.Duration
 }
 
 // ConfigJSON represents a human-friendly Config
@@ -40,6 +57,18 @@ type jsonConfig struct {
 	// Storage folder for snapshots, log store etc. Used by
 	// the Raft.
 	DataFolder string `json:"data_folder,omitempty"`
+
+	// How long to wait for a leader before failing
+	WaitForLeaderTimeout string `json:"wait_for_leader_timeout"`
+
+	// How long to wait before timing out network operations
+	NetworkTimeout string `json:"network_timeout"`
+
+	// How many retries to make upon a failed commit
+	CommitRetries int `json:"commit_retries"`
+
+	// How long to wait between commit retries
+	CommitRetryDelay string `json:"commit_retry_delay"`
 
 	// HeartbeatTimeout specifies the time in follower state without
 	// a leader before we attempt an election.
@@ -56,14 +85,6 @@ type jsonConfig struct {
 	// MaxAppendEntries controls the maximum number of append entries
 	// to send at once.
 	MaxAppendEntries int `json:"max_append_entries,omitempty"`
-
-	// If we are a member of a cluster, and RemovePeer is invoked for the
-	// local node, then we forget all peers and transition into the
-	// follower state.
-	// If ShutdownOnRemove is is set, we additional shutdown Raft.
-	// Otherwise, we can become a leader of a cluster containing
-	// only this node.
-	ShutdownOnRemove bool `json:"shutdown_on_remove,omitempty"`
 
 	// TrailingLogs controls how many logs we leave after a snapshot.
 	TrailingLogs uint64 `json:"trailing_logs,omitempty"`
@@ -100,11 +121,26 @@ func (cfg *Config) ConfigKey() string {
 // Validate checks that this configuration has working values,
 // at least in appereance.
 func (cfg *Config) Validate() error {
-	if cfg.HashiraftCfg == nil {
+	if cfg.RaftConfig == nil {
 		return errors.New("No hashicorp/raft.Config")
 	}
+	if cfg.WaitForLeaderTimeout <= 0 {
+		return errors.New("wait_for_leader_timeout <= 0")
+	}
 
-	return hashiraft.ValidateConfig(cfg.HashiraftCfg)
+	if cfg.NetworkTimeout <= 0 {
+		return errors.New("network_timeout <= 0")
+	}
+
+	if cfg.CommitRetries < 0 {
+		return errors.New("commit_retries is invalid")
+	}
+
+	if cfg.CommitRetryDelay <= 0 {
+		return errors.New("commit_retry_delay is invalid")
+	}
+
+	return hraft.ValidateConfig(cfg.RaftConfig)
 }
 
 // LoadJSON parses a json-encoded configuration (see jsonConfig).
@@ -118,81 +154,77 @@ func (cfg *Config) LoadJSON(raw []byte) error {
 		return err
 	}
 
-	cfg.setDefaults()
+	cfg.Default()
 
-	// Parse durations from strings
-	heartbeatTimeout, err := time.ParseDuration(jcfg.HeartbeatTimeout)
-	if err != nil && jcfg.HeartbeatTimeout != "" {
-		logger.Error("Error parsing heartbeat_timeout")
-		return err
+	parseDuration := func(txt string) time.Duration {
+		d, _ := time.ParseDuration(txt)
+		if txt != "" && d == 0 {
+			logger.Warningf("%s is not a valid duration. Default will be used", txt)
+		}
+		return d
 	}
 
-	electionTimeout, err := time.ParseDuration(jcfg.ElectionTimeout)
-	if err != nil && jcfg.ElectionTimeout != "" {
-		logger.Error("Error parsing election_timeout")
-		return err
-	}
+	// Parse durations. We ignore errors as 0 will take Default values.
+	waitForLeaderTimeout := parseDuration(jcfg.WaitForLeaderTimeout)
+	networkTimeout := parseDuration(jcfg.NetworkTimeout)
+	commitRetryDelay := parseDuration(jcfg.CommitRetryDelay)
+	heartbeatTimeout := parseDuration(jcfg.HeartbeatTimeout)
+	electionTimeout := parseDuration(jcfg.ElectionTimeout)
+	commitTimeout := parseDuration(jcfg.CommitTimeout)
+	snapshotInterval := parseDuration(jcfg.SnapshotInterval)
+	leaderLeaseTimeout := parseDuration(jcfg.LeaderLeaseTimeout)
 
-	commitTimeout, err := time.ParseDuration(jcfg.CommitTimeout)
-	if err != nil && jcfg.CommitTimeout != "" {
-		logger.Error("Error parsing commit_timeout")
-		return err
-	}
-
-	snapshotInterval, err := time.ParseDuration(jcfg.SnapshotInterval)
-	if err != nil && jcfg.SnapshotInterval != "" {
-		logger.Error("Error parsing snapshot_interval")
-		return err
-	}
-
-	leaderLeaseTimeout, err := time.ParseDuration(jcfg.LeaderLeaseTimeout)
-	if err != nil && jcfg.LeaderLeaseTimeout != "" {
-		logger.Error("Error parsing leader_lease_timeout")
-		return err
-	}
-
+	// Set all values in config. For some, take defaults if they are 0.
 	// Set values from jcfg if they are not 0 values
-	config.SetIfNotDefault(jcfg.DataFolder, &cfg.DataFolder)
-	config.SetIfNotDefault(heartbeatTimeout, &cfg.HashiraftCfg.HeartbeatTimeout)
-	config.SetIfNotDefault(electionTimeout, &cfg.HashiraftCfg.ElectionTimeout)
-	config.SetIfNotDefault(commitTimeout, &cfg.HashiraftCfg.CommitTimeout)
-	config.SetIfNotDefault(jcfg.MaxAppendEntries, &cfg.HashiraftCfg.MaxAppendEntries)
-	config.SetIfNotDefault(jcfg.ShutdownOnRemove, &cfg.HashiraftCfg.ShutdownOnRemove)
-	config.SetIfNotDefault(jcfg.TrailingLogs, &cfg.HashiraftCfg.TrailingLogs)
-	config.SetIfNotDefault(snapshotInterval, &cfg.HashiraftCfg.SnapshotInterval)
-	config.SetIfNotDefault(jcfg.SnapshotThreshold, &cfg.HashiraftCfg.SnapshotThreshold)
-	config.SetIfNotDefault(leaderLeaseTimeout, &cfg.HashiraftCfg.LeaderLeaseTimeout)
 
-	return nil
+	// Own values
+	config.SetIfNotDefault(jcfg.DataFolder, &cfg.DataFolder)
+	config.SetIfNotDefault(waitForLeaderTimeout, &cfg.WaitForLeaderTimeout)
+	config.SetIfNotDefault(networkTimeout, &cfg.NetworkTimeout)
+	cfg.CommitRetries = jcfg.CommitRetries
+	config.SetIfNotDefault(commitRetryDelay, &cfg.CommitRetryDelay)
+
+	// Raft values
+	config.SetIfNotDefault(heartbeatTimeout, &cfg.RaftConfig.HeartbeatTimeout)
+	config.SetIfNotDefault(electionTimeout, &cfg.RaftConfig.ElectionTimeout)
+	config.SetIfNotDefault(commitTimeout, &cfg.RaftConfig.CommitTimeout)
+	config.SetIfNotDefault(jcfg.MaxAppendEntries, &cfg.RaftConfig.MaxAppendEntries)
+	config.SetIfNotDefault(jcfg.TrailingLogs, &cfg.RaftConfig.TrailingLogs)
+	config.SetIfNotDefault(snapshotInterval, &cfg.RaftConfig.SnapshotInterval)
+	config.SetIfNotDefault(jcfg.SnapshotThreshold, &cfg.RaftConfig.SnapshotThreshold)
+	config.SetIfNotDefault(leaderLeaseTimeout, &cfg.RaftConfig.LeaderLeaseTimeout)
+
+	return cfg.Validate()
 }
 
 // ToJSON returns the pretty JSON representation of a Config.
 func (cfg *Config) ToJSON() ([]byte, error) {
 	jcfg := &jsonConfig{}
 	jcfg.DataFolder = cfg.DataFolder
-	jcfg.HeartbeatTimeout = cfg.HashiraftCfg.HeartbeatTimeout.String()
-	jcfg.ElectionTimeout = cfg.HashiraftCfg.ElectionTimeout.String()
-	jcfg.CommitTimeout = cfg.HashiraftCfg.CommitTimeout.String()
-	jcfg.MaxAppendEntries = cfg.HashiraftCfg.MaxAppendEntries
-	jcfg.ShutdownOnRemove = cfg.HashiraftCfg.ShutdownOnRemove
-	jcfg.TrailingLogs = cfg.HashiraftCfg.TrailingLogs
-	jcfg.SnapshotInterval = cfg.HashiraftCfg.SnapshotInterval.String()
-	jcfg.SnapshotThreshold = cfg.HashiraftCfg.SnapshotThreshold
-	jcfg.LeaderLeaseTimeout = cfg.HashiraftCfg.LeaderLeaseTimeout.String()
+	jcfg.WaitForLeaderTimeout = cfg.WaitForLeaderTimeout.String()
+	jcfg.NetworkTimeout = cfg.NetworkTimeout.String()
+	jcfg.CommitRetries = cfg.CommitRetries
+	jcfg.CommitRetryDelay = cfg.CommitRetryDelay.String()
+	jcfg.HeartbeatTimeout = cfg.RaftConfig.HeartbeatTimeout.String()
+	jcfg.ElectionTimeout = cfg.RaftConfig.ElectionTimeout.String()
+	jcfg.CommitTimeout = cfg.RaftConfig.CommitTimeout.String()
+	jcfg.MaxAppendEntries = cfg.RaftConfig.MaxAppendEntries
+	jcfg.TrailingLogs = cfg.RaftConfig.TrailingLogs
+	jcfg.SnapshotInterval = cfg.RaftConfig.SnapshotInterval.String()
+	jcfg.SnapshotThreshold = cfg.RaftConfig.SnapshotThreshold
+	jcfg.LeaderLeaseTimeout = cfg.RaftConfig.LeaderLeaseTimeout.String()
 
 	return config.DefaultJSONMarshal(jcfg)
 }
 
 // Default initializes this configuration with working defaults.
 func (cfg *Config) Default() error {
-	cfg.setDefaults()
-	return nil
-}
-
-// most defaults come directly from hashiraft.DefaultConfig()
-func (cfg *Config) setDefaults() {
-	cfg.DataFolder = ""
-	cfg.HashiraftCfg = hashiraft.DefaultConfig()
+	cfg.DataFolder = "" // empty so it gets ommitted
+	cfg.WaitForLeaderTimeout = DefaultWaitForLeaderTimeout
+	cfg.NetworkTimeout = DefaultNetworkTimeout
+	cfg.CommitRetries = DefaultCommitRetries
+	cfg.CommitRetryDelay = DefaultCommitRetryDelay
+	cfg.RaftConfig = hraft.DefaultConfig()
 
 	// These options are imposed over any Default Raft Config.
 	// Changing them causes cluster peers to show
@@ -202,11 +234,11 @@ func (cfg *Config) setDefaults() {
 	// does not work the way it is expected to.
 	// i.e. ShutdownOnRemove will cause that no snapshot will be taken
 	// when trying to shutdown a peer after removing it from a cluster.
-	cfg.HashiraftCfg.DisableBootstrapAfterElect = false
-	cfg.HashiraftCfg.EnableSingleNode = true
-	cfg.HashiraftCfg.ShutdownOnRemove = false
+	cfg.RaftConfig.ShutdownOnRemove = false
+	cfg.RaftConfig.LocalID = "will_be_set_automatically"
 
 	// Set up logging
-	cfg.HashiraftCfg.LogOutput = ioutil.Discard
-	cfg.HashiraftCfg.Logger = raftStdLogger // see logging.go
+	cfg.RaftConfig.LogOutput = ioutil.Discard
+	cfg.RaftConfig.Logger = raftStdLogger // see logging.go
+	return nil
 }

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -375,6 +375,21 @@ func (cc *Consensus) Leader() (peer.ID, error) {
 	return raftactor.Leader()
 }
 
+// Clean removes all raft data from disk. Next time
+// a full new peer will be bootstrapped.
+func (cc *Consensus) Clean() error {
+	if !cc.shutdown {
+		return errors.New("consensus component is not shutdown")
+	}
+
+	err := cc.raft.Clean()
+	if err != nil {
+		return err
+	}
+	logger.Info("consensus data cleaned")
+	return nil
+}
+
 // Rollback replaces the current agreed-upon
 // state with the state provided. Only the consensus leader
 // can perform this operation.

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -259,7 +259,7 @@ func (cc *Consensus) redirectToLeader(method string, arg interface{}) (bool, err
 func (cc *Consensus) commit(op *LogOp, rpcOp string, redirectArg interface{}) error {
 	var finalErr error
 	for i := 0; i <= cc.config.CommitRetries; i++ {
-		logger.Debug("attempt #%d: committing %+v", i, op)
+		logger.Debugf("attempt #%d: committing %+v", i, op)
 
 		// this means we are retrying
 		if finalErr != nil {

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -285,6 +285,10 @@ func (cc *Consensus) commit(op *LogOp, rpcOp string, redirectArg interface{}) er
 
 		// addPeer and rmPeer need to apply the change to Raft directly.
 		switch op.Type {
+		case LogOpPin:
+			logger.Infof("pin committed to global state: %s", op.Cid.Cid)
+		case LogOpUnpin:
+			logger.Infof("unpin committed to global state: %s", op.Cid.Cid)
 		case LogOpAddPeer:
 			pidstr := parsePIDFromMultiaddr(op.Peer.ToMultiaddr())
 			finalErr = cc.raft.AddPeer(pidstr)
@@ -316,7 +320,6 @@ func (cc *Consensus) LogPin(pin api.Pin) error {
 	if err != nil {
 		return err
 	}
-	logger.Infof("pin committed to global state: %s", pin.Cid)
 	return nil
 }
 
@@ -327,7 +330,6 @@ func (cc *Consensus) LogUnpin(pin api.Pin) error {
 	if err != nil {
 		return err
 	}
-	logger.Infof("unpin committed to global state: %s", pin.Cid)
 	return nil
 }
 

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -160,7 +160,6 @@ func (cc *Consensus) Shutdown() error {
 	err := cc.raft.Shutdown()
 	if err != nil {
 		logger.Error(err)
-		return err
 	}
 	cc.shutdown = true
 	cc.cancel()

--- a/consensus/raft/consensus_test.go
+++ b/consensus/raft/consensus_test.go
@@ -60,7 +60,7 @@ func testingConsensus(t *testing.T, port int) *Consensus {
 	if err != nil {
 		t.Fatal("cannot create Consensus:", err)
 	}
-	cc.SetClient(test.NewMockRPCClient(t))
+	cc.SetClient(test.NewMockRPCClientWithHost(t, h))
 	<-cc.Ready()
 	return cc
 }
@@ -68,18 +68,23 @@ func testingConsensus(t *testing.T, port int) *Consensus {
 func TestShutdownConsensus(t *testing.T) {
 	// Bring it up twice to make sure shutdown cleans up properly
 	// but also to make sure raft comes up ok when re-initialized
-	defer cleanRaft(p2pPort)
 	cc := testingConsensus(t, p2pPort)
 	err := cc.Shutdown()
 	if err != nil {
 		t.Fatal("Consensus cannot shutdown:", err)
 	}
-	cc.Shutdown()
+	err = cc.Shutdown() // should be fine to shutdown twice
+	if err != nil {
+		t.Fatal("Consensus should be able to shutdown several times")
+	}
+	cleanRaft(p2pPort)
+
 	cc = testingConsensus(t, p2pPort)
 	err = cc.Shutdown()
 	if err != nil {
 		t.Fatal("Consensus cannot shutdown:", err)
 	}
+	cleanRaft(p2pPort)
 }
 
 func TestConsensusPin(t *testing.T) {
@@ -129,6 +134,7 @@ func TestConsensusLogAddPeer(t *testing.T) {
 
 	addr, _ := ma.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", p2pPortAlt))
 	haddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", cc2.host.ID().Pretty()))
+
 	cc.host.Peerstore().AddAddr(cc2.host.ID(), addr, peerstore.TempAddrTTL)
 	err := cc.LogAddPeer(addr.Encapsulate(haddr))
 	if err != nil {
@@ -138,12 +144,43 @@ func TestConsensusLogAddPeer(t *testing.T) {
 
 func TestConsensusLogRmPeer(t *testing.T) {
 	cc := testingConsensus(t, p2pPort)
+	cc2 := testingConsensus(t, p2pPortAlt)
 	defer cleanRaft(p2pPort)
+	defer cleanRaft(p2pPortAlt)
 	defer cc.Shutdown()
+	defer cc2.Shutdown()
 
-	err := cc.LogRmPeer(test.TestPeerID1)
+	addr, _ := ma.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", p2pPortAlt))
+	haddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", cc2.host.ID().Pretty()))
+	cc.host.Peerstore().AddAddr(cc2.host.ID(), addr, peerstore.TempAddrTTL)
+
+	err := cc.LogAddPeer(addr.Encapsulate(haddr))
+	if err != nil {
+		t.Error("could not add peer:", err)
+	}
+
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	cc.raft.WaitForLeader(ctx)
+
+	c, _ := cid.Decode(test.TestCid1)
+	err = cc.LogPin(api.Pin{Cid: c, ReplicationFactor: -1})
+	if err != nil {
+		t.Error("could not pin after adding peer:", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	// Remove unexisting peer
+	err = cc.LogRmPeer(test.TestPeerID1)
 	if err != nil {
 		t.Error("the operation did not make it to the log:", err)
+	}
+
+	// Remove real peer. At least the leader can succeed
+	err = cc2.LogRmPeer(cc.host.ID())
+	err2 := cc.LogRmPeer(cc2.host.ID())
+	if err != nil && err2 != nil {
+		t.Error("could not remove peer:", err, err2)
 	}
 }
 

--- a/consensus/raft/log_op.go
+++ b/consensus/raft/log_op.go
@@ -74,7 +74,6 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 			"PeerManagerAddPeer",
 			op.Peer,
 			&struct{}{})
-		// TODO rebalance ops
 	case LogOpRmPeer:
 		pidstr := parsePIDFromMultiaddr(op.Peer.ToMultiaddr())
 		pid, err := peer.IDB58Decode(pidstr)
@@ -86,7 +85,6 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 			"PeerManagerRmPeer",
 			pid,
 			&struct{}{})
-		// TODO rebalance ops
 	default:
 		logger.Error("unknown LogOp type. Ignoring")
 	}

--- a/consensus/raft/log_op_test.go
+++ b/consensus/raft/log_op_test.go
@@ -1,7 +1,6 @@
 package raft
 
 import (
-	"context"
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
@@ -12,12 +11,14 @@ import (
 )
 
 func TestApplyToPin(t *testing.T) {
+	cc := testingConsensus(t, p2pPort)
 	op := &LogOp{
 		Cid:       api.PinSerial{Cid: test.TestCid1},
 		Type:      LogOpPin,
-		ctx:       context.Background(),
-		rpcClient: test.NewMockRPCClient(t),
+		consensus: cc,
 	}
+	defer cleanRaft(p2pPort)
+	defer cc.Shutdown()
 
 	st := mapstate.NewMapState()
 	op.ApplyTo(st)
@@ -28,12 +29,14 @@ func TestApplyToPin(t *testing.T) {
 }
 
 func TestApplyToUnpin(t *testing.T) {
+	cc := testingConsensus(t, p2pPort)
 	op := &LogOp{
 		Cid:       api.PinSerial{Cid: test.TestCid1},
 		Type:      LogOpUnpin,
-		ctx:       context.Background(),
-		rpcClient: test.NewMockRPCClient(t),
+		consensus: cc,
 	}
+	defer cleanRaft(p2pPort)
+	defer cc.Shutdown()
 
 	st := mapstate.NewMapState()
 	c, _ := cid.Decode(test.TestCid1)
@@ -53,10 +56,8 @@ func TestApplyToBadState(t *testing.T) {
 	}()
 
 	op := &LogOp{
-		Cid:       api.PinSerial{Cid: test.TestCid1},
-		Type:      LogOpUnpin,
-		ctx:       context.Background(),
-		rpcClient: test.NewMockRPCClient(t),
+		Cid:  api.PinSerial{Cid: test.TestCid1},
+		Type: LogOpUnpin,
 	}
 
 	var st interface{}

--- a/consensus/raft/logging.go
+++ b/consensus/raft/logging.go
@@ -7,9 +7,23 @@ import (
 	logging "github.com/ipfs/go-log"
 )
 
+const (
+	debug = iota
+	info
+	warn
+	err
+)
+
 // This provides a custom logger for Raft which intercepts Raft log messages
 // and rewrites us to our own logger (for "raft" facility).
-type logForwarder struct{}
+type logForwarder struct {
+	last map[int]*lastMsg
+}
+
+type lastMsg struct {
+	msg    string
+	tipped bool
+}
 
 var raftStdLogger = log.New(&logForwarder{}, "", 0)
 var raftLogger = logging.Logger("raft")
@@ -17,19 +31,61 @@ var raftLogger = logging.Logger("raft")
 // Write forwards to our go-log logger.
 // According to https://golang.org/pkg/log/#Logger.Output
 // it is called per line.
-func (fw *logForwarder) Write(p []byte) (n int, err error) {
+func (fw *logForwarder) Write(p []byte) (n int, e error) {
 	t := strings.TrimSuffix(string(p), "\n")
+
 	switch {
 	case strings.Contains(t, "[DEBUG]"):
-		raftLogger.Debug(strings.TrimPrefix(t, "[DEBUG] raft: "))
+		if !fw.repeated(debug, t) {
+			fw.log(debug, strings.TrimPrefix(t, "[DEBUG] raft: "))
+		}
 	case strings.Contains(t, "[WARN]"):
-		raftLogger.Warning(strings.TrimPrefix(t, "[WARN]  raft: "))
+		if !fw.repeated(warn, t) {
+			fw.log(warn, strings.TrimPrefix(t, "[WARN]  raft: "))
+		}
 	case strings.Contains(t, "[ERR]"):
-		raftLogger.Error(strings.TrimPrefix(t, "[ERR] raft: "))
+		if !fw.repeated(err, t) {
+			fw.log(err, strings.TrimPrefix(t, "[ERR] raft: "))
+		}
 	case strings.Contains(t, "[INFO]"):
-		raftLogger.Info(strings.TrimPrefix(t, "[INFO] raft: "))
+		if !fw.repeated(info, t) {
+			fw.log(info, strings.TrimPrefix(t, "[INFO] raft: "))
+		}
 	default:
-		raftLogger.Debug(t)
+		fw.log(debug, t)
 	}
 	return len(p), nil
+}
+
+func (fw *logForwarder) repeated(t int, msg string) bool {
+	if fw.last == nil {
+		fw.last = make(map[int]*lastMsg)
+	}
+
+	last, ok := fw.last[t]
+	if !ok || last.msg != msg {
+		fw.last[t] = &lastMsg{msg, false}
+		return false
+	} else {
+		if !last.tipped {
+			fw.log(t, "NOTICE: The last RAFT log message repeats and will only be logged once")
+			last.tipped = true
+		}
+		return true
+	}
+}
+
+func (fw *logForwarder) log(t int, msg string) {
+	switch t {
+	case debug:
+		raftLogger.Debug(msg)
+	case info:
+		raftLogger.Info(msg)
+	case warn:
+		raftLogger.Warning(msg)
+	case err:
+		raftLogger.Error(msg)
+	default:
+		raftLogger.Debug(msg)
+	}
 }

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -116,17 +116,19 @@ func newRaftWrapper(peers []peer.ID, host host.Host, cfg *Config, fsm hraft.FSM)
 		added, removed := diffConfigurations(srvCfg, currentCfg)
 		if len(added)+len(removed) > 0 {
 			raftW.Shutdown()
-			logger.Error("Raft peers do not match cluster peers")
-			logger.Error("Aborting. Please clean this peer.")
-			logger.Errorf("Raft state peers:")
+			logger.Warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+			logger.Warning("Raft peers do not match cluster peers from the configuration.")
+			logger.Warning("If problems arise, clean this peer and bootstrap it to a working cluster.")
+			logger.Warning("Raft peers peers:")
 			for _, s := range currentCfg.Servers {
-				logger.Errorf("  - %s", s.ID)
+				logger.Warningf("  - %s", s.ID)
 			}
-			logger.Errorf("Cluster configuration peers:")
+			logger.Warning("Cluster configuration peers:")
 			for _, s := range srvCfg.Servers {
-				logger.Errorf("  - %s", s.ID)
+				logger.Warningf("  - %s", s.ID)
 			}
-			return nil, errors.New("Bad cluster peers")
+			logger.Warningf("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+			//return nil, errors.New("Bad cluster peers")
 		}
 	}
 

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -43,6 +43,7 @@ const sixtyfour = uint64(^uint(0)) == ^uint64(0)
 // if need be.
 type raftWrapper struct {
 	raft          *hraft.Raft
+	dataFolder    string
 	srvConfig     hraft.Configuration
 	transport     *hraft.NetworkTransport
 	snapshotStore hraft.SnapshotStore
@@ -125,6 +126,7 @@ func newRaftWrapper(peers []peer.ID, host host.Host, cfg *Config, fsm hraft.FSM)
 
 	raftW := &raftWrapper{
 		raft:          r,
+		dataFolder:    dataFolder,
 		srvConfig:     srvCfg,
 		transport:     transport,
 		snapshotStore: snap,
@@ -423,6 +425,11 @@ func (rw *raftWrapper) Peers() ([]string, error) {
 	}
 
 	return ids, nil
+}
+
+// only call when Raft is shutdown
+func (rw *raftWrapper) Clean() error {
+	return os.RemoveAll(rw.dataFolder)
 }
 
 func find(s []string, elem string) bool {

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -117,7 +117,15 @@ func newRaftWrapper(peers []peer.ID, host host.Host, cfg *Config, fsm hraft.FSM)
 		if len(added)+len(removed) > 0 {
 			raftW.Shutdown()
 			logger.Error("Raft peers do not match cluster peers")
-			logger.Error("Aborting. Please clean this peer")
+			logger.Error("Aborting. Please clean this peer.")
+			logger.Errorf("Raft state peers:")
+			for _, s := range currentCfg.Servers {
+				logger.Errorf("  - %s", s.ID)
+			}
+			logger.Errorf("Cluster configuration peers:")
+			for _, s := range srvCfg.Servers {
+				logger.Errorf("  - %s", s.ID)
+			}
 			return nil, errors.New("Bad cluster peers")
 		}
 	}

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -108,7 +108,6 @@ func newRaftWrapper(peers []peer.ID, host host.Host, cfg *Config, fsm hraft.FSM)
 
 	// Handle existing, different configuration
 	if hasState {
-		logger.Error("has state")
 		cf := r.GetConfiguration()
 		if err := cf.Error(); err != nil {
 			return nil, err

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -5,173 +5,237 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	hashiraft "github.com/hashicorp/raft"
+	hraft "github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
 	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
-	libp2praft "github.com/libp2p/go-libp2p-raft"
+	p2praft "github.com/libp2p/go-libp2p-raft"
 )
 
 // RaftMaxSnapshots indicates how many snapshots to keep in the consensus data
 // folder.
+// TODO: Maybe include this in Config. Not sure how useful it is to touch
+// this anyways.
 var RaftMaxSnapshots = 5
 
-// is this running 64 bits arch? https://groups.google.com/forum/#!topic/golang-nuts/vAckmhUMAdQ
+// Are we compiled on a 64-bit architecture?
+// https://groups.google.com/forum/#!topic/golang-nuts/vAckmhUMAdQ
+// This is used below because raft Observers panic on 32-bit.
 const sixtyfour = uint64(^uint(0)) == ^uint64(0)
 
-// Raft performs all Raft-specific operations which are needed by Cluster but
-// are not fulfilled by the consensus interface. It should contain most of the
-// Raft-related stuff so it can be easily replaced in the future, if need be.
-type Raft struct {
-	raft          *hashiraft.Raft
-	transport     *libp2praft.Libp2pTransport
-	snapshotStore hashiraft.SnapshotStore
-	logStore      hashiraft.LogStore
-	stableStore   hashiraft.StableStore
-	peerstore     *libp2praft.Peerstore
+// raftWrapper performs all Raft-specific operations which are needed by
+// Cluster but are not fulfilled by the consensus interface. It should contain
+// most of the Raft-related stuff so it can be easily replaced in the future,
+// if need be.
+type raftWrapper struct {
+	raft          *hraft.Raft
+	srvConfig     hraft.Configuration
+	transport     *hraft.NetworkTransport
+	snapshotStore hraft.SnapshotStore
+	logStore      hraft.LogStore
+	stableStore   hraft.StableStore
 	boltdb        *raftboltdb.BoltStore
-	dataFolder    string
 }
 
-// NewRaft launches a go-libp2p-raft consensus peer.
-func NewRaft(peers []peer.ID, host host.Host, cfg *Config, fsm hashiraft.FSM) (*Raft, error) {
+// newRaft launches a go-libp2p-raft consensus peer.
+func newRaftWrapper(peers []peer.ID, host host.Host, cfg *Config, fsm hraft.FSM) (*raftWrapper, error) {
+	// Set correct LocalID
+	cfg.RaftConfig.LocalID = hraft.ServerID(peer.IDB58Encode(host.ID()))
+
+	// Prepare data folder
+	dataFolder, err := makeDataFolder(cfg.BaseDir, cfg.DataFolder)
+	if err != nil {
+		return nil, err
+	}
+	srvCfg := makeServerConf(peers)
+
 	logger.Debug("creating libp2p Raft transport")
-	transport, err := libp2praft.NewLibp2pTransportWithHost(host)
+	transport, err := p2praft.NewLibp2pTransport(host, cfg.NetworkTimeout)
 	if err != nil {
-		logger.Error("creating libp2p-raft transport: ", err)
 		return nil, err
 	}
 
-	pstore := &libp2praft.Peerstore{}
-	peersStr := make([]string, len(peers), len(peers))
-	for i, p := range peers {
-		peersStr[i] = peer.IDB58Encode(p)
-	}
-	pstore.SetPeers(peersStr)
-
-	logger.Debug("creating file snapshot store")
-	dataFolder := cfg.DataFolder
-	if dataFolder == "" {
-		dataFolder = filepath.Join(cfg.BaseDir, DefaultDataSubFolder)
-	}
-
-	err = os.MkdirAll(dataFolder, 0700)
+	logger.Debug("creating raft snapshot store")
+	snapshots, err := hraft.NewFileSnapshotStoreWithLogger(
+		dataFolder, RaftMaxSnapshots, raftStdLogger)
 	if err != nil {
-		logger.Errorf("creating cosensus data folder (%s): %s",
-			dataFolder, err)
-		return nil, err
-	}
-	snapshots, err := hashiraft.NewFileSnapshotStoreWithLogger(dataFolder, RaftMaxSnapshots, raftStdLogger)
-	if err != nil {
-		logger.Error("creating file snapshot store: ", err)
 		return nil, err
 	}
 
 	logger.Debug("creating BoltDB log store")
-	logStore, err := raftboltdb.NewBoltStore(filepath.Join(dataFolder, "raft.db"))
+	logStore, err := raftboltdb.NewBoltStore(
+		filepath.Join(dataFolder, "raft.db"))
 	if err != nil {
-		logger.Error("creating bolt store: ", err)
 		return nil, err
 	}
 
+	logger.Debug("checking for existing raft states")
+	hasState, err := hraft.HasExistingState(logStore, logStore, snapshots)
+	if err != nil {
+		return nil, err
+	}
+	if !hasState {
+		logger.Info("bootstrapping raft cluster")
+		err := hraft.BootstrapCluster(cfg.RaftConfig,
+			logStore, logStore, snapshots, transport, srvCfg)
+		if err != nil {
+			logger.Error("bootstrapping cluster: ", err)
+			return nil, err
+		}
+	} else {
+		logger.Info("raft cluster is already bootstrapped")
+	}
+
 	logger.Debug("creating Raft")
-	r, err := hashiraft.NewRaft(cfg.HashiraftCfg, fsm, logStore, logStore, snapshots, pstore, transport)
+	r, err := hraft.NewRaft(cfg.RaftConfig,
+		fsm, logStore, logStore, snapshots, transport)
 	if err != nil {
 		logger.Error("initializing raft: ", err)
 		return nil, err
 	}
 
-	raft := &Raft{
+	raftW := &raftWrapper{
 		raft:          r,
+		srvConfig:     srvCfg,
 		transport:     transport,
 		snapshotStore: snapshots,
 		logStore:      logStore,
 		stableStore:   logStore,
-		peerstore:     pstore,
 		boltdb:        logStore,
-		dataFolder:    dataFolder,
 	}
 
-	return raft, nil
+	// Handle existing, different configuration
+	if hasState {
+		logger.Error("has state")
+		cf := r.GetConfiguration()
+		if err := cf.Error(); err != nil {
+			return nil, err
+		}
+		currentCfg := cf.Configuration()
+		added, removed := diffConfigurations(srvCfg, currentCfg)
+		if len(added)+len(removed) > 0 {
+			raftW.Shutdown()
+			logger.Error("Raft peers do not match cluster peers")
+			logger.Error("Aborting. Please clean this peer")
+			return nil, errors.New("Bad cluster peers")
+		}
+	}
+
+	return raftW, nil
+}
+
+// returns the folder path after creating it.
+// if folder is empty, it uses baseDir+Default.
+func makeDataFolder(baseDir, folder string) (string, error) {
+	if folder == "" {
+		folder = filepath.Join(baseDir, DefaultDataSubFolder)
+	}
+
+	err := os.MkdirAll(folder, 0700)
+	if err != nil {
+		return "", err
+	}
+	return folder, nil
+}
+
+// create Raft servers configuration
+func makeServerConf(peers []peer.ID) hraft.Configuration {
+	sm := make(map[string]struct{})
+
+	servers := make([]hraft.Server, 0)
+	for _, pid := range peers {
+		p := peer.IDB58Encode(pid)
+		_, ok := sm[p]
+		if !ok { // avoid dups
+			sm[p] = struct{}{}
+			servers = append(servers, hraft.Server{
+				Suffrage: hraft.Voter,
+				ID:       hraft.ServerID(p),
+				Address:  hraft.ServerAddress(p),
+			})
+		}
+	}
+	return hraft.Configuration{
+		Servers: servers,
+	}
+}
+
+// diffConfigurations returns the serverIDs added and removed from
+// c2 in relation to c1.
+func diffConfigurations(
+	c1, c2 hraft.Configuration) (added, removed []hraft.ServerID) {
+	m1 := make(map[hraft.ServerID]struct{})
+	m2 := make(map[hraft.ServerID]struct{})
+	added = make([]hraft.ServerID, 0)
+	removed = make([]hraft.ServerID, 0)
+	for _, s := range c1.Servers {
+		m1[s.ID] = struct{}{}
+	}
+	for _, s := range c2.Servers {
+		m2[s.ID] = struct{}{}
+	}
+	for k, _ := range m1 {
+		_, ok := m2[k]
+		if !ok {
+			removed = append(removed, k)
+		}
+	}
+	for k, _ := range m2 {
+		_, ok := m1[k]
+		if !ok {
+			added = append(added, k)
+		}
+	}
+	return
 }
 
 // WaitForLeader holds until Raft says we have a leader.
-// Returns an error if we don't.
-func (r *Raft) WaitForLeader(ctx context.Context) error {
-	// Using Raft observers panics on non-64 architectures.
-	// This is a work around
-	if sixtyfour {
-		return r.waitForLeader(ctx)
+// Returns uf ctx is cancelled.
+func (rw *raftWrapper) WaitForLeader(ctx context.Context) (string, error) {
+	obsCh := make(chan hraft.Observation, 1)
+	if sixtyfour { // 32-bit systems don't support observers
+		observer := hraft.NewObserver(obsCh, false, nil)
+		rw.raft.RegisterObserver(observer)
+		defer rw.raft.DeregisterObserver(observer)
 	}
-	return r.waitForLeaderLegacy(ctx)
-}
-
-func (r *Raft) waitForLeader(ctx context.Context) error {
-	obsCh := make(chan hashiraft.Observation, 1)
-	filter := func(o *hashiraft.Observation) bool {
-		switch o.Data.(type) {
-		case hashiraft.LeaderObservation:
-			return true
-		default:
-			return false
-		}
-	}
-	observer := hashiraft.NewObserver(obsCh, false, filter)
-	r.raft.RegisterObserver(observer)
-	defer r.raft.DeregisterObserver(observer)
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(time.Second / 2)
 	for {
 		select {
 		case obs := <-obsCh:
-			switch obs.Data.(type) {
-			case hashiraft.LeaderObservation:
-				leaderObs := obs.Data.(hashiraft.LeaderObservation)
-				logger.Infof("Raft Leader elected: %s", leaderObs.Leader)
-				return nil
-			}
+			_ = obs
+			// See https://github.com/hashicorp/raft/issues/254
+			// switch obs.Data.(type) {
+			// case hraft.LeaderObservation:
+			// 	lObs := obs.Data.(hraft.LeaderObservation)
+			// 	logger.Infof("Raft Leader elected: %s",
+			// 		lObs.Leader)
+			// 	return string(lObs.Leader), nil
+			// }
 		case <-ticker.C:
-			if l := r.raft.Leader(); l != "" { //we missed or there was no election
+			if l := rw.raft.Leader(); l != "" {
 				logger.Debug("waitForleaderTimer")
 				logger.Infof("Raft Leader elected: %s", l)
 				ticker.Stop()
-				return nil
+				return string(l), nil
 			}
 		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-// 32-bit systems should use this.
-func (r *Raft) waitForLeaderLegacy(ctx context.Context) error {
-	for {
-		leader := r.raft.Leader()
-		if leader != "" {
-			logger.Infof("Raft Leader elected: %s", leader)
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			time.Sleep(500 * time.Millisecond)
+			return "", ctx.Err()
 		}
 	}
 }
 
 // WaitForUpdates holds until Raft has synced to the last index in the log
-func (r *Raft) WaitForUpdates(ctx context.Context) error {
-	logger.Debug("Raft state is catching up")
+func (rw *raftWrapper) WaitForUpdates(ctx context.Context) error {
+	logger.Info("Raft state is catching up")
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			lai := r.raft.AppliedIndex()
-			li := r.raft.LastIndex()
+			lai := rw.raft.AppliedIndex()
+			li := rw.raft.LastIndex()
 			logger.Debugf("current Raft index: %d/%d",
 				lai, li)
 			if lai == li {
@@ -183,25 +247,25 @@ func (r *Raft) WaitForUpdates(ctx context.Context) error {
 }
 
 // Snapshot tells Raft to take a snapshot.
-func (r *Raft) Snapshot() error {
-	future := r.raft.Snapshot()
+func (rw *raftWrapper) Snapshot() error {
+	future := rw.raft.Snapshot()
 	err := future.Error()
-	if err != nil && !strings.Contains(err.Error(), "Nothing new to snapshot") {
-		return errors.New("could not take snapshot: " + err.Error())
+	if err != nil && err.Error() != hraft.ErrNothingNewToSnapshot.Error() {
+		return err
 	}
 	return nil
 }
 
 // Shutdown shutdown Raft and closes the BoltDB.
-func (r *Raft) Shutdown() error {
-	future := r.raft.Shutdown()
+func (rw *raftWrapper) Shutdown() error {
+	future := rw.raft.Shutdown()
 	err := future.Error()
 	errMsgs := ""
 	if err != nil {
 		errMsgs += "could not shutdown raft: " + err.Error() + ".\n"
 	}
 
-	err = r.boltdb.Close() // important!
+	err = rw.boltdb.Close() // important!
 	if err != nil {
 		errMsgs += "could not close boltdb: " + err.Error()
 	}
@@ -210,76 +274,88 @@ func (r *Raft) Shutdown() error {
 		return errors.New(errMsgs)
 	}
 
-	// If the shutdown worked correctly
-	// (including snapshot) we can remove the Raft
-	// database (which traces peers additions
-	// and removals). It makes re-start of the peer
-	// way less confusing for Raft while the state
-	// can be restored from the snapshot.
-	//os.Remove(filepath.Join(r.dataFolder, "raft.db"))
 	return nil
 }
 
 // AddPeer adds a peer to Raft
-func (r *Raft) AddPeer(peer string) error {
-	if r.hasPeer(peer) {
-		logger.Debug("skipping raft add as already in peer set")
+func (rw *raftWrapper) AddPeer(peer string) error {
+	// Check that we don't have it to not waste
+	// log entries if so.
+	peers, err := rw.Peers()
+	if err != nil {
+		return err
+	}
+	if find(peers, peer) {
+		logger.Infof("%s is already a raft peer", peer)
 		return nil
 	}
 
-	future := r.raft.AddPeer(peer)
-	err := future.Error()
+	future := rw.raft.AddVoter(
+		hraft.ServerID(peer),
+		hraft.ServerAddress(peer),
+		0,
+		0) // TODO: Extra cfg value?
+	err = future.Error()
 	if err != nil {
 		logger.Error("raft cannot add peer: ", err)
-		return err
 	}
-	peers, _ := r.peerstore.Peers()
-	logger.Debugf("raft peerstore: %s", peers)
 	return err
 }
 
 // RemovePeer removes a peer from Raft
-func (r *Raft) RemovePeer(peer string) error {
-	if !r.hasPeer(peer) {
+func (rw *raftWrapper) RemovePeer(peer string) error {
+	// Check that we have it to not waste
+	// log entries if we don't.
+	peers, err := rw.Peers()
+	if err != nil {
+		return err
+	}
+	if !find(peers, peer) {
+		logger.Infof("%s is not among raft peers", peer)
 		return nil
 	}
 
-	future := r.raft.RemovePeer(peer)
-	err := future.Error()
+	if len(peers) == 1 && peers[0] == peer {
+		return errors.New("cannot remove ourselves from a 1-peer cluster")
+	}
+
+	future := rw.raft.RemoveServer(
+		hraft.ServerID(peer),
+		0,
+		0) // TODO: Extra cfg value?
+	err = future.Error()
 	if err != nil {
 		logger.Error("raft cannot remove peer: ", err)
-		return err
 	}
-	peers, _ := r.peerstore.Peers()
-	logger.Debugf("raft peerstore: %s", peers)
 	return err
 }
 
-// func (r *Raft) SetPeers(peers []string) error {
-//	logger.Debugf("SetPeers(): %s", peers)
-//	future := r.raft.SetPeers(peers)
-//	err := future.Error()
-//	if err != nil {
-//		logger.Error(err)
-//	}
-//	return err
-// }
-
 // Leader returns Raft's leader. It may be an empty string if
 // there is no leader or it is unknown.
-func (r *Raft) Leader() string {
-	return r.raft.Leader()
+func (rw *raftWrapper) Leader() string {
+	return string(rw.raft.Leader())
 }
 
-func (r *Raft) hasPeer(peer string) bool {
-	found := false
-	peers, _ := r.peerstore.Peers()
-	for _, p := range peers {
-		if p == peer {
-			found = true
-			break
-		}
+func (rw *raftWrapper) Peers() ([]string, error) {
+	ids := make([]string, 0)
+
+	configFuture := rw.raft.GetConfiguration()
+	if err := configFuture.Error(); err != nil {
+		return nil, err
 	}
 
-	return found
+	for _, server := range configFuture.Configuration().Servers {
+		ids = append(ids, string(server.ID))
+	}
+
+	return ids, nil
+}
+
+func find(s []string, elem string) bool {
+	for _, selem := range s {
+		if selem == elem {
+			return true
+		}
+	}
+	return false
 }

--- a/debug.go
+++ b/debug.go
@@ -8,6 +8,9 @@ func init() {
 		SetFacilityLogLevel(f, l)
 	}
 
+	//SetFacilityLogLevel("cluster", l)
+	//SetFacilityLogLevel("consensus", l)
+	//SetFacilityLogLevel("monitor", "INFO")
 	//SetFacilityLogLevel("raft", l)
 	//SetFacilityLogLevel("p2p-gorpc", l)
 	//SetFacilityLogLevel("swarm2", l)

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -317,13 +317,15 @@ func daemon(c *cli.Context) error {
 		case <-signalChan:
 			err = cluster.Shutdown()
 			checkErr("shutting down cluster", err)
-			cfg.Shutdown()
 		case <-cluster.Done():
 			return nil
 
 			//case <-cluster.Ready():
 		}
 	}
+	// wait for configuration to be saved
+	cfg.Shutdown()
+	return nil
 }
 
 var facilities = []string{

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -54,6 +54,8 @@ type Consensus interface {
 	// Only returns when the consensus state has all log
 	// updates applied to it
 	WaitForSync() error
+	// Clean removes all consensus data
+	Clean() error
 }
 
 // API is a component which offers an API for Cluster. This is

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -225,7 +225,7 @@ func waitForLeader(t *testing.T, clusters []*Cluster) {
 
 	// Make sure we don't check on a shutdown cluster
 	j := rand.Intn(len(clusters))
-	for clusters[j].shutdown {
+	for clusters[j].shutdownB {
 		j = rand.Intn(len(clusters))
 	}
 

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmQA5mdxru8Bh6dpC9PJfSkumqnmHgJX7knxSgBo5Lpime",
+      "hash": "QmefgzMbKZYsmHFkLqxgaTBG9ypeEjrdWRD5WXH4j1cWDL",
       "name": "go-libp2p",
-      "version": "4.3.12"
+      "version": "5.0.5"
     },
     {
       "author": "hsanjuan",
-      "hash": "QmSLvGe32QcBEDjqrC93pnZzB6gh4VZTi2wVLt9EyUTUWX",
+      "hash": "QmcjpDnmS6jGrYrTnuT4RDHUHduF97w2V8JuYs6eynbFg2",
       "name": "go-libp2p-raft",
-      "version": "1.0.6"
+      "version": "1.1.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD",
+      "hash": "QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ",
       "name": "go-cid",
-      "version": "0.7.7"
+      "version": "0.7.18"
     },
     {
       "author": "urfave",
@@ -39,9 +39,9 @@
     },
     {
       "author": "hashicorp",
-      "hash": "QmfNTPUT6FKg2wyPcqgn3tKuGJWnvu6QqwHoo56FgcR4c2",
+      "hash": "QmZa48BnsaEMVNf1hT2HYP2ak97fqyTnadXu6xSu2Y8xui",
       "name": "raft-boltdb",
-      "version": "2017.7.27"
+      "version": "2017.10.24"
     },
     {
       "author": "gorilla",
@@ -51,15 +51,15 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmayPizdYNaSKGyFFxcjKf4ZkZ6kriQePqZkFwZQyvteDp",
+      "hash": "QmW2qYs8uJUSAsdGrWZo1LnzAwTQjPBRKk66X9H16EABMg",
       "name": "go-libp2p-gorpc",
-      "version": "1.0.2"
+      "version": "1.0.4"
     },
     {
       "author": "libp2p",
-      "hash": "QmTJoXQ24GqDf9MqAUwf3vW38HG6ahE9S7GzZoRMEeE8Kc",
+      "hash": "QmcWmYQEQCrezztaQ81nXzMx2jaAEow17wdesDAjjR769r",
       "name": "go-libp2p-pnet",
-      "version": "2.2.4"
+      "version": "2.3.1"
     }
   ],
   "gxVersion": "0.11.0",

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -153,11 +153,11 @@ func (pm *peerManager) peersAddrs() []ma.Multiaddr {
 }
 
 // func (pm *peerManager) addFromConfig(cfg *Config) error {
-// 	return pm.addFromMultiaddrs(cfg.ClusterPeers)
+// 	return pm.setFromMultiaddrs(cfg.ClusterPeers)
 // }
 
 // this resets peers!
-func (pm *peerManager) addFromMultiaddrs(addrs []ma.Multiaddr, save bool) error {
+func (pm *peerManager) setFromMultiaddrs(addrs []ma.Multiaddr, save bool) error {
 	pm.resetPeers()
 	for _, m := range addrs {
 		err := pm.addPeer(m, false)

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -37,8 +37,10 @@ func (pm *peerManager) addPeer(addr ma.Multiaddr) error {
 	}
 	pm.ps.AddAddr(pid, decapAddr, peerstore.PermanentAddrTTL)
 
-	if !pm.isPeer(pid) {
-		logger.Infof("new Cluster peer %s", addr.String())
+	// Only log these when we are not starting cluster (rpcClient == nil)
+	// They pollute the start up logs redundantly.
+	if !pm.isPeer(pid) && pm.cluster.rpcClient != nil {
+		logger.Infof("new peer: %s", addr.String())
 	}
 
 	pm.m.Lock()

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -77,6 +77,7 @@ func (pm *peerManager) rmPeer(pid peer.ID, save bool) error {
 		pm.cluster.config.Bootstrap = pm.peersAddrs()
 		pm.resetPeers()
 		time.Sleep(1 * time.Second)
+		pm.cluster.removed = true
 		// should block and do nothing if already doing it
 		pm.cluster.Shutdown()
 	}

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -294,10 +294,10 @@ func (rpcapi *RPCAPI) PeerManagerAddPeer(in api.MultiaddrSerial, out *struct{}) 
 	return err
 }
 
-// PeerManagerAddFromMultiaddrs runs peerManager.addFromMultiaddrs().
-func (rpcapi *RPCAPI) PeerManagerAddFromMultiaddrs(in api.MultiaddrsSerial, out *struct{}) error {
+// PeerManagerSetFromMultiaddrs runs peerManager.setFromMultiaddrs().
+func (rpcapi *RPCAPI) PeerManagerSetFromMultiaddrs(in api.MultiaddrsSerial, out *struct{}) error {
 	addrs := in.ToMultiaddrs()
-	err := rpcapi.c.peerManager.addFromMultiaddrs(addrs, true)
+	err := rpcapi.c.peerManager.setFromMultiaddrs(addrs, true)
 	return err
 }
 

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -290,25 +290,20 @@ func (rpcapi *RPCAPI) ConsensusLogRmPeer(in peer.ID, out *struct{}) error {
 // PeerManagerAddPeer runs peerManager.addPeer().
 func (rpcapi *RPCAPI) PeerManagerAddPeer(in api.MultiaddrSerial, out *struct{}) error {
 	addr := in.ToMultiaddr()
-	err := rpcapi.c.peerManager.addPeer(addr)
+	err := rpcapi.c.peerManager.addPeer(addr, true)
 	return err
 }
 
 // PeerManagerAddFromMultiaddrs runs peerManager.addFromMultiaddrs().
 func (rpcapi *RPCAPI) PeerManagerAddFromMultiaddrs(in api.MultiaddrsSerial, out *struct{}) error {
 	addrs := in.ToMultiaddrs()
-	err := rpcapi.c.peerManager.addFromMultiaddrs(addrs)
+	err := rpcapi.c.peerManager.addFromMultiaddrs(addrs, true)
 	return err
-}
-
-// PeerManagerRmPeerShutdown runs peerManager.rmPeer().
-func (rpcapi *RPCAPI) PeerManagerRmPeerShutdown(in peer.ID, out *struct{}) error {
-	return rpcapi.c.peerManager.rmPeer(in, true)
 }
 
 // PeerManagerRmPeer runs peerManager.rmPeer().
 func (rpcapi *RPCAPI) PeerManagerRmPeer(in peer.ID, out *struct{}) error {
-	return rpcapi.c.peerManager.rmPeer(in, false)
+	return rpcapi.c.peerManager.rmPeer(in, true)
 }
 
 // PeerManagerPeers runs peerManager.peers().

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -9,6 +9,7 @@ import (
 
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 	cid "github.com/ipfs/go-cid"
+	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
@@ -21,8 +22,14 @@ type mockService struct{}
 // NewMockRPCClient creates a mock ipfs-cluster RPC server and returns
 // a client to it.
 func NewMockRPCClient(t *testing.T) *rpc.Client {
-	s := rpc.NewServer(nil, "mock")
-	c := rpc.NewClientWithServer(nil, "mock", s)
+	return NewMockRPCClientWithHost(t, nil)
+}
+
+// NewMockRPCClientWithHost returns a mock ipfs-cluster RPC server
+// initialized with a given host.
+func NewMockRPCClientWithHost(t *testing.T, h host.Host) *rpc.Client {
+	s := rpc.NewServer(h, "mock")
+	c := rpc.NewClientWithServer(h, "mock", s)
 	err := s.RegisterName("Cluster", &mockService{})
 	if err != nil {
 		t.Fatal(err)
@@ -273,4 +280,12 @@ func (mock *mockService) IPFSFreeSpace(in struct{}, out *uint64) error {
 	// RepoSize is 2KB, StorageMax is 100KB
 	*out = 98000
 	return nil
+}
+
+func (mock *mockService) ConsensusLogAddPeer(in api.MultiaddrSerial, out *struct{}) error {
+	return errors.New("mock rpc cannot redirect")
+}
+
+func (mock *mockService) ConsensusLogRmPeer(in peer.ID, out *struct{}) error {
+	return errors.New("mock rpc cannot redirect")
 }


### PR DESCRIPTION
The main differences is that the new version of Raft is more strict
about starting raft peers which already contain configurations.

For a start, cluster will fail to start if the configured cluster
peers are different from the Raft peers. The user will have to
manually cleanup Raft (TODO: an ipfs-cluster-service command for it).

Additionally, this commit adds extra options to the consensus/raft
configuration section, adds tests and improves existing ones and
improves certain code sections.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>