### PR TITLE
Add files to calling cluster peer's ipfs daemon

### DIFF
--- a/api/rest/client/request.go
+++ b/api/rest/client/request.go
@@ -59,8 +59,9 @@ func (c *Client) doStreamRequest(method, path string, body io.Reader, headers ma
 	}
 
 	// Here are the streaming specific modifications
-	r.ProtoMajor = 1
-	r.ProtoMinor = 1
+	// Using HTTP 2.0 to enable parallel reading req and writing resp
+	r.ProtoMajor = 2
+	r.ProtoMinor = 0
 	r.ContentLength = -1
 
 	return c.client.Do(r)

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -386,7 +386,7 @@ func (api *API) addFileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	outChan := make(chan *ipld.Node)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(api.ctx)
 	go func() {
 		for nodePtr := range outChan {
 			node := *nodePtr

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -386,6 +386,7 @@ func (api *API) addFileHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	outChan := make(chan *ipld.Node)
+	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		for nodePtr := range outChan {
 			node := *nodePtr
@@ -398,15 +399,17 @@ func (api *API) addFileHandler(w http.ResponseWriter, r *http.Request) {
 				&pinS)
 
 			/* Verify that block put cid matches*/
-			if err != nil {
-				logger.Warning(err)
-			}
 			if node.String() != pinS.Cid { // node string is just cid string
 				logger.Warningf("mismatch. node cid: %s\nrpc cid: %s", node.String(), pinS.Cid)
 			}
+			if err != nil { // error will be triggered in importer
+				logger.Error(err)
+				cancel()
+				return
+			}
 		}
 	}()
-	err := dex.ImportToChannel(f, outChan, context.Background())
+	err := dex.ImportToChannel(f, outChan, ctx)
 	/*	buf := make([]byte, 256)
 		for {
 			file, err := f.NextFile()

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -88,7 +88,7 @@ func (ipfs *mockConnector) ConnectSwarms() error                          { retu
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
 func (ipfs *mockConnector) FreeSpace() (uint64, error)                    { return 100, nil }
 func (ipfs *mockConnector) RepoSize() (uint64, error)                     { return 0, nil }
-func (ipfs *mockConnector) BlockPut(data []byte) (api.Pin, error)         { return api.Pin{}, nil }
+func (ipfs *mockConnector) BlockPut(data []byte) (string, error)          { return "", nil }
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *maptracker.MapPinTracker) {
 	clusterCfg, _, _, consensusCfg, trackerCfg, monCfg, _ := testingConfigs()

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -88,6 +88,7 @@ func (ipfs *mockConnector) ConnectSwarms() error                          { retu
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
 func (ipfs *mockConnector) FreeSpace() (uint64, error)                    { return 100, nil }
 func (ipfs *mockConnector) RepoSize() (uint64, error)                     { return 0, nil }
+func (ipfs *mockConnector) BlockPut(data []byte) (api.Pin, error)         { return api.Pin{}, nil }
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *maptracker.MapPinTracker) {
 	clusterCfg, _, _, consensusCfg, trackerCfg, monCfg, _ := testingConfigs()

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -88,6 +88,8 @@ type IPFSConnector interface {
 	// RepoSize returns the current repository size as expressed
 	// by "repo stat".
 	RepoSize() (uint64, error)
+	// BlockPut directly adds a block of data to the IPFS repo
+	BlockPut([]byte) (api.Pin, error)
 }
 
 // Peered represents a component which needs to be aware of the peers

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -89,7 +89,7 @@ type IPFSConnector interface {
 	// by "repo stat".
 	RepoSize() (uint64, error)
 	// BlockPut directly adds a block of data to the IPFS repo
-	BlockPut([]byte) (api.Pin, error)
+	BlockPut([]byte) (string, error)
 }
 
 // Peered represents a component which needs to be aware of the peers

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -884,9 +884,7 @@ func (ipfs *Connector) SwarmPeers() (api.SwarmPeers, error) {
 
 // BlockPut triggers an ipfs block put on the given data, inserting the block
 // into the ipfs daemon's repo.
-func (ipfs *Connector) BlockPut(data []byte) (api.Pin, error) {
-	pin := api.Pin{}
-
+func (ipfs *Connector) BlockPut(data []byte) (string, error) {
 	r := ioutil.NopCloser(bytes.NewReader(data))
 	rFile := files.NewReaderFile("", "", r, nil)
 	sliceFile := files.NewSliceFile("", "", []files.File{rFile}) // IPFS reqs require a wrapping directory
@@ -895,17 +893,12 @@ func (ipfs *Connector) BlockPut(data []byte) (api.Pin, error) {
 
 	res, err := ipfs.post("block/put", contentType, multiFileR)
 	if err != nil {
-		return pin, err
+		return "", err
 	}
 	var keyRaw ipfsBlockPutResp
 	err = json.Unmarshal(res, &keyRaw)
 	if err != nil {
-		return pin, err
+		return "", err
 	}
-	c, err := cid.Decode(keyRaw.Key)
-	if err != nil {
-		return pin, err
-	}
-
-	return api.PinCid(c), nil
+	return keyRaw.Key, nil
 }

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -22,6 +22,7 @@ import (
 
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipfs-cmdkit/files"
 	logging "github.com/ipfs/go-log"
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
@@ -102,6 +103,10 @@ type ipfsPeer struct {
 
 type ipfsStream struct {
 	Protocol string
+}
+
+type ipfsBlockPutResp struct {
+	Key string
 }
 
 // NewConnector creates the component and leaves it ready to be started
@@ -564,7 +569,7 @@ func (ipfs *Connector) Shutdown() error {
 // contains the error message.
 func (ipfs *Connector) ID() (api.IPFSID, error) {
 	id := api.IPFSID{}
-	body, err := ipfs.post("id")
+	body, err := ipfs.post("id", "", nil)
 	if err != nil {
 		id.Error = err.Error()
 		return id, err
@@ -606,7 +611,7 @@ func (ipfs *Connector) Pin(hash *cid.Cid) error {
 	}
 	if !pinStatus.IsPinned() {
 		path := fmt.Sprintf("pin/add?arg=%s", hash)
-		_, err = ipfs.post(path)
+		_, err = ipfs.post(path, "", nil)
 		if err == nil {
 			logger.Info("IPFS Pin request succeeded: ", hash)
 		}
@@ -625,7 +630,7 @@ func (ipfs *Connector) Unpin(hash *cid.Cid) error {
 	}
 	if pinStatus.IsPinned() {
 		path := fmt.Sprintf("pin/rm?arg=%s", hash)
-		_, err := ipfs.post(path)
+		_, err := ipfs.post(path, "", nil)
 		if err == nil {
 			logger.Info("IPFS Unpin request succeeded:", hash)
 		}
@@ -639,7 +644,7 @@ func (ipfs *Connector) Unpin(hash *cid.Cid) error {
 // PinLs performs a "pin ls --type typeFilter" request against the configured
 // IPFS daemon and returns a map of cid strings and their status.
 func (ipfs *Connector) PinLs(typeFilter string) (map[string]api.IPFSPinStatus, error) {
-	body, err := ipfs.post("pin/ls?type=" + typeFilter)
+	body, err := ipfs.post("pin/ls?type="+typeFilter, "", nil)
 
 	// Some error talking to the daemon
 	if err != nil {
@@ -665,7 +670,7 @@ func (ipfs *Connector) PinLs(typeFilter string) (map[string]api.IPFSPinStatus, e
 // an api.IPFSPinStatus for that hash.
 func (ipfs *Connector) PinLsCid(hash *cid.Cid) (api.IPFSPinStatus, error) {
 	lsPath := fmt.Sprintf("pin/ls?arg=%s&type=recursive", hash)
-	body, err := ipfs.post(lsPath)
+	body, err := ipfs.post(lsPath, "", nil)
 
 	// Network error, daemon down
 	if body == nil && err != nil {
@@ -694,13 +699,13 @@ func (ipfs *Connector) PinLsCid(hash *cid.Cid) (api.IPFSPinStatus, error) {
 
 // post performs the heavy lifting of a post request against
 // the IPFS daemon.
-func (ipfs *Connector) post(path string) ([]byte, error) {
+func (ipfs *Connector) post(path string, contentType string, postBody io.Reader) ([]byte, error) {
 	logger.Debugf("posting %s", path)
 	url := fmt.Sprintf("%s/%s",
 		ipfs.apiURL(),
 		path)
 
-	res, err := http.Post(url, "", nil)
+	res, err := http.Post(url, contentType, postBody)
 	if err != nil {
 		logger.Error("error posting:", err)
 		return nil, err
@@ -758,7 +763,7 @@ func (ipfs *Connector) ConnectSwarms() error {
 			// We ignore errors which happens
 			// when passing in a bunch of addresses
 			_, err := ipfs.post(
-				fmt.Sprintf("swarm/connect?arg=%s", addr))
+				fmt.Sprintf("swarm/connect?arg=%s", addr), "", nil)
 			if err != nil {
 				logger.Debug(err)
 				continue
@@ -773,7 +778,7 @@ func (ipfs *Connector) ConnectSwarms() error {
 // a given configuration key. For example, "Datastore/StorageMax" will return
 // the value for StorageMax in the Datastore configuration object.
 func (ipfs *Connector) ConfigKey(keypath string) (interface{}, error) {
-	res, err := ipfs.post("config/show")
+	res, err := ipfs.post("config/show", "", nil)
 	if err != nil {
 		logger.Error(err)
 		return nil, err
@@ -817,7 +822,7 @@ func getConfigValue(path []string, cfg map[string]interface{}) (interface{}, err
 // value is derived from the RepoSize and StorageMax values given by "repo
 // stats". The value is in bytes.
 func (ipfs *Connector) FreeSpace() (uint64, error) {
-	res, err := ipfs.post("repo/stat")
+	res, err := ipfs.post("repo/stat", "", nil)
 	if err != nil {
 		logger.Error(err)
 		return 0, err
@@ -835,7 +840,7 @@ func (ipfs *Connector) FreeSpace() (uint64, error) {
 // RepoSize returns the current repository size of the ipfs daemon as
 // provided by "repo stats". The value is in bytes.
 func (ipfs *Connector) RepoSize() (uint64, error) {
-	res, err := ipfs.post("repo/stat")
+	res, err := ipfs.post("repo/stat", "", nil)
 	if err != nil {
 		logger.Error(err)
 		return 0, err
@@ -850,10 +855,10 @@ func (ipfs *Connector) RepoSize() (uint64, error) {
 	return stats.RepoSize, nil
 }
 
-// SwarmPeers returns the peers currently connected to this ipfs daemon
+// SwarmPeers returns the peers currently connected to this ipfs daemon.
 func (ipfs *Connector) SwarmPeers() (api.SwarmPeers, error) {
 	swarm := api.SwarmPeers{}
-	res, err := ipfs.post("swarm/peers")
+	res, err := ipfs.post("swarm/peers", "", nil)
 	if err != nil {
 		logger.Error(err)
 		return swarm, err
@@ -875,4 +880,32 @@ func (ipfs *Connector) SwarmPeers() (api.SwarmPeers, error) {
 		swarm[i] = pID
 	}
 	return swarm, nil
+}
+
+// BlockPut triggers an ipfs block put on the given data, inserting the block
+// into the ipfs daemon's repo.
+func (ipfs *Connector) BlockPut(data []byte) (api.Pin, error) {
+	pin := api.Pin{}
+
+	r := ioutil.NopCloser(bytes.NewReader(data))
+	rFile := files.NewReaderFile("", "", r, nil)
+	sliceFile := files.NewSliceFile("", "", []files.File{rFile}) // IPFS reqs require a wrapping directory
+	multiFileR := files.NewMultiFileReader(sliceFile, true)
+	contentType := "multipart/form-data; boundary=" + multiFileR.Boundary()
+
+	res, err := ipfs.post("block/put", contentType, multiFileR)
+	if err != nil {
+		return pin, err
+	}
+	var keyRaw ipfsBlockPutResp
+	err = json.Unmarshal(res, &keyRaw)
+	if err != nil {
+		return pin, err
+	}
+	c, err := cid.Decode(keyRaw.Key)
+	if err != nil {
+		return pin, err
+	}
+
+	return api.PinCid(c), nil
 }

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -559,6 +559,21 @@ func TestSwarmPeers(t *testing.T) {
 	}
 }
 
+func TestBlockPut(t *testing.T) {
+	ipfs, mock := testIPFSConnector(t)
+	defer mock.Close()
+	defer ipfs.Shutdown()
+
+	data := []byte(test.TestCid4Data)
+	resp, err := ipfs.BlockPut(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Cid.String() != test.TestCid4 {
+		t.Fatal("Unexpected resulting cid")
+	}
+}
+
 func TestRepoSize(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -569,7 +569,7 @@ func TestBlockPut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.Cid.String() != test.TestCid4 {
+	if resp != test.TestCid4 {
 		t.Fatal("Unexpected resulting cid")
 	}
 }

--- a/ipld-importer/import.go
+++ b/ipld-importer/import.go
@@ -50,7 +50,7 @@ func ToPrint(f files.File) error {
 
 // ToChannel imports file to ipfs ipld nodes, outputting nodes on the
 // provided channel
-func ToChannel(f files.File, ctx context.Context) (<-chan *ipld.Node, error) {
+func ToChannel(ctx context.Context, f files.File) (<-chan *ipld.Node, error) {
 	outChan := make(chan *ipld.Node)
 	dserv := &outDAGService{
 		membership: make(map[string]struct{}),

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -307,6 +307,13 @@ func (rpcapi *RPCAPI) IPFSSwarmPeers(in struct{}, out *api.SwarmPeersSerial) err
 	return err
 }
 
+// IPFSBlockPut runs IPFSConnector.BlockPut().
+func (rpcapi *RPCAPI) IPFSBlockPut(in []byte, out *api.PinSerial) error {
+	res, err := rpcapi.c.ipfs.BlockPut(in)
+	*out = res.ToSerial()
+	return err
+}
+
 /*
    Consensus component methods
 */

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -308,9 +308,9 @@ func (rpcapi *RPCAPI) IPFSSwarmPeers(in struct{}, out *api.SwarmPeersSerial) err
 }
 
 // IPFSBlockPut runs IPFSConnector.BlockPut().
