### PR TITLE
Raft: do not ever remove state, rename it and leave it around

### DIFF
--- a/consensus/raft/data_helper.go
+++ b/consensus/raft/data_helper.go
@@ -1,0 +1,69 @@
+package raft
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// RaftDataBackupKeep indicates the number of data folders we keep around
+// after consensus.Clean() has been called.
+var RaftDataBackupKeep = 5
+
+// dataBackupHelper helps making and rotating backups from a folder.
+// it will name them <folderName>.old.0, .old.1... and so on.
+// when a new backup is made, the old.0 is renamed to old.1 and so on.
+// when the RaftDataBackupKeep number is reached, the last is always
+// discarded.
+type dataBackupHelper struct {
+	baseDir    string
+	folderName string
+}
+
+func newDataBackupHelper(dataFolder string) *dataBackupHelper {
+	return &dataBackupHelper{
+		baseDir:    filepath.Dir(dataFolder),
+		folderName: filepath.Base(dataFolder),
+	}
+}
+
+func (dbh *dataBackupHelper) makeName(i int) string {
+	return filepath.Join(dbh.baseDir, fmt.Sprintf("%s.old.%d", dbh.folderName, i))
+}
+
+func (dbh *dataBackupHelper) listBackups() []string {
+	backups := []string{}
+	for i := 0; i < RaftDataBackupKeep; i++ {
+		name := dbh.makeName(i)
+		if _, err := os.Stat(name); os.IsNotExist(err) {
+			return backups
+		}
+		backups = append(backups, name)
+	}
+	return backups
+}
+
+func (dbh *dataBackupHelper) makeBackup() error {
+	err := os.MkdirAll(dbh.baseDir, 0700)
+	if err != nil {
+		return err
+	}
+	backups := dbh.listBackups()
+	// remove last / oldest
+	if len(backups) >= RaftDataBackupKeep {
+		os.RemoveAll(backups[len(backups)-1])
+	} else {
+		backups = append(backups, dbh.makeName(len(backups)))
+	}
+
+	// increase number for all backups folders
+	for i := len(backups) - 1; i > 0; i-- {
+		err := os.Rename(backups[i-1], backups[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	// save new as name.old.0
+	return os.Rename(filepath.Join(dbh.baseDir, dbh.folderName), dbh.makeName(0))
+}

--- a/consensus/raft/data_helper_test.go
+++ b/consensus/raft/data_helper_test.go
@@ -24,10 +24,9 @@ func TestDataBackupHelper(t *testing.T) {
 			t.Fatal(err)
 		}
 		backups := helper.listBackups()
-		if i < RaftDataBackupKeep && len(backups) != i+1 {
-			t.Fatal("not saving enough backups")
-		} else if i >= RaftDataBackupKeep && len(backups) != RaftDataBackupKeep {
-			t.Fatal("saving too many backups")
+		if (i < RaftDataBackupKeep && len(backups) != i+1) ||
+			(i >= RaftDataBackupKeep && len(backups) != RaftDataBackupKeep) {
+			t.Fatal("incorrect number of backups saved")
 		}
 		os.MkdirAll("data_helper_testing", 0700)
 	}

--- a/consensus/raft/data_helper_test.go
+++ b/consensus/raft/data_helper_test.go
@@ -1,0 +1,34 @@
+package raft
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestDataBackupHelper(t *testing.T) {
+	cleanup := func() {
+		os.RemoveAll("data_helper_testing")
+		for i := 0; i < 2*RaftDataBackupKeep; i++ {
+			os.RemoveAll(fmt.Sprintf("data_helper_testing.old.%d", i))
+		}
+	}
+	cleanup()
+	defer cleanup()
+
+	os.MkdirAll("data_helper_testing", 0700)
+	helper := newDataBackupHelper("data_helper_testing")
+	for i := 0; i < 2*RaftDataBackupKeep; i++ {
+		err := helper.makeBackup()
+		if err != nil {
+			t.Fatal(err)
+		}
+		backups := helper.listBackups()
+		if i < RaftDataBackupKeep && len(backups) != i+1 {
+			t.Fatal("not saving enough backups")
+		} else if i >= RaftDataBackupKeep && len(backups) != RaftDataBackupKeep {
+			t.Fatal("saving too many backups")
+		}
+		os.MkdirAll("data_helper_testing", 0700)
+	}
+}

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -429,7 +429,14 @@ func (rw *raftWrapper) Peers() ([]string, error) {
 
 // only call when Raft is shutdown
 func (rw *raftWrapper) Clean() error {
-	return os.RemoveAll(rw.dataFolder)
+	dbh := newDataBackupHelper(rw.dataFolder)
+	err := dbh.makeBackup()
+	if err != nil {
+		logger.Warning(err)
+		logger.Warning("the state could not be cleaned properly")
+		logger.Warning("manual intervention may be needed before starting cluster again")
+	}
+	return nil
 }
 
 func find(s []string, elem string) bool {


### PR DESCRIPTION
This commit changes the way that consensus.Clean() works. Before
it deleted the whole data folder. Now it renames it as <name>.old.0
and leaves it. When Clean() is called again, it renames <name>.old.0
as <name>.old.1, and the actual data becomes <name>.old.0. Higher number
means older. The number of backups is fixed to 5. When 5 backups exists
and a new one comes up again, the last one is discarded.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>