### PR TITLE
Fix #260: Add REST API client and use it in ipfs-cluster-ctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-gx_version=v0.12.0
-gx-go_version=v1.5.0
+gx_version=v0.12.1
+gx-go_version=v1.6.0
 
 deptools=deptools
 

--- a/api/rest/client/.travis.yml
+++ b/api/rest/client/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+go:
+- '1.9'
+- tip
+install:
+- go get golang.org/x/tools/cmd/cover
+- go get github.com/mattn/goveralls
+- make deps
+script:
+- make test
+- "$GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN"
+env:
+  global:
+    secure: Skjty77A/J/34pKFmHtxnpNejY2QAJw5PAacBnflo1yZfq4D2mEqVjyd0V2o/pSqm54b+eUouYp+9hNsBbVRHXlgi3PocVClBTV7McFMAoOn+OOEBrdt5wF57L0IPbt8yde+RpXcnCQ5rRvuSfCkEcTNhlxUdUjx4r9qhFsGWKvZVodcSO6xZTRwPYu7/MJWnJK/JV5CAWl7dWlWeAZhrASwXwS7662tu3SN9eor5+ZVF0t5BMhLP6juu6WPz9TFijQ/W4cRiXJ1REbg+M2RscAj9gOy7lIdKR5MEF1xj8naX2jtiZXcxIdV5cduLwSeBA8v5hahwV0H/1cN4Ypymix9vXfkZKyMbU7/TpO0pEzZOcoFne9edHRh6oUrCRBrf4veOiPbkObjmAs0HsdE1ZoeakgCQVHGqaMUlYW1ybeu04JJrXNAMC7s+RD9lxacwknrx333fSBmw+kQwJGmkYkdKcELo2toivrX+yXezISLf2+puqVPAZznY/OxHAuWDi047QLEBxW72ZuTCpT9QiOj3nl5chvmNV+edqgdLN3SlUNOB0jTOpyac/J1GicFkI7IgE2+PjeqpzVnrhZvpcAy4j8YLadGfISWVzbg4NaoUrBUIqA82rqwiZ1L+CcQKNW1h+vEXWp6cLnn2kcPSihM8RrsLuSiJMMgdIhMN3o=

