### PR TITLE
Three small state features

### DIFF
--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -193,6 +193,10 @@ func main() {
 			Value: "disk-freespace",
 			Usage: "allocation strategy to use [disk-freespace,disk-reposize,numpin].",
 		},
+		cli.BoolFlag{
+			Name:  "upgrade, u",
+			Usage: "run necessary state migrations before starting cluster service",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -424,6 +428,13 @@ func daemon(c *cli.Context) error {
 
 	// Load all the configurations
 	cfg, clusterCfg, apiCfg, ipfshttpCfg, consensusCfg, trackerCfg, monCfg, diskInfCfg, numpinInfCfg := makeConfigs()
+
+	// Run any migrations
+	if c.Bool("upgrade") {
+		err := upgrade()
+		checkErr("upgrading state", err)
+	}
+
 	// Execution lock
 	err := locker.lock()
 	checkErr("acquiring execution lock", err)

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -193,10 +193,6 @@ func main() {
 			Value: "disk-freespace",
 			Usage: "allocation strategy to use [disk-freespace,disk-reposize,numpin].",
 		},
-		cli.BoolFlag{
-			Name:  "upgrade, u",
-			Usage: "run necessary state migrations before starting cluster service",
-		},
 	}
 
 	app.Commands = []cli.Command{
@@ -244,8 +240,14 @@ configuration.
 			},
 		},
 		{
-			Name:   "daemon",
-			Usage:  "run the IPFS Cluster peer (default)",
+			Name:  "daemon",
+			Usage: "run the IPFS Cluster peer (default)",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "upgrade, u",
+					Usage: "run necessary state migrations before starting cluster service",
+				},
+			},
 			Action: daemon,
 		},
 		{

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -253,6 +253,14 @@ configuration.
 			Usage: "Manage ipfs-cluster-state",
 			Subcommands: []cli.Command{
 				{
+					Name:  "version",
+					Usage: "display the shared state format version",
+					Action: func(c *cli.Context) error {
+						fmt.Printf("%d\n", mapstate.Version)
+						return nil
+					},
+				},
+				{
 					Name:  "upgrade",
 					Usage: "upgrade the IPFS Cluster state to the current version",
 					Description: `

--- a/state/mapstate/map_state.go
+++ b/state/mapstate/map_state.go
@@ -4,6 +4,7 @@ package mapstate
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -99,6 +100,9 @@ func (st *MapState) Migrate(r io.Reader) error {
 		return err
 	}
 	err = st.Unmarshal(bs)
+	if err != nil {
+		return err
+	}
 	if st.Version == Version { // Unmarshal restored for us
 		return nil
 	}
@@ -142,6 +146,9 @@ func (st *MapState) Marshal() ([]byte, error) {
 func (st *MapState) Unmarshal(bs []byte) error {
 	// Check version byte
 	// logger.Debugf("The incoming bytes to unmarshal: %x", bs)
+	if len(bs) < 1 {
+		return errors.New("cannot unmarshal from empty bytes")
+	}
 	v := int(bs[0])
 	logger.Debugf("The interpreted version: %d", v)
 	if v != Version { // snapshot is out of date


### PR DESCRIPTION
Feat #300 -- `--upgrade` flag for automatically running upgrades when launching service
Fix #296   -- current state formats no longer cause upgrades.  No error but a warning
Feat #298 -- `ipfs-cluster-service state version` reports the mapstate version used by this cluster binary