### PR TITLE
Feat/add pin name

### DIFF
--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -490,6 +490,10 @@ func parseCidOrError(w http.ResponseWriter, r *http.Request) types.PinSerial {
 	}
 
 	queryValues := r.URL.Query()
+	name := queryValues.Get("name")
+	if name != "" {
+		pin.Name = name
+	}
 	rplStr := queryValues.Get("replication_factor")
 	if rpl, err := strconv.Atoi(rplStr); err == nil {
 		pin.ReplicationFactor = rpl

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -491,9 +491,7 @@ func parseCidOrError(w http.ResponseWriter, r *http.Request) types.PinSerial {
 
 	queryValues := r.URL.Query()
 	name := queryValues.Get("name")
-	if name != "" {
-		pin.Name = name
-	}
+	pin.Name = name
 	rplStr := queryValues.Get("replication_factor")
 	if rpl, err := strconv.Atoi(rplStr); err == nil {
 		pin.ReplicationFactor = rpl

--- a/api/types.go
+++ b/api/types.go
@@ -350,6 +350,7 @@ func (addrsS MultiaddrsSerial) ToMultiaddrs() []ma.Multiaddr {
 // future.
 type Pin struct {
 	Cid               *cid.Cid
+	Name              string
 	Allocations       []peer.ID
 	ReplicationFactor int
 }
@@ -364,6 +365,7 @@ func PinCid(c *cid.Cid) Pin {
 // PinSerial is a serializable version of Pin
 type PinSerial struct {
 	Cid               string   `json:"cid"`
+	Name              string   `json:"name,omitempty"`
 	Allocations       []string `json:"allocations"`
 	Everywhere        bool     `json:"everywhere,omitempty"` // legacy
 	ReplicationFactor int      `json:"replication_factor"`
@@ -379,6 +381,7 @@ func (pin Pin) ToSerial() PinSerial {
 
 	return PinSerial{
 		Cid:               pin.Cid.String(),
+		Name:              pin.Name,
 		Allocations:       allocs,
 		ReplicationFactor: pin.ReplicationFactor,
 	}
@@ -400,6 +403,7 @@ func (pins PinSerial) ToPin() Pin {
 
 	return Pin{
 		Cid:               c,
+		Name:              pins.Name,
 		Allocations:       allocs,
 		ReplicationFactor: pins.ReplicationFactor,
 	}

--- a/api/types.go
+++ b/api/types.go
@@ -365,7 +365,7 @@ func PinCid(c *cid.Cid) Pin {
 // PinSerial is a serializable version of Pin
 type PinSerial struct {
 	Cid               string   `json:"cid"`
-	Name              string   `json:"name,omitempty"`
+	Name              string   `json:"name"`
 	Allocations       []string `json:"allocations"`
 	Everywhere        bool     `json:"everywhere,omitempty"` // legacy
 	ReplicationFactor int      `json:"replication_factor"`

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -130,7 +130,7 @@ func textFormatPrintVersion(obj *api.Version) {
 }
 
 func textFormatPrintPin(obj *api.PinSerial) {
-	fmt.Printf("%s | %s | Allocations: ", obj.Cid, obj.Name)
+	fmt.Printf("%s | '%s' | Allocations: ", obj.Cid, obj.Name)
 	if obj.ReplicationFactor < 0 {
 		fmt.Printf("[everywhere]\n")
 	} else {

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -130,7 +130,7 @@ func textFormatPrintVersion(obj *api.Version) {
 }
 
 func textFormatPrintPin(obj *api.PinSerial) {
-	fmt.Printf("%s | '%s' | Allocations: ", obj.Cid, obj.Name)
+	fmt.Printf("%s | %s | Allocations: ", obj.Cid, obj.Name)
 	if obj.ReplicationFactor < 0 {
 		fmt.Printf("[everywhere]\n")
 	} else {

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -130,7 +130,7 @@ func textFormatPrintVersion(obj *api.Version) {
 }
 
 func textFormatPrintPin(obj *api.PinSerial) {
-	fmt.Printf("%s | Allocations: ", obj.Cid)
+	fmt.Printf("%s | %s | Allocations: ", obj.Cid, obj.Name)
 	if obj.ReplicationFactor < 0 {
 		fmt.Printf("[everywhere]\n")
 	} else {

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -249,12 +249,17 @@ peers should pin this content.
 							Value: 0,
 							Usage: "Sets a custom replication factor for this pin",
 						},
+						cli.StringFlag{
+							Name:  "name, n",
+							Value: "",
+							Usage: "Sets a name for this pin",
+						},
 					},
 					Action: func(c *cli.Context) error {
 						cidStr := c.Args().First()
 						_, err := cid.Decode(cidStr)
 						checkErr("parsing cid", err)
-						query := fmt.Sprintf("?replication_factor=%d", c.Int("replication"))
+						query := fmt.Sprintf("?replication_factor=%d&name=%s", c.Int("replication"), c.String("name"))
 						resp := request("POST", "/pins/"+cidStr+query, nil)
 						formatResponse(c, resp)
 						if resp.StatusCode < 300 {

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -259,7 +260,8 @@ peers should pin this content.
 						cidStr := c.Args().First()
 						_, err := cid.Decode(cidStr)
 						checkErr("parsing cid", err)
-						query := fmt.Sprintf("?replication_factor=%d&name=%s", c.Int("replication"), c.String("name"))
+						escapedName := url.QueryEscape(c.String("name"))
+						query := fmt.Sprintf("?replication_factor=%d&name=%s", c.Int("replication"), escapedName)
 						resp := request("POST", "/pins/"+cidStr+query, nil)
 						formatResponse(c, resp)
 						if resp.StatusCode < 300 {

--- a/state/mapstate/map_state.go
+++ b/state/mapstate/map_state.go
@@ -18,7 +18,7 @@ import (
 
 // Version is the map state Version. States with old versions should
 // perform an upgrade before.
-const Version = 3
+const Version = 2
 
 var logger = logging.Logger("mapstate")
 

--- a/state/mapstate/map_state.go
+++ b/state/mapstate/map_state.go
@@ -18,7 +18,7 @@ import (
 
 // Version is the map state Version. States with old versions should
 // perform an upgrade before.
-const Version = 2
+const Version = 3
 
 var logger = logging.Logger("mapstate")
 


### PR DESCRIPTION
This adds a Name attribute to Pins. It exposes a URL parameter to set the name and returns the name via the allocations API call. A command line argument added for ipfs-cluster-ctl. I've also updated the map_state version because I believe this change would require a migration.

This PR fixes #249 by adding storing the name in the consensus layer.

These changes do not touch the output of the status command.