### PR TITLE
Escape the variable in the snapcraft loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ deploy:
     branch: master
   provider: script
   script: docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "apt update -qq
-    && cd $(pwd) && for arch in amd64 i386 armhf arm64; do snapcraft snap --target-arch $arch --output ipfs-cluser.snap && snapcraft push ipfs-cluster.snap --release edge && snapcraft clean; done"
+    && cd $(pwd) && for arch in amd64 i386 armhf arm64; do snapcraft snap --target-arch \$arch --output ipfs-cluser.snap && snapcraft push ipfs-cluster.snap --release edge && snapcraft clean; done"
   skip_cleanup: true


### PR DESCRIPTION
I didn't escape the arch variable in the loop of the script to build the snap.
```
$ sudo docker run -t snapcore/snapcraft sh -c "for var in amd64 i386 armhf arm64; do echo $var; done"




$ sudo docker run -t snapcore/snapcraft sh -c "for var in amd64 i386 armhf arm64; do echo \$var; done"
amd64
i386
armhf
arm64
```