### PR TITLE
cluster: safeguard consensus not set when calling ID

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -586,7 +586,12 @@ func (c *Cluster) ID() api.ID {
 		addrs = append(addrs, multiaddrJoin(addr, c.id))
 	}
 
-	peers, _ := c.consensus.Peers()
+	peers := []peer.ID{}
+	// This method might get called very early by a remote peer
+	// and might catch us when consensus is not set
+	if c.consensus != nil {
+		peers, _ = c.consensus.Peers()
+	}
 
 	return api.ID{
 		ID: c.id,

--- a/cluster.go
+++ b/cluster.go
@@ -344,11 +344,7 @@ func (c *Cluster) alertsHandler() {
 func (c *Cluster) watchPeers() {
 	// TODO: Config option?
 	ticker := time.NewTicker(5 * time.Second)
-	var lastPeers []peer.ID
-	lastPeers, err := c.consensus.Peers()
-	if err != nil {
-		logger.Error("starting to watch peers", err)
-	}
+	lastPeers := peersFromMultiaddrs(c.config.Peers)
 
 	for {
 		select {

--- a/ipfsconn/ipfshttp/config.go
+++ b/ipfsconn/ipfshttp/config.go
@@ -17,7 +17,7 @@ const configKey = "ipfshttp"
 const (
 	DefaultProxyAddr              = "/ip4/127.0.0.1/tcp/9095"
 	DefaultNodeAddr               = "/ip4/127.0.0.1/tcp/5001"
-	DefaultConnectSwarmsDelay     = 7 * time.Second
+	DefaultConnectSwarmsDelay     = 30 * time.Second
 	DefaultProxyReadTimeout       = 10 * time.Minute
 	DefaultProxyReadHeaderTimeout = 5 * time.Second
 	DefaultProxyWriteTimeout      = 10 * time.Minute

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -92,7 +92,8 @@ func TestClustersPeerAdd(t *testing.T) {
 		// This only works because each peer only has one multiaddress
 		// (localhost)
 		if len(c.config.Peers) != nClusters-1 {
-			t.Error("expected different cluster peers in the configuration")
+			t.Error(c.config.Peers)
+			t.Errorf("%s: expected different cluster peers in the configuration", c.id)
 		}
 
 		for _, peer := range c.config.Peers {

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -91,7 +91,7 @@ func TestClustersPeerAdd(t *testing.T) {
 		// check that they are part of the configuration
 		// This only works because each peer only has one multiaddress
 		// (localhost)
-		if len(c.config.Peers) != nClusters-1 {
+		if len(peersFromMultiaddrs(c.config.Peers)) != nClusters-1 {
 			t.Error(c.config.Peers)
 			t.Errorf("%s: expected different cluster peers in the configuration", c.id)
 		}

--- a/util.go
+++ b/util.go
@@ -81,14 +81,22 @@ func multiaddrJoin(addr ma.Multiaddr, p peer.ID) ma.Multiaddr {
 	return addr.Encapsulate(pidAddr)
 }
 
+// returns all the different peers in the given addresses.
+// each peer only will appear once in the result, even if several
+// multiaddresses for it are provided.
 func peersFromMultiaddrs(addrs []ma.Multiaddr) []peer.ID {
 	var pids []peer.ID
+	pm := make(map[peer.ID]struct{})
 	for _, addr := range addrs {
 		pid, _, err := multiaddrSplit(addr)
 		if err != nil {
 			continue
 		}
-		pids = append(pids, pid)
+		_, ok := pm[pid]
+		if !ok {
+			pm[pid] = struct{}{}
+			pids = append(pids, pid)
+		}
 	}
 	return pids
 }


### PR DESCRIPTION
SwarmConnect on the ipfs connector calls rpc Peers() which
requests IDs for every peer member. If that peer member
is booting, it might get the request after RPC is setup
but before consensus is initialized. In which case
a panic happens. Probability that this happens is small, but still.

Also increase the connect swarms delay to 30 seconds, which
should be a bit longer than the default wait_for_leader timeout,
otherwise we might connect swarms while there's not even a leader.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>