### PR TITLE
Fix #216: Docker does not like an env variable in CMD (anymore?)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ RUN mkdir -p $IPFS_CLUSTER_PATH && \
 VOLUME $IPFS_CLUSTER_PATH
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start-daemons.sh"]
 
-CMD ["$IPFS_CLUSTER_OPTS"]
+# Defaults for ipfs-cluster-service would go here
+CMD []

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -53,4 +53,5 @@ RUN mkdir -p $IPFS_CLUSTER_PATH && \
 VOLUME $IPFS_CLUSTER_PATH
 ENTRYPOINT ["/usr/local/bin/start-daemons.sh"]
 
-CMD ["$IPFS_CLUSTER_OPTS"]
+# Defaults would go here
+CMD []

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 set -e
+if [ -n "$DOCKER_DEBUG" ]; then
+   set -x
+fi
 user=ipfs
 
 if [ `id -u` -eq 0 ]; then
@@ -8,7 +11,7 @@ if [ `id -u` -eq 0 ]; then
     # ensure directories are writable
     su-exec "$user" test -w "${IPFS_PATH}" || chown -R -- "$user" "${IPFS_PATH}"
     su-exec "$user" test -w "${IPFS_CLUSTER_PATH}" || chown -R -- "$user" "${IPFS_CLUSTER_PATH}"
-    exec su-exec "$user" "$0" "$@"
+    exec su-exec "$user" "$0" $@
 fi
 
 # Second invocation with regular user

--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 set -e
+if [ -n "$DOCKER_DEBUG" ]; then
+   set -x
+fi
 user=ipfs
 
 if [ `id -u` -eq 0 ]; then
@@ -8,7 +11,7 @@ if [ `id -u` -eq 0 ]; then
     # ensure directories are writable
     su-exec "$user" test -w "${IPFS_PATH}" || chown -R -- "$user" "${IPFS_PATH}"
     su-exec "$user" test -w "${IPFS_CLUSTER_PATH}" || chown -R -- "$user" "${IPFS_CLUSTER_PATH}"
-    exec su-exec "$user" "$0" "$@"
+    exec su-exec "$user" "$0" $@
 fi
 
 ipfs version


### PR DESCRIPTION
This used to work. Even if it's been surfaced by 4a8759939 we were
extensively testing the Dockerfile before that release.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>