### PR TITLE
Priority Allocations + Non-recursive pinning  -- PROPOSAL

### DIFF
--- a/allocator/ascendalloc/ascendalloc.go
+++ b/allocator/ascendalloc/ascendalloc.go
@@ -34,7 +34,10 @@ func (alloc AscendAllocator) Shutdown() error { return nil }
 // carry a numeric value such as "used disk". We do not pay attention to
 // the metrics of the currently allocated peers and we just sort the
 // candidates based on their metric values (smallest to largest).
-func (alloc AscendAllocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
+func (alloc AscendAllocator) Allocate(c *cid.Cid, current,
+	candidates, priority map[peer.ID]api.Metric) ([]peer.ID, error) {
 	// sort our metrics
-	return util.SortNumeric(candidates, false), nil
+	first := util.SortNumeric(priority, false)
+	last := util.SortNumeric(candidates, false)
+	return append(first, last...), nil
 }

--- a/allocator/ascendalloc/ascendalloc_test.go
+++ b/allocator/ascendalloc/ascendalloc_test.go
@@ -99,7 +99,7 @@ func Test(t *testing.T) {
 	alloc := &AscendAllocator{}
 	for i, tc := range testCases {
 		t.Logf("Test case %d", i)
-		res, err := alloc.Allocate(testCid, tc.current, tc.candidates)
+		res, err := alloc.Allocate(testCid, tc.current, tc.candidates, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/allocator/descendalloc/descendalloc.go
+++ b/allocator/descendalloc/descendalloc.go
@@ -34,7 +34,9 @@ func (alloc DescendAllocator) Shutdown() error { return nil }
 // carry a numeric value such as "used disk". We do not pay attention to
 // the metrics of the currently allocated peers and we just sort the
 // candidates based on their metric values (largest to smallest).
-func (alloc DescendAllocator) Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error) {
+func (alloc DescendAllocator) Allocate(c *cid.Cid, current, candidates, priority map[peer.ID]api.Metric) ([]peer.ID, error) {
 	// sort our metrics
-	return util.SortNumeric(candidates, true), nil
+	first := util.SortNumeric(priority, true)
+	last := util.SortNumeric(candidates, true)
+	return append(first, last...), nil
 }

--- a/allocator/descendalloc/descendalloc_test.go
+++ b/allocator/descendalloc/descendalloc_test.go
@@ -99,7 +99,7 @@ func Test(t *testing.T) {
 	alloc := &DescendAllocator{}
 	for i, tc := range testCases {
 		t.Logf("Test case %d", i)
-		res, err := alloc.Allocate(testCid, tc.current, tc.candidates)
+		res, err := alloc.Allocate(testCid, tc.current, tc.candidates, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -673,6 +673,7 @@ func parseCidOrError(w http.ResponseWriter, r *http.Request) types.PinSerial {
 	queryValues := r.URL.Query()
 	name := queryValues.Get("name")
 	pin.Name = name
+	pin.Recursive = true // For now all CLI pins are recursive
 	rplStr := queryValues.Get("replication_factor")
 	rplStrMin := queryValues.Get("replication_factor_min")
 	rplStrMax := queryValues.Get("replication_factor_max")

--- a/api/types.go
+++ b/api/types.go
@@ -523,13 +523,16 @@ type Pin struct {
 	Allocations          []peer.ID
 	ReplicationFactorMin int
 	ReplicationFactorMax int
+	Recursive            bool
 }
 
-// PinCid is a shorcut to create a Pin only with a Cid.
+// PinCid is a shorcut to create a Pin only with a Cid.  Default is for pin to
+// be recursive
 func PinCid(c *cid.Cid) Pin {
 	return Pin{
 		Cid:         c,
 		Allocations: []peer.ID{},
+		Recursive:   true,
 	}
 }
 
@@ -540,6 +543,7 @@ type PinSerial struct {
 	Allocations          []string `json:"allocations"`
 	ReplicationFactorMin int      `json:"replication_factor_min"`
 	ReplicationFactorMax int      `json:"replication_factor_max"`
+	Recursive            bool     `json:"recursive"`
 }
 
 // ToSerial converts a Pin to PinSerial.
@@ -558,6 +562,7 @@ func (pin Pin) ToSerial() PinSerial {
 		Allocations:          allocs,
 		ReplicationFactorMin: pin.ReplicationFactorMin,
 		ReplicationFactorMax: pin.ReplicationFactorMax,
+		Recursive:            pin.Recursive,
 	}
 }
 
@@ -573,6 +578,10 @@ func (pin Pin) Equals(pin2 Pin) bool {
 	}
 
 	if pin1s.Name != pin2s.Name {
+		return false
+	}
+
+	if pin1s.Recursive != pin2s.Recursive {
 		return false
 	}
 
@@ -606,6 +615,7 @@ func (pins PinSerial) ToPin() Pin {
 		Allocations:          StringsToPeers(pins.Allocations),
 		ReplicationFactorMin: pins.ReplicationFactorMin,
 		ReplicationFactorMax: pins.ReplicationFactorMax,
+		Recursive:            pins.Recursive,
 	}
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -401,7 +401,7 @@ func (c *Cluster) repinFromPeer(p peer.ID) {
 	list := cState.List()
 	for _, pin := range list {
 		if containsPeer(pin.Allocations, p) {
-			ok, err := c.pin(pin, []peer.ID{p}) // pin blacklisting this peer
+			ok, err := c.pin(pin, []peer.ID{p}, []peer.ID{}) // pin blacklisting this peer
 			if ok && err == nil {
 				logger.Infof("repinned %s out of %s", pin.Cid, p.Pretty())
 			}
@@ -979,7 +979,19 @@ func (c *Cluster) PinGet(h *cid.Cid) (api.Pin, error) {
 // to the global state. Pin does not reflect the success or failure
 // of underlying IPFS daemon pinning operations.
 func (c *Cluster) Pin(pin api.Pin) error {
-	_, err := c.pin(pin, []peer.ID{})
+	_, err := c.pin(pin, []peer.ID{}, []peer.ID{})
+	return err
+}
+
+// PinTo, like Pin, makes the cluster Pin a Cid.  PinTo's argument already
+// contains a set of peers that should perform the pin.  If the max repl factor
+// is less than the size of the specified peerset then peers are chosen from
+// this set in allocation order.  If the min repl factor is greater than the
+// specified peerset then peers are allocated as in Pin.  PinTo is best effort.
+// If the peers selected for pinning are unavailable then PinTo will attempt to
+// allocate other peers and will not register an error.
+func (c *Cluster) PinTo(pin api.Pin) error {
+	_, err := c.pin(pin, []peer.ID{}, pin.Allocations)
 	return err
 }
 
@@ -987,7 +999,7 @@ func (c *Cluster) Pin(pin api.Pin) error {
 // able to evacuate a node and returns whether the pin was submitted
 // to the consensus layer or skipped (due to error or to the fact
 // that it was already valid).
-func (c *Cluster) pin(pin api.Pin, blacklist []peer.ID) (bool, error) {
+func (c *Cluster) pin(pin api.Pin, blacklist []peer.ID, prioritylist []peer.ID) (bool, error) {
 	if pin.Cid == nil {
 		return false, errors.New("bad pin object")
 	}
@@ -1010,7 +1022,7 @@ func (c *Cluster) pin(pin api.Pin, blacklist []peer.ID) (bool, error) {
 	case rplMin == -1 && rplMax == -1:
 		pin.Allocations = []peer.ID{}
 	default:
-		allocs, err := c.allocate(pin.Cid, rplMin, rplMax, blacklist)
+		allocs, err := c.allocate(pin.Cid, rplMin, rplMax, blacklist, prioritylist)
 		if err != nil {
 			return false, err
 		}

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -70,7 +70,7 @@ type API interface {
 type IPFSConnector interface {
 	Component
 	ID() (api.IPFSID, error)
-	Pin(*cid.Cid) error
+	Pin(*cid.Cid, bool) error
 	Unpin(*cid.Cid) error
 	PinLsCid(*cid.Cid) (api.IPFSPinStatus, error)
 	PinLs(typeFilter string) (map[string]api.IPFSPinStatus, error)

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -149,7 +149,7 @@ type PinAllocator interface {
 	// which are currently pinning the content. The candidates map
 	// contains the metrics for all peers which are eligible for pinning
 	// the content.
-	Allocate(c *cid.Cid, current, candidates map[peer.ID]api.Metric) ([]peer.ID, error)
+	Allocate(c *cid.Cid, current, candidates, priority map[peer.ID]api.Metric) ([]peer.ID, error)
 }
 
 // PeerMonitor is a component in charge of monitoring the peers in the cluster

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -604,13 +604,13 @@ func (ipfs *Connector) ID() (api.IPFSID, error) {
 
 // Pin performs a pin request against the configured IPFS
 // daemon.
-func (ipfs *Connector) Pin(hash *cid.Cid) error {
+func (ipfs *Connector) Pin(hash *cid.Cid, recursive bool) error {
 	pinStatus, err := ipfs.PinLsCid(hash)
 	if err != nil {
 		return err
 	}
 	if !pinStatus.IsPinned() {
-		path := fmt.Sprintf("pin/add?arg=%s", hash)
+		path := fmt.Sprintf("pin/add?arg=%s&recursive=%t", hash, recursive)
 		_, err = ipfs.post(path, "", nil)
 		if err == nil {
 			logger.Info("IPFS Pin request succeeded: ", hash)

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -80,7 +80,7 @@ func TestIPFSPin(t *testing.T) {
 	defer mock.Close()
 	defer ipfs.Shutdown()
 	c, _ := cid.Decode(test.TestCid1)
-	err := ipfs.Pin(c)
+	err := ipfs.Pin(c, true)
 	if err != nil {
 		t.Error("expected success pinning cid")
 	}
@@ -93,7 +93,7 @@ func TestIPFSPin(t *testing.T) {
 	}
 
 	c2, _ := cid.Decode(test.ErrorCid)
-	err = ipfs.Pin(c2)
+	err = ipfs.Pin(c2, true)
 	if err == nil {
 		t.Error("expected error pinning cid")
 	}
@@ -108,7 +108,7 @@ func TestIPFSUnpin(t *testing.T) {
 	if err != nil {
 		t.Error("expected success unpinning non-pinned cid")
 	}
-	ipfs.Pin(c)
+	ipfs.Pin(c, true)
 	err = ipfs.Unpin(c)
 	if err != nil {
 		t.Error("expected success unpinning pinned cid")
@@ -122,7 +122,7 @@ func TestIPFSPinLsCid(t *testing.T) {
 	c, _ := cid.Decode(test.TestCid1)
 	c2, _ := cid.Decode(test.TestCid2)
 
-	ipfs.Pin(c)
+	ipfs.Pin(c, true)
 	ips, err := ipfs.PinLsCid(c)
 	if err != nil || !ips.IsPinned() {
 		t.Error("c should appear pinned")
@@ -141,8 +141,8 @@ func TestIPFSPinLs(t *testing.T) {
 	c, _ := cid.Decode(test.TestCid1)
 	c2, _ := cid.Decode(test.TestCid2)
 
-	ipfs.Pin(c)
-	ipfs.Pin(c2)
+	ipfs.Pin(c, true)
+	ipfs.Pin(c2, true)
 	ipsMap, err := ipfs.PinLs("")
 	if err != nil {
 		t.Error("should not error")
@@ -589,7 +589,7 @@ func TestRepoSize(t *testing.T) {
 	}
 
 	c, _ := cid.Decode(test.TestCid1)
-	err = ipfs.Pin(c)
+	err = ipfs.Pin(c, true)
 	if err != nil {
 		t.Error("expected success pinning cid")
 	}

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -254,7 +254,8 @@ func (rpcapi *RPCAPI) TrackerRecover(in api.PinSerial, out *api.PinInfoSerial) e
 // IPFSPin runs IPFSConnector.Pin().
 func (rpcapi *RPCAPI) IPFSPin(in api.PinSerial, out *struct{}) error {
 	c := in.ToPin().Cid
-	return rpcapi.c.ipfs.Pin(c)
+	r := in.ToPin().Recursive
+	return rpcapi.c.ipfs.Pin(c, r)
 }
 
 // IPFSUnpin runs IPFSConnector.Unpin().

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -35,6 +35,11 @@ func (rpcapi *RPCAPI) Pin(in api.PinSerial, out *struct{}) error {
 	return rpcapi.c.Pin(in.ToPin())
 }
 
+// PinTo runs Cluster.PinTo().
+func (rpcapi *RPCAPI) PinTo(in api.PinSerial, out *struct{}) error {
+	return rpcapi.c.PinTo(in.ToPin())
+}
+
 // Unpin runs Cluster.Unpin().
 func (rpcapi *RPCAPI) Unpin(in api.PinSerial, out *struct{}) error {
 	c := in.ToPin().Cid


### PR DESCRIPTION
@hsanjuan this is my first stab at incorporating priority allocations into cluster to support the sharding use case of explicitly asking cluster to pin a cid on a certain peer so that blocks aren't moving around unnecessarily.  I have held off writing tests because I have a feeling that this design may not meet your standards.  A better solution would probably re-evaluate cluster's allocation approach more generally.  I went the quickest route and modified `pin` `allocate` `obtainAllocations` and the Allocator interface which you might find too intrusive to support this small edge case.  Interested to hear your thoughts.

This PR also tracks work extending the api.types Pin object to have a Recursive field to support non-recursive pinning.  This is to support non-recursive pinning of the clusterDAG root metadata nodes on all peers.  This shouldn't be too controversial a change and a commit will follow soon finishing this off.