### PR TITLE
Fix/297

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -157,7 +157,7 @@ func (c *Cluster) setupConsensus(consensuscfg *raft.Config) error {
 	var startPeers []peer.ID
 
 	if len(c.config.Peers) > 0 {
-		startPeers = peersFromMultiaddrs(c.config.Peers)
+		startPeers = PeersFromMultiaddrs(c.config.Peers)
 	} else {
 		// start as single cluster before being added
 		// to the bootstrapper peers' cluster.
@@ -341,7 +341,7 @@ func (c *Cluster) alertsHandler() {
 func (c *Cluster) watchPeers() {
 	// TODO: Config option?
 	ticker := time.NewTicker(5 * time.Second)
-	lastPeers := peersFromMultiaddrs(c.config.Peers)
+	lastPeers := PeersFromMultiaddrs(c.config.Peers)
 
 	for {
 		select {

--- a/ipfs-cluster-service/state.go
+++ b/ipfs-cluster-service/state.go
@@ -27,7 +27,8 @@ func upgrade() error {
 		return err
 	}
 
-	return raft.SnapshotSave(consensusCfg, newState, clusterCfg.ID)
+	raftPeers := append(ipfscluster.PeersFromMultiaddrs(clusterCfg.Peers), clusterCfg.ID)
+	return raft.SnapshotSave(consensusCfg, newState, raftPeers)
 }
 
 func export(w io.Writer) error {
@@ -87,8 +88,8 @@ func stateImport(r io.Reader) error {
 			return err
 		}
 	}
-
-	return raft.SnapshotSave(consensusCfg, stateToImport, clusterCfg.ID)
+	raftPeers := append(ipfscluster.PeersFromMultiaddrs(clusterCfg.Peers), clusterCfg.ID)
+	return raft.SnapshotSave(consensusCfg, stateToImport, raftPeers)
 }
 
 func validateVersion(cfg *ipfscluster.Config, cCfg *raft.Config) error {

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -92,7 +92,7 @@ func TestClustersPeerAdd(t *testing.T) {
 		// check that they are part of the configuration
 		// This only works because each peer only has one multiaddress
 		// (localhost)
-		if len(peersFromMultiaddrs(c.config.Peers)) != nClusters-1 {
+		if len(PeersFromMultiaddrs(c.config.Peers)) != nClusters-1 {
 			t.Error(c.config.Peers)
 			t.Errorf("%s: expected different cluster peers in the configuration", c.id)
 		}

--- a/util.go
+++ b/util.go
@@ -87,10 +87,10 @@ func multiaddrJoin(addr ma.Multiaddr, p peer.ID) ma.Multiaddr {
 	return addr.Encapsulate(pidAddr)
 }
 
-// returns all the different peers in the given addresses.
+// PeersFromMultiaddrs returns all the different peers in the given addresses.
 // each peer only will appear once in the result, even if several
 // multiaddresses for it are provided.
-func peersFromMultiaddrs(addrs []ma.Multiaddr) []peer.ID {
+func PeersFromMultiaddrs(addrs []ma.Multiaddr) []peer.ID {
 	var pids []peer.ID
 	pm := make(map[peer.ID]struct{})
 	for _, addr := range addrs {


### PR DESCRIPTION
This fixes the second problem discussed in issue #297, consensus peers are now directly copied from the config and imported snapshot replay is now forced on peers with empty state during bootstrap.

This has been tested out on a 3 peer cluster using the (export, _, _); (clean, clean, clean); (import, _,_); (start as single peer, bootstrap, bootstrap) order of operations.