### PR TITLE
Harden Sharness

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -688,7 +688,7 @@ func (ipfs *Connector) post(path string) ([]byte, error) {
 
 	res, err := http.Post(url, "", nil)
 	if err != nil {
-		logger.Error("error getting:", err)
+		logger.Error("error posting:", err)
 		return nil, err
 	}
 	defer res.Body.Close()

--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -32,7 +32,7 @@ test_ipfs_init() {
     else
         docker run --name ipfs -d -p 127.0.0.1:5001:5001 ipfs/go-ipfs > /dev/null 2>&1
         if [ $? -ne 0 ]; then
-            echo "Error running go-ipfs in docker."
+            echo "IPFS init FAIL: Error running go-ipfs in docker."
             exit 1
         fi
         while ! curl -s "localhost:5001/api/v0/version" > /dev/null; do
@@ -57,17 +57,17 @@ test_cluster_init() {
 
     which ipfs-cluster-service >/dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "ipfs-cluster-service not found"
+        echo "cluster init FAIL: ipfs-cluster-service not found"
         exit 1
     fi
     which ipfs-cluster-ctl >/dev/null 2>&1
     if [ $? -ne 0 ]; then
-        echo "ipfs-cluster-ctl not found"
+        echo "cluster init FAIL: ipfs-cluster-ctl not found"
         exit 1
     fi
     ipfs-cluster-service -f --config "test-config" init >"$IPFS_OUTPUT" 2>&1
     if [ $? -ne 0 ]; then
-        echo "error initializing ipfs cluster"
+        echo "cluster init FAIL: error on ipfs cluster init"
         exit 1
     fi
     rm -rf "test-config/ipfs-cluster-data"

--- a/sharness/t0020-service-basic-commands.sh
+++ b/sharness/t0020-service-basic-commands.sh
@@ -4,9 +4,7 @@ test_description="Test service startup and init functionality"
 
 . lib/test-lib.sh
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 
 test_expect_success "prerequisites" '
     test_have_prereq IPFS &&
@@ -30,5 +28,8 @@ test_expect_success "cluster-service --version succeeds and matches ctl" '
 test_expect_success "starting a second cluster-service process fails" '
     test_expect_code 1 ipfs-cluster-service --config "test-config"    
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0025-ctl-status-report-commands.sh
+++ b/sharness/t0025-ctl-status-report-commands.sh
@@ -5,9 +5,7 @@ test_description="Test ctl's status reporting functionality.  Test errors on inc
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 
 test_expect_success IPFS,CLUSTER,JQ "cluster-ctl can read id" '
     id=`cluster_id`
@@ -58,5 +56,8 @@ test_expect_success IPFS,CLUSTER "pin ls succeeds" '
 test_expect_success IPFS,CLUSTER "pin ls on invalid CID fails" '
     test_must_fail ipfs-cluster-ctl pin ls XXXinvalid-CIDXXX
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0030-ctl-pin.sh
+++ b/sharness/t0030-ctl-pin.sh
@@ -5,9 +5,7 @@ test_description="Test cluster-ctl's pinning and unpinning functionality"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 
 test_expect_success IPFS,CLUSTER "pin data to cluster with ctl" '
     cid=`docker exec ipfs sh -c "echo test | ipfs add -q"`
@@ -22,5 +20,8 @@ test_expect_success IPFS,CLUSTER "unpin data from cluster with ctl" '
     !(ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid") &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0040-ssl-simple-exchange.sh
+++ b/sharness/t0040-ssl-simple-exchange.sh
@@ -7,7 +7,6 @@ ssl_config="`pwd`/config/ssl"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 
 test_cluster_init "$ssl_config"
 cleanup test_clean_cluster
@@ -20,5 +19,7 @@ test_expect_success "ssl interaction succeeds" '
     id=`cluster_id`
     ipfs-cluster-ctl --https --no-check-certificate id | egrep -q "$id"
 '
+
+test_clean_ipfs
 
 test_done

--- a/sharness/t0041-ssl-enforcement.sh
+++ b/sharness/t0041-ssl-enforcement.sh
@@ -5,9 +5,7 @@ test_description="Test failure when server not using SSL but client requests it"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 
 test_expect_success "prerequisites" '
     test_have_prereq IPFS && test_have_prereq CLUSTER
@@ -17,5 +15,8 @@ test_expect_success "ssl enforced by client" '
     id=`cluster_id`
     test_must_fail ipfs-cluster-ctl --https --no-check-certificate id
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0042-basic-auth.sh
+++ b/sharness/t0042-basic-auth.sh
@@ -7,9 +7,7 @@ config="`pwd`/config/basic_auth"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init "$config"
-cleanup test_clean_cluster
 
 test_expect_success "prerequisites" '
     test_have_prereq IPFS && test_have_prereq CLUSTER
@@ -40,5 +38,8 @@ test_expect_success "BasicAuth succeeds with env var credentials" '
     export CLUSTER_CREDENTIALS="testuser:testpass"
     ipfs-cluster-ctl --force-http id | egrep -q "$id"
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0043-ssl-basic-auth.sh
+++ b/sharness/t0043-ssl-basic-auth.sh
@@ -7,9 +7,7 @@ config="`pwd`/config/ssl-basic_auth"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init "$config"
-cleanup test_clean_cluster
 
 test_expect_success "prerequisites" '
     test_have_prereq IPFS && test_have_prereq CLUSTER
@@ -25,5 +23,8 @@ test_expect_success "ssl interaction succeeds" '
     ipfs-cluster-ctl --no-check-certificate --basic-auth "userwithoutpass" id | egrep -q "$id" &&
     ipfs-cluster-ctl --no-check-certificate --basic-auth "testuser:testpass" id | egrep -q "$id"
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0050-service-state-upgrade-from-current.sh
+++ b/sharness/t0050-service-state-upgrade-from-current.sh
@@ -5,9 +5,7 @@ test_description="Test service state 'upgrade' from current version"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 
 test_expect_success IPFS,CLUSTER "cluster-service state upgrade works" '
     cid=`docker exec ipfs sh -c "echo testing | ipfs add -q"` &&
@@ -27,5 +25,8 @@ test_expect_success IPFS,CLUSTER "state is preserved after migration" '
     ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED"
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0051-service-state-upgrade-from-old.sh
+++ b/sharness/t0051-service-state-upgrade-from-old.sh
@@ -5,10 +5,8 @@ test_description="Test service state upgrade v1 -> v2 and v2 -> v2"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
 test_confirm_v1State
-cleanup test_clean_cluster
 
 # Make a pin and shutdown to force a snapshot. Modify snapshot files to specify
 # a snapshot of v1 state pinning "test" (it's easier than taking a new one each
@@ -29,5 +27,9 @@ test_expect_success IPFS,CLUSTER,V1STATE,JQ "cluster-service loads v1 state corr
      ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
      ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED"
 '
+
+test_clean_ipfs
+test_clean_cluster
+
 
 test_done

--- a/sharness/t0052-service-state-export.sh
+++ b/sharness/t0052-service-state-export.sh
@@ -5,9 +5,7 @@ test_description="Test service state export"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 
 
 test_expect_success IPFS,CLUSTER "state export fails without snapshots" '
@@ -27,5 +25,8 @@ test_expect_success IPFS,CLUSTER,JQ "state export saves the correct state to exp
     [ -f export.json ] &&
     jq ".[].cid" export.json | grep -q "$cid"
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0053-service-state-import.sh
+++ b/sharness/t0053-service-state-import.sh
@@ -5,9 +5,7 @@ test_description="Test service state import"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 test_confirm_importState
 
 # Kill cluster daemon but keep data folder
@@ -27,5 +25,8 @@ test_expect_success IPFS,CLUSTER,IMPORTSTATE "state import succeeds on correct f
     ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED"
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done

--- a/sharness/t0054-service-state-clean.sh
+++ b/sharness/t0054-service-state-clean.sh
@@ -5,9 +5,7 @@ test_description="Test service state import"
 . lib/test-lib.sh
 
 test_ipfs_init
-cleanup test_clean_ipfs
 test_cluster_init
-cleanup test_clean_cluster
 
 test_expect_success IPFS,CLUSTER "state cleanup refreshes state on restart" '
      cid=`docker exec ipfs sh -c "echo test_54 | ipfs add -q"` &&
@@ -34,5 +32,8 @@ test_expect_success IPFS,CLUSTER "export + cleanup + import == noop" '
     ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED" &&
     [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ]
 '
+
+test_clean_ipfs
+test_clean_cluster
 
 test_done


### PR DESCRIPTION
Recent sharness failures prompted more investigation.  In particular sharness `cleanup` does not run cleanup functions on failure (see here: https://github.com/chriscool/sharness/blob/master/sharness.sh#L763).  To ensure isolation among test failures we need reliable teardown of ipfs and cluster between each testfile so now the cleanup functions are run directly before test_done.  

Error messages are also slightly improved.

The current `test-lib.sh` already ensures that there is no data folder with `rm -rf ipfs-cluster-data` after the config folder is created.

Altogether this should close #181.