### PR TITLE
Fix #224: Better handling of progress updates when proxy-adding file

### DIFF
--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -58,8 +58,9 @@ type mockConfigResp struct {
 }
 
 type mockAddResp struct {
-	Name string
-	Hash string
+	Name  string
+	Hash  string
+	Bytes uint64
 }
 
 // NewIpfsMock returns a new mock.
@@ -104,6 +105,17 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			http.Error(w, "no file in /add", 500)
 			return
+		}
+
+		query := r.URL.Query()
+		progress, ok := query["progress"]
+		if ok && len(progress) > 0 && progress[0] != "false" {
+			progressResp := mockAddResp{
+				Name:  fheader.Filename,
+				Bytes: 4,
+			}
+			j, _ := json.Marshal(progressResp)
+			w.Write(j)
 		}
 
 		resp := mockAddResp{


### PR DESCRIPTION
Up to now, we hardcoded progress to "false" in the proxy, regardless
of what the original request said. We now leave it as it is, and
just ignore any progress updates when processing the response.

Since the response is buffered and sent back all together, they are
still useless, but at least the clients (ipfs cli) won't show a 0%
progress bar when successfully adding a file.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>