### PR TITLE
Fix #275: Attempt to wait for updates when shutting down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ script:
 env:
   global:
     - secure: M3K3y9+D933tCda7+blW3qqVV8fA6PBDRdJoQvmQc1f0XYbWinJ+bAziFp6diKkF8sMQ+cPwLMONYJuaNT2h7/PkG+sIwF0PuUo5VVCbhGmSDrn2qOjmSnfawNs8wW31f44FQA8ICka1EFZcihohoIMf0e5xZ0tXA9jqw+ngPJiRnv4zyzC3r6t4JMAZcbS9w4KTYpIev5Yj72eCvk6lGjadSVCDVXo2sVs27tNt+BSgtMXiH6Sv8GLOnN2kFspGITgivHgB/jtU6QVtFXB+cbBJJAs3lUYnzmQZ5INecbjweYll07ilwFiCVNCX67+L15gpymKGJbQggloIGyTWrAOa2TMaB/bvblzwwQZ8wE5P3Rss5L0TFkUAcdU+3BUHM+TwV4e8F9x10v1PjgWNBRJQzd1sjKKgGUBCeyCY7VeYDKn9AXI5llISgY/AAfCZwm2cbckMHZZJciMjm+U3Q1FCF+rfhlvUcMG1VEj8r9cGpmWIRjFYVm0NmpUDDNjlC3/lUfTCOOJJyM254EUw63XxabbK6EtDN1yQe8kYRcXH//2rtEwgtMBgqHVY+OOkekzGz8Ra3EBkh6jXrAQL3zKu/GwRlK7/a1OU5MQ7dWcTjbx1AQ6Zfyjg5bZ+idqPgMbqM9Zn2+OaSby8HEEXS0QeZVooDVf/6wdYO4MQ/0A=
-    - verbose=t
 after_success:
 - openssl aes-256-cbc -K $encrypted_5a1cb914c6c9_key -iv $encrypted_5a1cb914c6c9_iv
   -in .snapcraft/travis_snapcraft.cfg -out .snapcraft/snapcraft.cfg -d

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -379,23 +379,28 @@ func (api *API) peerRemoveHandler(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) pinHandler(w http.ResponseWriter, r *http.Request) {
 	if ps := parseCidOrError(w, r); ps.Cid != "" {
+		logger.Debugf("rest api pinHandler: %s", ps.Cid)
+
 		err := api.rpcClient.Call("",
 			"Cluster",
 			"Pin",
 			ps,
 			&struct{}{})
 		sendAcceptedResponse(w, err)
+		logger.Debug("rest api pinHandler done")
 	}
 }
 
 func (api *API) unpinHandler(w http.ResponseWriter, r *http.Request) {
 	if ps := parseCidOrError(w, r); ps.Cid != "" {
+		logger.Debugf("rest api unpinHandler: %s", ps.Cid)
 		err := api.rpcClient.Call("",
 			"Cluster",
 			"Unpin",
 			ps,
 			&struct{}{})
 		sendAcceptedResponse(w, err)
+		logger.Debug("rest api unpinHandler done")
 	}
 }
 

--- a/state/mapstate/map_state.go
+++ b/state/mapstate/map_state.go
@@ -125,7 +125,7 @@ func (st *MapState) Marshal() ([]byte, error) {
 	vCodec := make([]byte, 1)
 	vCodec[0] = byte(st.Version)
 	ret := append(vCodec, buf.Bytes()...)
-	logger.Debugf("Marshal-- The final marshaled bytes: %x", ret)
+	// logger.Debugf("Marshal-- The final marshaled bytes: %x", ret)
 	return ret, nil
 }
 
@@ -136,7 +136,7 @@ func (st *MapState) Marshal() ([]byte, error) {
 // version is not an error
 func (st *MapState) Unmarshal(bs []byte) error {
 	// Check version byte
-	logger.Debugf("The incoming bytes to unmarshal: %x", bs)
+	// logger.Debugf("The incoming bytes to unmarshal: %x", bs)
 	v := int(bs[0])
 	logger.Debugf("The interpreted version: %d", v)
 	if v != Version { // snapshot is out of date


### PR DESCRIPTION
Still thinking if worth to do retry-ing or something like that.

Did we ever try to Snapshot after shutdown?

There doesn't seem to be a way to tell raft to not take any more updates so this is a best effort...