### PR TITLE
Add the packaging metadata to build the ipfs-cluster snap

### DIFF
--- a/snap/patches/snap-home.patch
+++ b/snap/patches/snap-home.patch
@@ -1,0 +1,26 @@
+diff --git a/ipfs-cluster-service/main.go b/ipfs-cluster-service/main.go
+index 80561f6..7144a35 100644
+--- a/ipfs-cluster-service/main.go
++++ b/ipfs-cluster-service/main.go
+@@ -6,7 +6,6 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"os/signal"
+-	"os/user"
+ 	"path/filepath"
+ 	"syscall"
+ 
+@@ -116,12 +115,8 @@ func init() {
+ 	// Set the right commit. The only way I could make this work
+ 	ipfscluster.Commit = commit
+ 
+-	usr, err := user.Current()
+-	if err != nil {
+-		panic("cannot guess the current user")
+-	}
+ 	DefaultPath = filepath.Join(
+-		usr.HomeDir,
++		os.Getenv("HOME"),
+ 		".ipfs-cluster")
+ }
+ 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,44 @@
+name: ipfs-cluster
+version: master
+summary: Collective pinning and composition for IPFS
+description: |
+  ipfs-cluster allows to replicate content (by pinning) in multiple IPFS nodes.
+
+confinement: strict
+
+apps:
+  service:
+    command: ipfs-cluster-service
+    plugs: [home, network, network-bind]
+    aliases: [ipfs-cluster-service]
+  ctl:
+    command: ipfs-cluster-ctl
+    plugs: [network]
+    aliases: [ipfs-cluster-ctl]
+
+parts:
+  ipfs-cluster:
+    source: .
+    plugin: nil
+    build-packages: [make, wget]
+    prepare: |
+      # XXX workaround for
+      # https://forum.snapcraft.io/t/go-homedir-reads-etc-passwd-not-home/2727
+      # --elopio - 20171107
+      git apply $SNAPCRAFT_STAGE/snap-home.patch
+      mkdir -p ../go/src/github.com/ipfs/ipfs-cluster
+      cp -R . ../go/src/github.com/ipfs/ipfs-cluster
+    build: |
+      env GOPATH=$(pwd)/../go make -C ../go/src/github.com/ipfs/ipfs-cluster install
+    install: |
+      mkdir $SNAPCRAFT_PART_INSTALL/bin
+      mv ../go/bin/ipfs-cluster-service $SNAPCRAFT_PART_INSTALL/bin/
+      mv ../go/bin/ipfs-cluster-ctl $SNAPCRAFT_PART_INSTALL/bin/
+    after: [go, patches]
+  go:
+    source-tag: go1.8.3
+  patches:
+    source: snap/patches
+    plugin: dump
+    prime:
+      - -*


### PR DESCRIPTION
This package will let you publish the latest ipfs-cluster in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go follow https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-travis-ci and enable the automated continuous delivery.