### PR TITLE
cluster-service: add version subcommand and change some startup logging

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -86,7 +86,7 @@ func NewCluster(
 		return nil, err
 	}
 
-	logger.Infof("IPFS Cluster v%s listening on:", Version)
+	logger.Infof("IPFS Cluster v%s-%s listening on:", Version, Commit[0:8])
 	for _, addr := range host.Addrs() {
 		logger.Infof("        %s/ipfs/%s", addr, host.ID().Pretty())
 	}
@@ -450,7 +450,7 @@ func (c *Cluster) ready() {
 	}
 	close(c.readyCh)
 	c.readyB = true
-	logger.Info("IPFS Cluster is ready")
+	logger.Info("** IPFS Cluster is READY **")
 }
 
 func (c *Cluster) bootstrap() bool {

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -58,7 +58,7 @@ func NewConsensus(clusterPeers []peer.ID, host host.Host, cfg *Config, state sta
 
 	baseOp := &LogOp{}
 
-	logger.Infof("starting Consensus and waiting for a leader...")
+	logger.Debug("starting Consensus and waiting for a leader...")
 	consensus := libp2praft.NewOpLog(state, baseOp)
 	raft, err := newRaftWrapper(clusterPeers, host, cfg, consensus.FSM())
 	if err != nil {
@@ -113,7 +113,7 @@ func (cc *Consensus) finishBootstrap() {
 	if err != nil {
 		return
 	}
-	logger.Info("Consensus state is up to date")
+	logger.Debug("Raft state is now up to date")
 
 	// While rpc is not ready we cannot perform a sync
 	if cc.rpcClient == nil {

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -108,7 +108,7 @@ func newRaftWrapper(peers []peer.ID, host host.Host, cfg *Config, fsm hraft.FSM)
 		return nil, err
 	}
 	if !hasState {
-		logger.Info("bootstrapping raft cluster")
+		logger.Info("initializing raft cluster")
 		err := hraft.BootstrapCluster(cfg.RaftConfig,
 			log, stable, snap, transport, srvCfg)
 		if err != nil {
@@ -116,7 +116,7 @@ func newRaftWrapper(peers []peer.ID, host host.Host, cfg *Config, fsm hraft.FSM)
 			return nil, err
 		}
 	} else {
-		logger.Info("raft cluster is already bootstrapped")
+		logger.Debug("raft cluster is already initialized")
 	}
 
 	logger.Debug("creating Raft")
@@ -261,7 +261,7 @@ func (rw *raftWrapper) WaitForLeader(ctx context.Context) (string, error) {
 		case <-ticker.C:
 			if l := rw.raft.Leader(); l != "" {
 				logger.Debug("waitForleaderTimer")
-				logger.Infof("Raft Leader elected: %s", l)
+				logger.Infof("Current Raft Leader: %s", l)
 				ticker.Stop()
 				return string(l), nil
 			}
@@ -273,7 +273,7 @@ func (rw *raftWrapper) WaitForLeader(ctx context.Context) (string, error) {
 
 // WaitForUpdates holds until Raft has synced to the last index in the log
 func (rw *raftWrapper) WaitForUpdates(ctx context.Context) error {
-	logger.Info("Raft state is catching up")
+	logger.Debug("Raft state is catching up to the latest known version. Please wait...")
 	for {
 		select {
 		case <-ctx.Done():

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -52,7 +52,7 @@ using LibP2P. This is a simplified view of the components:
              | ipfs-cluster-ctl |
              +---------+--------+
                        |
-                       | HTTP
+                       | HTTP(s)
 ipfs-cluster-service   |                           HTTP
 +----------+--------+--v--+----------------------+      +-------------+
 | RPC/Raft | Peer 1 | API | IPFS Connector/Proxy +------> IPFS daemon |
@@ -266,6 +266,14 @@ removal, upgrade state using this command, and restart every peer.
 				},
 			},
 		},
+		{
+			Name:  "version",
+			Usage: "Print the ipfs-cluster version",
+			Action: func(c *cli.Context) error {
+				fmt.Printf("%s-%s\n", ipfscluster.Version, ipfscluster.Commit[0:8])
+				return nil
+			},
+		},
 	}
 
 	app.Before = func(c *cli.Context) error {
@@ -300,6 +308,8 @@ func run(c *cli.Context) error {
 }
 
 func daemon(c *cli.Context) error {
+	logger.Info("Initializing. For verbose output run with \"-l debug\". Please wait...")
+
 	// Load all the configurations
 	cfg, clusterCfg, apiCfg, ipfshttpCfg, consensusCfg, trackerCfg, monCfg, diskInfCfg, numpinInfCfg := makeConfigs()
 	// Execution lock

--- a/version.go
+++ b/version.go
@@ -4,5 +4,5 @@ package ipfscluster
 // components, apis and tools ensures compatibility among them.
 const Version = "0.3.1"
 
-// Commit is the current build commit of cluster. See Makefile
-var Commit string
+// Commit is the current build commit of cluster. See Makefile.
+var Commit = "00000000" // actual commit set during builds.


### PR DESCRIPTION
The --version flag is default from our cli library so I left that. The
version subcommand prints only the version number + the short commit
so it's a bit more easy to parse.

I have additionally reduced the amount of output on start up by converting
some messages to debug. I wish there was a level between INFO and DEBUG
though.

Fixes #201 

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>