-func (rpcapi *RPCAPI) IPFSBlockPut(in []byte, out *api.PinSerial) error {
+func (rpcapi *RPCAPI) IPFSBlockPut(in []byte, out *string) error {
 	res, err := rpcapi.c.ipfs.BlockPut(in)
-	*out = res.ToSerial()
+	*out = res
 	return err
 }
 

--- a/test/cids.go
+++ b/test/cids.go
@@ -4,9 +4,11 @@ import peer "github.com/libp2p/go-libp2p-peer"
 
 // Common variables used all around tests.
 var (
-	TestCid1 = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq"
-	TestCid2 = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmma"
-	TestCid3 = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmb"
+	TestCid1     = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq"
+	TestCid2     = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmma"
+	TestCid3     = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmb"
+	TestCid4     = "Qma24zbcWc6vAcQ7CP1v1FyePuTRxYNnaAyNtDfXDgwRsP"
+	TestCid4Data = "Cid4Data" // Cid resulting from block put NOT ipfs add
 	// ErrorCid is meant to be used as a Cid which causes errors. i.e. the
 	// ipfs mock fails when pinning this CID.
 	ErrorCid       = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmc"

--- a/test/cids.go
+++ b/test/cids.go
@@ -7,7 +7,7 @@ var (
 	TestCid1     = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq"
 	TestCid2     = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmma"
 	TestCid3     = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmb"
-	TestCid4     = "Qma24zbcWc6vAcQ7CP1v1FyePuTRxYNnaAyNtDfXDgwRsP"
+	TestCid4     = "zb2rhiKhUepkTMw7oFfBUnChAN7ABAvg2hXUwmTBtZ6yxuc57"
 	TestCid4Data = "Cid4Data" // Cid resulting from block put NOT ipfs add
 	// ErrorCid is meant to be used as a Cid which causes errors. i.e. the
 	// ipfs mock fails when pinning this CID.

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -251,7 +251,7 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			goto ERROR
 		}
-		c := cid.NewCidV0(u.Hash(data)).String()
+		c := cid.NewCidV1(cid.Raw, u.Hash(data)).String()
 		if c != TestCid4 {
 			goto ERROR
 		}

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -3,6 +3,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 
 	cid "github.com/ipfs/go-cid"
+	u "github.com/ipfs/go-ipfs-util"
 )
 
 // IpfsMock is an ipfs daemon mock which should sustain the functionality used by ipfscluster.
@@ -69,6 +71,10 @@ type mockSwarmPeersResp struct {
 
 type mockIpfsPeer struct {
 	Peer string
+}
+
+type mockBlockPutResp struct {
+	Key string
 }
 
 // NewIpfsMock returns a new mock.
@@ -228,6 +234,29 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		}
 		resp := mockSwarmPeersResp{
 			Peers: []mockIpfsPeer{peer1, peer2},
+		}
+		j, _ := json.Marshal(resp)
+		w.Write(j)
+	case "block/put":
+		// Get the data and retun the hash
+		mpr, err := r.MultipartReader()
+		if err != nil {
+			goto ERROR
+		}
+		part, err := mpr.NextPart()
+		if err != nil {
+			goto ERROR
+		}
+		data, err := ioutil.ReadAll(part)
+		if err != nil {
+			goto ERROR
+		}
+		c := cid.NewCidV0(u.Hash(data)).String()
+		if c != TestCid4 {
+			goto ERROR
+		}
+		resp := mockBlockPutResp{
+			Key: c,
 		}
 		j, _ := json.Marshal(resp)
 		w.Write(j)


### PR DESCRIPTION
Minimal code for adding files to ipfs via ipfs-cluster-ctl add.  Restapi now uses importToChannel and calls IPFS block/put on outgoing dag nodes' raw blocks' bytes.  Error checking and context cancellation could use some work.  Garbage collection is not considered.  As we are using block put the added data won't survive an ipfs gc.  

No golang tests yet, but I have tested by hand with complex directories (some paths up to 5 layers deep).  And things generally look good.  More extensive and precise tests to follow.

License: MIT
Signed-off-by: Wyatt Daviau <wdaviau@cs.stanford.edu>