--- a/api/rest/client/README.md
+++ b/api/rest/client/README.md
@@ -1,0 +1,52 @@
+# ipfs-cluster client
+
+
+[![Made by](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
+[![Main project](https://img.shields.io/badge/project-ipfs-blue.svg?style=flat-square)](http://github.com/ipfs/ipfs)
+[![IRC channel](https://img.shields.io/badge/freenode-%23ipfs--cluster-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs-cluster)
+[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+[![GoDoc](https://godoc.org/github.com/ipfs/ipfs-cluster?status.svg)](https://godoc.org/github.com/ipfs/ipfs-cluster)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ipfs/ipfs-cluster)](https://goreportcard.com/report/github.com/ipfs/ipfs-cluster)
+[![Build Status](https://travis-ci.org/ipfs/ipfs-cluster.svg?branch=master)](https://travis-ci.org/ipfs/ipfs-cluster)
+[![Coverage Status](https://coveralls.io/repos/github/ipfs/ipfs-cluster/badge.svg?branch=master)](https://coveralls.io/github/ipfs/ipfs-cluster?branch=master)
+
+
+> Go client for ipfs-cluster HTTP API.
+
+This is a Go client library to use the ipfs-cluster REST HTTP API.
+
+
+## Table of Contents
+
+- [Install](#install)
+- [Usage](#usage)
+- [Contribute](#contribute)
+- [License](#license)
+
+## Install
+
+You can import `github.com/ipfs/ipfs-cluster/api/rest/client` in your code. If you wish to use [`gx`](https://github.com/whyrusleeping/gx-go) for dependency management, it can be imported with:
+
+```
+$ gx import github.com/ipfs/ipfs-cluster/
+```
+
+The code can be downloaded and tested with:
+
+```
+$ go get -u -d github.com/ipfs/ipfs-cluster
+$ cd $GOPATH/src/github.com/ipfs/ipfs-cluster/rest/api/client
+$ go test -v
+```
+
+## Usage
+
+Documentation can be read at [Godoc](https://godoc.org/github.com/ipfs/ipfs-cluster/api/rest/client).
+
+## Contribute
+
+PRs accepted.
+
+## License
+
+MIT © Protocol Labs

--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	logging "github.com/ipfs/go-log"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr-net"
+)
+
+// Configuration defaults
+var (
+	DefaultTimeout = 60 * time.Second
+	DefaultAPIAddr = "/ip4/127.0.0.1/tcp/9094"
+)
+
+var logger = logging.Logger("apiclient")
+
+// Config allows to configure the parameters to connect
+// to the ipfs-cluster REST API.
+type Config struct {
+	// Enable SSL support
+	SSL bool
+	// Skip certificate verification (insecure)
+	NoVerifyCert bool
+
+	// Username and password for basic authentication
+	Username string
+	Password string
+
+	// The ipfs-cluster REST API endpoint
+	APIAddr ma.Multiaddr
+
+	// Define timeout for network operations
+	Timeout time.Duration
+
+	// LogLevel defines the verbosity of the "apiclient" facility
+	LogLevel string
+}
+
+// Client provides methods to interact with the ipfs-cluster API. Use
+// NewClient() to create one.
+type Client struct {
+	ctx       context.Context
+	cancel    func()
+	config    *Config
+	transport http.RoundTripper
+	urlPrefix string
+}
+
+// NewClient initializes a client given a Config.
+func NewClient(cfg *Config) (*Client, error) {
+	var urlPrefix = ""
+
+	var tr http.RoundTripper
+	if cfg.SSL {
+		tr = newTLSTransport(cfg.NoVerifyCert)
+		urlPrefix += "https://"
+	} else {
+		tr = http.DefaultTransport
+		urlPrefix += "http://"
+	}
+
+	if cfg.APIAddr == nil {
+		cfg.APIAddr, _ = ma.NewMultiaddr(DefaultAPIAddr)
+	}
+	_, host, err := manet.DialArgs(cfg.APIAddr)
+	if err != nil {
+		return nil, err
+	}
+	urlPrefix += host
+
+	if lvl := cfg.LogLevel; lvl != "" {
+		logging.SetLogLevel("apiclient", lvl)
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Client{
+		ctx:       ctx,
+		cancel:    cancel,
+		urlPrefix: urlPrefix,
+		transport: tr,
+		config:    cfg,
+	}, nil
+}

--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -38,6 +38,10 @@ type Config struct {
 	// Define timeout for network operations
 	Timeout time.Duration
 
+	// Specifies if we attempt to re-use connections to the same
+	// hosts.
+	DisableKeepAlives bool
+
 	// LogLevel defines the verbosity of the logging facility
 	LogLevel string
 }
@@ -50,6 +54,7 @@ type Client struct {
 	config    *Config
 	transport http.RoundTripper
 	urlPrefix string
+	client    *http.Client
 }
 
 // NewClient initializes a client given a Config.
@@ -86,11 +91,17 @@ func NewClient(cfg *Config) (*Client, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   cfg.Timeout,
+	}
+
 	return &Client{
 		ctx:       ctx,
 		cancel:    cancel,
 		urlPrefix: urlPrefix,
 		transport: tr,
 		config:    cfg,
+		client:    client,
 	}, nil
 }

--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -12,11 +12,13 @@ import (
 
 // Configuration defaults
 var (
-	DefaultTimeout = 60 * time.Second
-	DefaultAPIAddr = "/ip4/127.0.0.1/tcp/9094"
+	DefaultTimeout  = 60 * time.Second
+	DefaultAPIAddr  = "/ip4/127.0.0.1/tcp/9094"
+	DefaultLogLevel = "info"
 )
 
-var logger = logging.Logger("apiclient")
+var loggingFacility = "apiclient"
+var logger = logging.Logger(loggingFacility)
 
 // Config allows to configure the parameters to connect
 // to the ipfs-cluster REST API.
@@ -36,7 +38,7 @@ type Config struct {
 	// Define timeout for network operations
 	Timeout time.Duration
 
-	// LogLevel defines the verbosity of the "apiclient" facility
+	// LogLevel defines the verbosity of the logging facility
 	LogLevel string
 }
 
@@ -73,7 +75,9 @@ func NewClient(cfg *Config) (*Client, error) {
 	urlPrefix += host
 
 	if lvl := cfg.LogLevel; lvl != "" {
-		logging.SetLogLevel("apiclient", lvl)
+		logging.SetLogLevel(loggingFacility, lvl)
+	} else {
+		logging.SetLogLevel(loggingFacility, DefaultLogLevel)
 	}
 
 	if cfg.Timeout == 0 {

--- a/api/rest/client/client_test.go
+++ b/api/rest/client/client_test.go
@@ -24,9 +24,6 @@ func testAPI(t *testing.T) *rest.API {
 		t.Fatal("should be able to create a new Api: ", err)
 	}
 
-	// No keep alive! Otherwise tests hang with
-	// connections re-used from previous tests
-	//rest.server.SetKeepAlivesEnabled(false)
 	rest.SetClient(test.NewMockRPCClient(t))
 	return rest
 }
@@ -89,7 +86,8 @@ func TestPeers(t *testing.T) {
 func TestPeersWithError(t *testing.T) {
 	c, api := testClient(t)
 	defer api.Shutdown()
-	c, _ = NewClient(&Config{})
+	addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/44444")
+	c, _ = NewClient(&Config{APIAddr: addr})
 	ids, err := c.Peers()
 	if err == nil {
 		t.Fatal("expected error")

--- a/api/rest/client/client_test.go
+++ b/api/rest/client/client_test.go
@@ -1,0 +1,253 @@
+package client
+
+import (
+	"testing"
+
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/ipfs-cluster/api/rest"
+	"github.com/ipfs/ipfs-cluster/test"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+var apiAddr = "/ip4/127.0.0.1/tcp/10002"
+
+func testAPI(t *testing.T) *rest.API {
+	//logging.SetDebugLogging()
+	apiMAddr, _ := ma.NewMultiaddr(apiAddr)
+
+	cfg := &rest.Config{}
+	cfg.Default()
+	cfg.ListenAddr = apiMAddr
+
+	rest, err := rest.NewAPI(cfg)
+	if err != nil {
+		t.Fatal("should be able to create a new Api: ", err)
+	}
+
+	// No keep alive! Otherwise tests hang with
+	// connections re-used from previous tests
+	//rest.server.SetKeepAlivesEnabled(false)
+	rest.SetClient(test.NewMockRPCClient(t))
+	return rest
+}
+
+func testClient(t *testing.T) (*Client, *rest.API) {
+	api := testAPI(t)
+
+	addr, _ := ma.NewMultiaddr(apiAddr)
+	cfg := &Config{
+		APIAddr: addr,
+	}
+	c, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return c, api
+}
+
+func TestNewClient(t *testing.T) {
+	_, api := testClient(t)
+	api.Shutdown()
+}
+
+func TestVersion(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+	v, err := c.Version()
+	if err != nil || v.Version == "" {
+		t.Logf("%+v", v)
+		t.Log(err)
+		t.Error("expected something in version")
+	}
+}
+
+func TestID(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+	id, err := c.ID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id.ID == "" {
+		t.Error("bad id")
+	}
+}
+
+func TestPeers(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+	ids, err := c.Peers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) == 0 {
+		t.Error("expected some peers")
+	}
+}
+
+func TestPeersWithError(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+	c, _ = NewClient(&Config{})
+	ids, err := c.Peers()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if ids == nil || len(ids) != 0 {
+		t.Fatal("expected no ids")
+	}
+}
+
+func TestPeerAdd(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	addr, _ := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/1234/ipfs/" + test.TestPeerID1.Pretty())
+	id, err := c.PeerAdd(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id.ID != test.TestPeerID1 {
+		t.Error("bad peer")
+	}
+}
+
+func TestPeerRm(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	err := c.PeerRm(test.TestPeerID1)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPin(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	ci, _ := cid.Decode(test.TestCid1)
+	err := c.Pin(ci, 7, "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnpin(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	ci, _ := cid.Decode(test.TestCid1)
+	err := c.Unpin(ci)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAllocations(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	pins, err := c.Allocations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pins) == 0 {
+		t.Error("should be some pins")
+	}
+}
+
+func TestAllocation(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	ci, _ := cid.Decode(test.TestCid1)
+	pin, err := c.Allocation(ci)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pin.Cid.String() != test.TestCid1 {
+		t.Error("should be same pin")
+	}
+}
+
+func TestStatus(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	ci, _ := cid.Decode(test.TestCid1)
+	pin, err := c.Status(ci, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pin.Cid.String() != test.TestCid1 {
+		t.Error("should be same pin")
+	}
+}
+
+func TestStatusAll(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	pins, err := c.StatusAll(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pins) == 0 {
+		t.Error("there should be some pins")
+	}
+}
+
+func TestSync(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	ci, _ := cid.Decode(test.TestCid1)
+	pin, err := c.Sync(ci, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pin.Cid.String() != test.TestCid1 {
+		t.Error("should be same pin")
+	}
+}
+
+func TestSyncAll(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	pins, err := c.SyncAll(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pins) == 0 {
+		t.Error("there should be some pins")
+	}
+}
+
+func TestRecover(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	ci, _ := cid.Decode(test.TestCid1)
+	pin, err := c.Recover(ci, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pin.Cid.String() != test.TestCid1 {
+		t.Error("should be same pin")
+	}
+}
+
+func TestRecoverAll(t *testing.T) {
+	c, api := testClient(t)
+	defer api.Shutdown()
+
+	_, err := c.RecoverAll(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/api/rest/client/client_test.go
+++ b/api/rest/client/client_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
+	ma "github.com/multiformats/go-multiaddr"
+
 	"github.com/ipfs/ipfs-cluster/api/rest"
 	"github.com/ipfs/ipfs-cluster/test"
-	ma "github.com/multiformats/go-multiaddr"
 )
 
-var apiAddr = "/ip4/127.0.0.1/tcp/10002"
+var apiAddr = "/ip4/127.0.0.1/tcp/10005"
 
 func testAPI(t *testing.T) *rest.API {
 	//logging.SetDebugLogging()
@@ -33,7 +34,8 @@ func testClient(t *testing.T) (*Client, *rest.API) {
 
 	addr, _ := ma.NewMultiaddr(apiAddr)
 	cfg := &Config{
-		APIAddr: addr,
+		APIAddr:           addr,
+		DisableKeepAlives: true,
 	}
 	c, err := NewClient(cfg)
 	if err != nil {
@@ -87,7 +89,7 @@ func TestPeersWithError(t *testing.T) {
 	c, api := testClient(t)
 	defer api.Shutdown()
 	addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/44444")
-	c, _ = NewClient(&Config{APIAddr: addr})
+	c, _ = NewClient(&Config{APIAddr: addr, DisableKeepAlives: true})
 	ids, err := c.Peers()
 	if err == nil {
 		t.Fatal("expected error")

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -1,0 +1,164 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/ipfs-cluster/api"
+	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// ID returns information about the cluster Peer.
+func (c *Client) ID() (api.ID, *api.Error) {
+	var id api.IDSerial
+	err := c.do("GET", "/id", nil, &id)
+	return id.ToID(), err
+}
+
+// Peers requests ID information for all cluster peers.
+func (c *Client) Peers() ([]api.ID, *api.Error) {
+	var ids []api.IDSerial
+	err := c.do("GET", "/peers", nil, &ids)
+	result := make([]api.ID, len(ids))
+	for i, id := range ids {
+		result[i] = id.ToID()
+	}
+	return result, err
+}
+
+type peerAddBody struct {
+	Addr string `json:"peer_multiaddress"`
+}
+
+// PeerAdd adds a new peer to the cluster.
+func (c *Client) PeerAdd(addr ma.Multiaddr) (api.ID, *api.Error) {
+	addrStr := addr.String()
+	body := peerAddBody{addrStr}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.Encode(body)
+
+	var id api.IDSerial
+	err := c.do("POST", "/peers", &buf, &id)
+	return id.ToID(), err
+}
+
+// PeerRm removes a current peer from the cluster
+func (c *Client) PeerRm(id peer.ID) *api.Error {
+	return c.do("DELETE", fmt.Sprintf("/peers/%s", id.Pretty()), nil, nil)
+}
+
+// Pin tracks a Cid with the given replication factor and a name for
+// human-friendliness.
+func (c *Client) Pin(ci *cid.Cid, replicationFactor int, name string) *api.Error {
+	escName := url.QueryEscape(name)
+	err := c.do(
+		"POST",
+		fmt.Sprintf("/pins/%s?replication_factor=%d&name=%s",
+			ci.String(),
+			replicationFactor,
+			escName),
+		nil, nil)
+	return err
+}
+
+// Unpin untracks a Cid from cluster.
+func (c *Client) Unpin(ci *cid.Cid) *api.Error {
+	return c.do("DELETE", fmt.Sprintf("/pins/%s", ci.String()), nil, nil)
+}
+
+// Allocations returns the consensus state listing all tracked items and
+// the peers that should be pinning them.
+func (c *Client) Allocations() ([]api.Pin, *api.Error) {
+	var pins []api.PinSerial
+	err := c.do("GET", "/allocations", nil, &pins)
+	result := make([]api.Pin, len(pins))
+	for i, p := range pins {
+		result[i] = p.ToPin()
+	}
+	return result, err
+}
+
+// Allocation returns the current allocations for a given Cid.
+func (c *Client) Allocation(ci *cid.Cid) (api.Pin, *api.Error) {
+	var pin api.PinSerial
+	err := c.do("GET", fmt.Sprintf("/allocations/%s", ci.String()), nil, &pin)
+	return pin.ToPin(), err
+}
+
+// Status returns the current ipfs state for a given Cid. If local is true,
+// the information affects only the current peer, otherwise the information
+// is fetched from all cluster peers.
+func (c *Client) Status(ci *cid.Cid, local bool) (api.GlobalPinInfo, *api.Error) {
+	var gpi api.GlobalPinInfoSerial
+	err := c.do("GET", fmt.Sprintf("/pins/%s?local=%t", ci.String(), local), nil, &gpi)
+	return gpi.ToGlobalPinInfo(), err
+}
+
+// StatusAll gathers Status() for all tracked items.
+func (c *Client) StatusAll(local bool) ([]api.GlobalPinInfo, *api.Error) {
+	var gpis []api.GlobalPinInfoSerial
+	err := c.do("GET", fmt.Sprintf("/pins?local=%t", local), nil, &gpis)
+	result := make([]api.GlobalPinInfo, len(gpis))
+	for i, p := range gpis {
+		result[i] = p.ToGlobalPinInfo()
+	}
+	return result, err
+}
+
+// Sync makes sure the state of a Cid corresponds to the state reported by
+// the ipfs daemon, and returns it. If local is true, this operation only
+// happens on the current peer, otherwise it happens on every cluster peer.
+func (c *Client) Sync(ci *cid.Cid, local bool) (api.GlobalPinInfo, *api.Error) {
+	var gpi api.GlobalPinInfoSerial
+	err := c.do("POST", fmt.Sprintf("/pins/%s/sync?local=%t", ci.String(), local), nil, &gpi)
+	return gpi.ToGlobalPinInfo(), err
+}
+
+// SyncAll triggers Sync() operations for all tracked items. It only returns
+// informations for items that were de-synced or have an error state. If
+// local is true, the operation is limited to the current peer. Otherwise
+// it happens on every cluster peer.
+func (c *Client) SyncAll(local bool) ([]api.GlobalPinInfo, *api.Error) {
+	var gpis []api.GlobalPinInfoSerial
+	err := c.do("POST", fmt.Sprintf("/pins/sync?local=%t", local), nil, &gpis)
+	result := make([]api.GlobalPinInfo, len(gpis))
+	for i, p := range gpis {
+		result[i] = p.ToGlobalPinInfo()
+	}
+	return result, err
+}
+
+// Recover retriggers pin or unpin ipfs operations for a Cid in error state.
+// If local is true, the operation is limited to the current peer, otherwise
+// it happens on every cluster peer.
+func (c *Client) Recover(ci *cid.Cid, local bool) (api.GlobalPinInfo, *api.Error) {
+	var gpi api.GlobalPinInfoSerial
+	err := c.do("POST", fmt.Sprintf("/pins/%s/recover?local=%t", ci.String(), local), nil, &gpi)
+	return gpi.ToGlobalPinInfo(), err
+}
+
+// RecoverAll triggers Recover() operations on all tracked items. If local is
+// true, the operation is limited to the current peer. Otherwise, it happens
+// everywhere.
+func (c *Client) RecoverAll(local bool) ([]api.GlobalPinInfo, *api.Error) {
+	var gpis []api.GlobalPinInfoSerial
+	err := c.do("POST", fmt.Sprintf("/pins/recover?local=%t", local), nil, &gpis)
+	result := make([]api.GlobalPinInfo, len(gpis))
+	for i, p := range gpis {
+		result[i] = p.ToGlobalPinInfo()
+	}
+	return result, err
+}
+
+// Version returns the ipfs-cluster peer's version.
+func (c *Client) Version() (api.Version, *api.Error) {
+	var ver api.Version
+	err := c.do("GET", "/version", nil, &ver)
+	return ver, err
+}

--- a/api/rest/client/request.go
+++ b/api/rest/client/request.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/ipfs/ipfs-cluster/api"
+)
+
+func (c *Client) do(method, path string, body io.Reader, obj interface{}) *api.Error {
+	resp, err := c.doRequest(method, path, body)
+	if err != nil {
+		return &api.Error{Code: 0, Message: err.Error()}
+	}
+	return c.handleResponse(resp, obj)
+}
+
+func (c *Client) doRequest(method, path string, body io.Reader) (*http.Response, error) {
+	ctx, cancel := context.WithTimeout(c.ctx, c.config.Timeout)
+	defer cancel()
+
+	urlpath := c.urlPrefix + "/" + strings.TrimPrefix(path, "/")
+	logger.Debugf("%s: %s", method, urlpath)
+
+	r, err := http.NewRequest(method, urlpath, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.config.Username != "" {
+		r.SetBasicAuth(c.config.Username, c.config.Password)
+	}
+
+	client := &http.Client{Transport: c.transport}
+	return client.Do(r.WithContext(ctx))
+}
+
+func (c *Client) handleResponse(resp *http.Response, obj interface{}) *api.Error {
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &api.Error{Code: resp.StatusCode, Message: err.Error()}
+	}
+	logger.Debugf("Response body: %s", body)
+
+	switch {
+	case resp.StatusCode == http.StatusAccepted:
+		logger.Debug("Request accepted")
+	case resp.StatusCode == http.StatusNoContent:
+		logger.Debug("Request suceeded. Response has no content")
+	default:
+		if resp.StatusCode > 399 {
+			var apiErr api.Error
+			err = json.Unmarshal(body, &apiErr)
+			if err != nil {
+				return &api.Error{
+					Code:    resp.StatusCode,
+					Message: err.Error(),
+				}
+			}
+			return &apiErr
+		}
+		err = json.Unmarshal(body, obj)
+		if err != nil {
+			return &api.Error{
+				Code:    resp.StatusCode,
+				Message: err.Error(),
+			}
+		}
+	}
+	return nil
+}

--- a/api/rest/client/tls.go
+++ b/api/rest/client/tls.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func newTLSTransport(skipVerify bool) *http.Transport {
+	// based on https://github.com/denji/golang-tls
+	tlsCfg := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+		InsecureSkipVerify: skipVerify,
+	}
+	return &http.Transport{
+		TLSClientConfig: tlsCfg,
+	}
+}

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -25,18 +25,27 @@ func jsonFormatObject(resp interface{}) {
 	case api.Error:
 		jsonFormatPrint(resp.(api.Error))
 	case []api.ID:
-		for _, item := range resp.([]api.ID) {
-			jsonFormatObject(item)
+		r := resp.([]api.ID)
+		serials := make([]api.IDSerial, len(r), len(r))
+		for i, item := range r {
+			serials[i] = item.ToSerial()
 		}
+		jsonFormatPrint(serials)
 
 	case []api.GlobalPinInfo:
-		for _, item := range resp.([]api.GlobalPinInfo) {
-			jsonFormatObject(item)
+		r := resp.([]api.GlobalPinInfo)
+		serials := make([]api.GlobalPinInfoSerial, len(r), len(r))
+		for i, item := range r {
+			serials[i] = item.ToSerial()
 		}
+		jsonFormatPrint(serials)
 	case []api.Pin:
-		for _, item := range resp.([]api.Pin) {
-			jsonFormatObject(item)
+		r := resp.([]api.Pin)
+		serials := make([]api.PinSerial, len(r), len(r))
+		for i, item := range r {
+			serials[i] = item.ToSerial()
 		}
+		jsonFormatPrint(serials)
 	default:
 		checkErr("", errors.New("unsupported type returned"))
 	}

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,75 +10,79 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 )
 
-const (
-	formatNone = iota
-	formatID
-	formatGPInfo
-	formatPInfo
-	formatString
-	formatVersion
-	formatPin
-	formatError
-)
+func jsonFormatObject(resp interface{}) {
+	switch resp.(type) {
+	case nil:
+		return
+	case api.ID:
+		jsonFormatPrint(resp.(api.ID).ToSerial())
+	case api.GlobalPinInfo:
+		jsonFormatPrint(resp.(api.GlobalPinInfo).ToSerial())
+	case api.Pin:
+		jsonFormatPrint(resp.(api.Pin).ToSerial())
+	case api.Version:
+		jsonFormatPrint(resp.(api.Version))
+	case api.Error:
+		jsonFormatPrint(resp.(api.Error))
+	case []api.ID:
+		for _, item := range resp.([]api.ID) {
+			jsonFormatObject(item)
+		}
 
-type format int
-
-func textFormat(body []byte, format int) {
-	if len(body) < 2 {
-		fmt.Println("")
-	}
-
-	slice := body[0] == '['
-	if slice {
-		textFormatSlice(body, format)
-	} else {
-		textFormatObject(body, format)
-	}
-}
-
-func textFormatObject(body []byte, format int) {
-	switch format {
-	case formatID:
-		var obj api.IDSerial
-		textFormatDecodeOn(body, &obj)
-		textFormatPrintIDSerial(&obj)
-	case formatGPInfo:
-		var obj api.GlobalPinInfoSerial
-		textFormatDecodeOn(body, &obj)
-		textFormatPrintGPinfo(&obj)
-	case formatPInfo:
-		var obj api.PinInfoSerial
-		textFormatDecodeOn(body, &obj)
-		textFormatPrintPInfo(&obj)
-	case formatVersion:
-		var obj api.Version
-		textFormatDecodeOn(body, &obj)
-		textFormatPrintVersion(&obj)
-	case formatPin:
-		var obj api.PinSerial
-		textFormatDecodeOn(body, &obj)
-		textFormatPrintPin(&obj)
-	case formatError:
-		var obj api.Error
-		textFormatDecodeOn(body, &obj)
-		textFormatPrintError(&obj)
+	case []api.GlobalPinInfo:
+		for _, item := range resp.([]api.GlobalPinInfo) {
+			jsonFormatObject(item)
+		}
+	case []api.Pin:
+		for _, item := range resp.([]api.Pin) {
+			jsonFormatObject(item)
+		}
 	default:
-		var obj interface{}
-		textFormatDecodeOn(body, &obj)
-		fmt.Printf("%s\n", obj)
+		checkErr("", errors.New("unsupported type returned"))
 	}
 }
 
-func textFormatSlice(body []byte, format int) {
-	var rawMsg []json.RawMessage
-	textFormatDecodeOn(body, &rawMsg)
-	for _, raw := range rawMsg {
-		textFormatObject(raw, format)
-	}
+func jsonFormatPrint(obj interface{}) {
+	j, err := json.MarshalIndent(obj, "", "    ")
+	checkErr("generating json output", err)
+	fmt.Printf("%s\n", j)
 }
 
-func textFormatDecodeOn(body []byte, obj interface{}) {
-	checkErr("decoding JSON", json.Unmarshal(body, obj))
+func textFormatObject(resp interface{}) {
+	switch resp.(type) {
+	case nil:
+		return
+	case api.ID:
+		serial := resp.(api.ID).ToSerial()
+		textFormatPrintIDSerial(&serial)
+	case api.GlobalPinInfo:
+		serial := resp.(api.GlobalPinInfo).ToSerial()
+		textFormatPrintGPInfo(&serial)
+	case api.Pin:
+		serial := resp.(api.Pin).ToSerial()
+		textFormatPrintPin(&serial)
+	case api.Version:
+		serial := resp.(api.Version)
+		textFormatPrintVersion(&serial)
+	case api.Error:
+		serial := resp.(api.Error)
+		textFormatPrintError(&serial)
+	case []api.ID:
+		for _, item := range resp.([]api.ID) {
+			textFormatObject(item)
+		}
+
+	case []api.GlobalPinInfo:
+		for _, item := range resp.([]api.GlobalPinInfo) {
+			textFormatObject(item)
+		}
+	case []api.Pin:
+		for _, item := range resp.([]api.Pin) {
+			textFormatObject(item)
+		}
+	default:
+		checkErr("", errors.New("unsupported type returned"))
+	}
 }
 
 func textFormatPrintIDSerial(obj *api.IDSerial) {
@@ -112,7 +117,7 @@ func textFormatPrintIDSerial(obj *api.IDSerial) {
 	}
 }
 
-func textFormatPrintGPinfo(obj *api.GlobalPinInfoSerial) {
+func textFormatPrintGPInfo(obj *api.GlobalPinInfoSerial) {
 	fmt.Printf("%s :\n", obj.Cid)
 	peers := make(sort.StringSlice, 0, len(obj.PeerMap))
 	for k := range obj.PeerMap {
@@ -137,7 +142,7 @@ func textFormatPrintPInfo(obj *api.PinInfoSerial) {
 			obj.Peer: *obj,
 		},
 	}
-	textFormatPrintGPinfo(&gpinfo)
+	textFormatPrintGPInfo(&gpinfo)
 }
 
 func textFormatPrintVersion(obj *api.Version) {

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -138,6 +138,11 @@ requires authorization. implies --https, which you can disable with --force-http
 			logging.SetLogLevel("apiclient", "debug")
 		}
 
+		enc := c.String("encoding")
+		if enc != "text" && enc != "json" {
+			checkErr("", errors.New("unsupported encoding"))
+		}
+
 		globalClient, err = client.NewClient(cfg)
 		checkErr("creating API client", err)
 		return nil
@@ -495,6 +500,11 @@ func formatResponse(c *cli.Context, resp interface{}, err *api.Error) {
 			jsonFormatPrint(err)
 		default:
 			checkErr("", errors.New("unsupported encoding selected"))
+		}
+		if err.Code == 0 {
+			os.Exit(1) // problem with the call
+		} else {
+			os.Exit(2) // call went fine, response has an error
 		}
 	}
 

--- a/ipfs-cluster-service/lock.go
+++ b/ipfs-cluster-service/lock.go
@@ -12,47 +12,47 @@ import (
 // The name of the file used for locking
 const lockFileName = "cluster.lock"
 
-var locker *Locker
+var locker *lock
 
-// Global file, close to relinquish lock access
-type Locker struct {
+// lock helps to coordinate procees via a lock file
+type lock struct {
 	lockCloser io.Closer
 	path       string
 }
 
-func (locker *Locker) lock() error {
-	if locker.lockCloser != nil {
+func (l *lock) lock() error {
+	if l.lockCloser != nil {
 		return fmt.Errorf("cannot acquire lock twice")
 	}
 	// set the lock file within this function
 	logger.Debug("checking lock")
-	lk, err := filelock.Lock(path.Join(locker.path, lockFileName))
+	lk, err := filelock.Lock(path.Join(l.path, lockFileName))
 	if err != nil {
 		logger.Debug(err)
-		locker.lockCloser = nil
+		l.lockCloser = nil
 		errStr := `could not obtain execution lock.  If no other process
 is running, remove ~/path/to/lock, or make sure that the config folder is 
 writable for the user running ipfs-cluster.  Run with -d for more information
 about the error`
 		logger.Error(errStr)
-		return fmt.Errorf("could not obtain execution lock.")
+		return fmt.Errorf("could not obtain execution lock")
 	}
 	logger.Debug("Success! ipfs-cluster-service lock acquired")
-	locker.lockCloser = lk
+	l.lockCloser = lk
 	return nil
 }
 
-func (locker *Locker) tryUnlock() error {
+func (l *lock) tryUnlock() error {
 	// Noop in the uninitialized case
-	if locker.lockCloser == nil {
+	if l.lockCloser == nil {
 		logger.Debug("locking not initialized, unlock is noop")
 		return nil
 	}
-	err := locker.lockCloser.Close()
+	err := l.lockCloser.Close()
 	if err != nil {
 		return err
 	}
 	logger.Debug("Successfully released execution lock")
-	locker.lockCloser = nil
+	l.lockCloser = nil
 	return nil
 }

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -281,7 +281,7 @@ removal, upgrade state using this command, and restart every peer.
 			setupDebug()
 		}
 
-		locker = &Locker{path: absPath}
+		locker = &lock{path: absPath}
 
 		return nil
 	}


### PR DESCRIPTION
This adds the pakage api/rest/client which implements a go-client
for the REST API component. It also update the ipfs-cluster-ctl
tool to rely on it.

Originally, I wanted this to live it in it's own separate repository,
but the api client uses /api/types.go, which is part of cluster.

Therefore it would need to import all of cluster as a dependency.
ipfs-cluster-ctl would also need to import go-ipfs-cluster-api-client
as a dependency, creating circular gx deps which would be a mess to
maintain.

Only the splitting of cluster in multiple repositories (at least for
api, rest, ipfs-cluster-ctl, rest/client and test) would allow better
dependency management by allowing rest/client and the ctl tool
to only import what is needed, but this is something which brings
maintenance costs and can probably wait a bit until cluster is more stable.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>