### PR TITLE
Fix #167: Useful messages when consensus doesn't start

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -429,15 +429,17 @@ func (c *Cluster) ready(timeout time.Duration) {
 	timer := time.NewTimer(timeout)
 	select {
 	case <-timer.C:
-		logger.Error("**************************************************")
-		logger.Error("***** ipfs-cluster consensus start timed out *****")
-		logger.Error("This peer was not able to become part of the cluster.")
-		logger.Error("This might be due to one or several causes:")
-		logger.Error(`  - Check that there is connectivity to the "bootstrap" and "peers" multiaddresses`)
-		logger.Error(`  - Check that all cluster peers are using the same "secret"`)
-		logger.Error(`  - Check that this peer is reachable on its "listen_multiaddress"`)
-		logger.Error(`  - Check that there is a majority of available peers`)
-		logger.Error("**************************************************")
+		logger.Error("***** ipfs-cluster consensus start timed out (tips below) *****")
+		logger.Error(`
+**************************************************
+This peer was not able to become part of the cluster.
+This might be due to one or several causes:
+  - Check that there is connectivity to the "bootstrap" and "peers" multiaddresses
+  - Check that all cluster peers are using the same "secret"
+  - Check that this peer is reachable on its "listen_multiaddress"
+  - Check that there is a majority of available peers
+**************************************************
+`)
 		c.Shutdown()
 		return
 	case <-c.consensus.Ready():

--- a/consensus/raft/logging.go
+++ b/consensus/raft/logging.go
@@ -63,8 +63,8 @@ func (fw *logForwarder) repeated(t int, msg string) bool {
 		fw.lastTip = make(map[int]time.Time)
 	}
 
-	// We we haven't tipped about repeated log messages
-	// in while, do it and forget the list
+	// We haven't tipped about repeated log messages
+	// in a while, do it and forget the list
 	if time.Now().After(fw.lastTip[t].Add(repeatReset)) {
 		fw.lastTip[t] = time.Now()
 		fw.lastMsgs[t] = nil

--- a/consensus/raft/logging.go
+++ b/consensus/raft/logging.go
@@ -3,6 +3,7 @@ package raft
 import (
 	"log"
 	"strings"
+	"time"
 
 	logging "github.com/ipfs/go-log"
 )
@@ -14,15 +15,14 @@ const (
 	err
 )
 
+const repeatPoolSize = 10
+const repeatReset = time.Minute
+
 // This provides a custom logger for Raft which intercepts Raft log messages
 // and rewrites us to our own logger (for "raft" facility).
 type logForwarder struct {
-	last map[int]*lastMsg
-}
-
-type lastMsg struct {
-	msg    string
-	tipped bool
+	lastMsgs map[int][]string
+	lastTip  map[int]time.Time
 }
 
 var raftStdLogger = log.New(&logForwarder{}, "", 0)
@@ -58,19 +58,38 @@ func (fw *logForwarder) Write(p []byte) (n int, e error) {
 }
 
 func (fw *logForwarder) repeated(t int, msg string) bool {
-	if fw.last == nil {
-		fw.last = make(map[int]*lastMsg)
+	if fw.lastMsgs == nil {
+		fw.lastMsgs = make(map[int][]string)
+		fw.lastTip = make(map[int]time.Time)
 	}
 
-	last, ok := fw.last[t]
-	if !ok || last.msg != msg {
-		fw.last[t] = &lastMsg{msg, false}
-		return false
+	// We we haven't tipped about repeated log messages
+	// in while, do it and forget the list
+	if time.Now().After(fw.lastTip[t].Add(repeatReset)) {
+		fw.lastTip[t] = time.Now()
+		fw.lastMsgs[t] = nil
+		fw.log(t, "NOTICE: Some RAFT log messages repeat and will only be logged once")
 	}
-	if !last.tipped {
-		fw.log(t, "NOTICE: The last RAFT log message repeats and will only be logged once")
-		last.tipped = true
+
+	var found string
+
+	// Do we know about this message
+	for _, lmsg := range fw.lastMsgs[t] {
+		if lmsg == msg {
+			found = lmsg
+			break
+		}
 	}
+
+	if found == "" { // new message. Add to slice.
+		if len(fw.lastMsgs[t]) >= repeatPoolSize { // drop oldest
+			fw.lastMsgs[t] = fw.lastMsgs[t][1:]
+		}
+		fw.lastMsgs[t] = append(fw.lastMsgs[t], msg)
+		return false // not-repeated
+	}
+
+	// repeated, don't log
 	return true
 }
 

--- a/docs/ipfs-cluster-guide.md
+++ b/docs/ipfs-cluster-guide.md
@@ -433,6 +433,8 @@ This is usually the result of a desync between the *shared state* and the *local
 Since cluster is built on top of libp2p, many errors that new users face come from libp2p and have confusing messages which are not obvious at first sight. This list compiles some of them:
 
 * `dial attempt failed: misdial to <peer.ID XXXXXX> through ....`: this means that the multiaddress you are contacting has a different peer in it than expected.
-* `dial attempt failed: context deadline exceeded`: this means that the address is not reachable.
+* `dial attempt failed: connection refused`: the peer is not running or not listening on the expected address/protocol/port.
+* `dial attempt failed: context deadline exceeded`: this means that the address is not reachable or that the wrong secret is being used.
+* `dial backoff`: same as above.
 * `dial attempt failed: incoming message was too large`: this probably means that your cluster peers are not sharing the same secret.
 * `version not supported`: this means that your nodes are running different versions of raft/cluster.


### PR DESCRIPTION
This will display a few hints when consensus fails to start.
If consensus doesn't start (normally WaitForLeader times out),
it's because of libp2p not being able to reach other peers.

I have reworked the raft-logging de-duplicator part to keep a list of last messages and not spam the logs all the time with the same things.

Before:
```
23:45:14.802  INFO    cluster: IPFS Cluster v0.3.4-c276c31a listening on: cluster.go:90
23:45:14.802  INFO    cluster:         /ip4/127.0.0.1/tcp/10096/ipfs/Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me cluster.go:95
23:45:14.802  INFO    cluster:         /ip4/192.168.123.103/tcp/10096/ipfs/Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me cluster.go:95
23:45:14.806  INFO    restapi: REST API: /ip4/127.0.0.1/tcp/10094 restapi.go:285
23:45:14.806  INFO   ipfshttp: IPFS Proxy: /ip4/127.0.0.1/tcp/10095 -> /ip4/127.0.0.1/tcp/5001 ipfshttp.go:182
23:45:16.165 ERROR       raft: Failed to make RequestVote RPC to {Voter Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd}: dial attempt failed: <peer.ID a7KpVh> --> <peer.ID b9qpF5> dial attempt failed: connection refused logging.go:86
23:45:17.789 ERROR       raft: Failed to make RequestVote RPC to {Voter Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd}: dial backoff logging.go:86
23:45:18.943 ERROR       raft: NOTICE: The last RAFT log message repeats and will only be logged once logging.go:86
23:45:22.044 ERROR       raft: Failed to make RequestVote RPC to {Voter Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd}: dial attempt failed: <peer.ID a7KpVh> --> <peer.ID b9qpF5> dial attempt failed: incoming message was too large logging.go:86
23:45:23.554 ERROR       raft: Failed to make RequestVote RPC to {Voter Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd}: dial backoff logging.go:86
23:45:24.969 ERROR       raft: NOTICE: The last RAFT log message repeats and will only be logged once logging.go:86
23:45:38.325 ERROR       raft: Failed to make RequestVote RPC to {Voter Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd}: dial attempt failed: context deadline exceeded logging.go:86
23:45:38.325 ERROR       raft: NOTICE: The last RAFT log message repeats and will only be logged once logging.go:86
23:45:39.289 ERROR       raft: Failed to make RequestVote RPC to {Voter Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd}: dial backoff logging.go:86
23:45:40.533 ERROR       raft: NOTICE: The last RAFT log message repeats and will only be logged once logging.go:86
23:45:44.806 ERROR    cluster: consensus start timed out cluster.go:432
23:45:44.806  INFO    cluster: shutting down Cluster cluster.go:496
23:45:44.806  INFO  consensus: stopping Consensus component consensus.go:159
23:45:48.764 ERROR       raft: Failed to make RequestVote RPC to {Voter Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd}: dial attempt failed: <peer.ID a7KpVh> --> <peer.ID b9qpF5> dial attempt failed: incoming message was too large logging.go:86
23:45:49.811 WARNI  consensus: timed out waiting for state updates before shutdown. Snapshotting may fail raft.go:360
23:45:49.811 ERROR       raft: Failed to take snapshot: nothing new to snapshot logging.go:86
23:45:49.811  INFO    monitor: stopping Monitor peer_monitor.go:161
23:45:49.811  INFO    restapi: stopping Cluster API restapi.go:303
23:45:49.811  INFO   ipfshttp: stopping IPFS Proxy ipfshttp.go:559
23:45:49.811  INFO pintracker: stopping MapPinTracker maptracker.go:107
23:45:49.811 ERROR    cluster: consensus is shutdown cluster.go:217

```
After:

```
23:46:40.104  INFO    cluster: IPFS Cluster v0.3.4-740f3149 listening on: cluster.go:90
23:46:40.104  INFO    cluster:         /ip4/127.0.0.1/tcp/9096/ipfs/Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd cluster.go:95
23:46:40.104  INFO    cluster:         /ip4/192.168.123.103/tcp/9096/ipfs/Qmb9qpF5JkxkJWfmoXydwjATbhBwfp2uF8yVC8BbhyXpPd cluster.go:95
23:46:40.108  INFO   ipfshttp: IPFS Proxy: /ip4/127.0.0.1/tcp/9095 -> /ip4/127.0.0.1/tcp/5001 ipfshttp.go:182
23:46:40.108  INFO    restapi: REST API: /ip4/127.0.0.1/tcp/9094 restapi.go:285
23:46:42.107 ERROR       raft: NOTICE: Some RAFT log messages repeat and will only be logged once logging.go:105
23:46:42.108 ERROR       raft: Failed to make RequestVote RPC to {Voter Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me}: dial attempt failed: <peer.ID b9qpF5> --> <peer.ID a7KpVh> dial attempt failed: received mismatch in protocol id logging.go:105
23:46:43.883 ERROR       raft: Failed to make RequestVote RPC to {Voter Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me}: dial backoff logging.go:105
23:46:58.498 ERROR       raft: Failed to make RequestVote RPC to {Voter Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me}: dial attempt failed: context deadline exceeded logging.go:105
23:47:05.369 ERROR       raft: Failed to make RequestVote RPC to {Voter Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me}: dial attempt failed: <peer.ID b9qpF5> --> <peer.ID a7KpVh> dial attempt failed: incoming message was too large logging.go:105
23:47:10.108 ERROR    cluster: ************************************************** cluster.go:432
23:47:10.108 ERROR    cluster: ***** ipfs-cluster consensus start timed out ***** cluster.go:433
23:47:10.108 ERROR    cluster: This peer was not able to become part of the cluster. cluster.go:434
23:47:10.108 ERROR    cluster: This might be due to one or several causes: cluster.go:435
23:47:10.108 ERROR    cluster:   - Check that there is connectivity to the "bootstrap" and "peers" multiaddresses cluster.go:436
23:47:10.108 ERROR    cluster:   - Check that all cluster peers are using the same "secret" cluster.go:437
23:47:10.108 ERROR    cluster:   - Check that this peer is reachable on its "listen_multiaddress" cluster.go:438
23:47:10.108 ERROR    cluster:   - Check that there is a majority of available peers cluster.go:439
23:47:10.108 ERROR    cluster: ************************************************** cluster.go:440
23:47:10.108  INFO    cluster: shutting down Cluster cluster.go:504
23:47:10.108  INFO  consensus: stopping Consensus component consensus.go:159
23:47:14.440 ERROR       raft: Failed to make RequestVote RPC to {Voter Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me Qma7KpVhrTgkdUxBanyVSffjydx9dceDXDz1K8GzspB7me}: dial attempt failed: <peer.ID b9qpF5> --> <peer.ID a7KpVh> dial attempt failed: dial tcp4 127.0.0.1:10096: getsockopt: connection refused logging.go:105
23:47:15.113 WARNI  consensus: timed out waiting for state updates before shutdown. Snapshotting may fail raft.go:360
23:47:15.113 ERROR       raft: Failed to take snapshot: nothing new to snapshot logging.go:105
23:47:15.113  INFO    monitor: stopping Monitor peer_monitor.go:161
23:47:15.113  INFO    restapi: stopping Cluster API restapi.go:303
23:47:15.113  INFO   ipfshttp: stopping IPFS Proxy ipfshttp.go:559
23:47:15.113  INFO pintracker: stopping MapPinTracker maptracker.go:107
23:47:15.113 ERROR    cluster: consensus is shutdown cluster.go:217

```