### PR TITLE
Update libp2p and deps to correct versions

### DIFF
--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -43,13 +44,13 @@ func badRPCClient(t *testing.T) *rpc.Client {
 // 	return nil
 // }
 
-func (mock *badRPCService) IPFSRepoSize(in struct{}, out *uint64) error {
+func (mock *badRPCService) IPFSRepoSize(ctx context.Context, in struct{}, out *uint64) error {
 	*out = 2
 	mock.nthCall++
 	return errors.New("fake error")
 }
 
-func (mock *badRPCService) IPFSFreeSpace(in struct{}, out *uint64) error {
+func (mock *badRPCService) IPFSFreeSpace(ctx context.Context, in struct{}, out *uint64) error {
 	*out = 2
 	mock.nthCall++
 	return errors.New("fake error")

--- a/informer/numpin/numpin_test.go
+++ b/informer/numpin/numpin_test.go
@@ -1,6 +1,7 @@
 package numpin
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ipfs/ipfs-cluster/api"
@@ -20,7 +21,7 @@ func mockRPCClient(t *testing.T) *rpc.Client {
 	return c
 }
 
-func (mock *mockService) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) error {
+func (mock *mockService) IPFSPinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
 	*out = map[string]api.IPFSPinStatus{
 		"QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa": api.IPFSPinStatusRecursive,
 		"QmUZ13osndQ5uL4tPWHXe3iBgBgq9gfewcBMSCAuMBsDJ6": api.IPFSPinStatusRecursive,

--- a/package.json
+++ b/package.json
@@ -15,21 +15,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmefgzMbKZYsmHFkLqxgaTBG9ypeEjrdWRD5WXH4j1cWDL",
+      "hash": "QmNh1kGFFdsPu79KNSaL4NUKUPb4Eiz4KHdMtFY6664RDp",
       "name": "go-libp2p",
-      "version": "5.0.5"
+      "version": "5.0.14"
     },
     {
       "author": "hsanjuan",
-      "hash": "QmSzULQiTbMnt36oxzdaUUomNuTHwXa1DvnyM8o7ogJ7Hb",
+      "hash": "QmeQA8UUz7MFqhJfEbo7MphMaSBnBcid4ByBECLcZakTtJ",
       "name": "go-libp2p-raft",
-      "version": "1.2.0"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ",
-      "name": "go-cid",
-      "version": "0.7.18"
+      "version": "1.2.2"
     },
     {
       "author": "urfave",
@@ -51,21 +45,21 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmW2qYs8uJUSAsdGrWZo1LnzAwTQjPBRKk66X9H16EABMg",
+      "hash": "QmSvGoJcmisjcXr7x47LQuC3iW8BqTjh2RaqV17MUMRXQ3",
       "name": "go-libp2p-gorpc",
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     {
       "author": "libp2p",
-      "hash": "QmcWmYQEQCrezztaQ81nXzMx2jaAEow17wdesDAjjR769r",
+      "hash": "QmenK8PgcpM2KYzEKnGx1LyN1QXawswM2F6HktCbWKuC1b",
       "name": "go-libp2p-pnet",
-      "version": "2.3.1"
+      "version": "2.3.6"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe",
+      "hash": "QmTevRdYUfixypqMWtSKDQ3hqr3QFCbfoBx6gbSxmfWoqT",
       "name": "lock",
-      "version": "0.0.0"
+      "version": "0.0.1"
     },
     {
       "author": "ZenGround0",

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -1,6 +1,7 @@
 package ipfscluster
 
 import (
+	"context"
 	"errors"
 
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -24,25 +25,25 @@ type RPCAPI struct {
 */
 
 // ID runs Cluster.ID()
-func (rpcapi *RPCAPI) ID(in struct{}, out *api.IDSerial) error {
+func (rpcapi *RPCAPI) ID(ctx context.Context, in struct{}, out *api.IDSerial) error {
 	id := rpcapi.c.ID().ToSerial()
 	*out = id
 	return nil
 }
 
 // Pin runs Cluster.Pin().
-func (rpcapi *RPCAPI) Pin(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) Pin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	return rpcapi.c.Pin(in.ToPin())
 }
 
 // Unpin runs Cluster.Unpin().
-func (rpcapi *RPCAPI) Unpin(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) Unpin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	c := in.ToPin().Cid
 	return rpcapi.c.Unpin(c)
 }
 
 // Pins runs Cluster.Pins().
-func (rpcapi *RPCAPI) Pins(in struct{}, out *[]api.PinSerial) error {
+func (rpcapi *RPCAPI) Pins(ctx context.Context, in struct{}, out *[]api.PinSerial) error {
 	cidList := rpcapi.c.Pins()
 	cidSerialList := make([]api.PinSerial, 0, len(cidList))
 	for _, c := range cidList {
@@ -53,7 +54,7 @@ func (rpcapi *RPCAPI) Pins(in struct{}, out *[]api.PinSerial) error {
 }
 
 // PinGet runs Cluster.PinGet().
-func (rpcapi *RPCAPI) PinGet(in api.PinSerial, out *api.PinSerial) error {
+func (rpcapi *RPCAPI) PinGet(ctx context.Context, in api.PinSerial, out *api.PinSerial) error {
 	cidarg := in.ToPin()
 	pin, err := rpcapi.c.PinGet(cidarg.Cid)
 	if err == nil {
@@ -63,7 +64,7 @@ func (rpcapi *RPCAPI) PinGet(in api.PinSerial, out *api.PinSerial) error {
 }
 
 // Version runs Cluster.Version().
-func (rpcapi *RPCAPI) Version(in struct{}, out *api.Version) error {
+func (rpcapi *RPCAPI) Version(ctx context.Context, in struct{}, out *api.Version) error {
 	*out = api.Version{
 		Version: rpcapi.c.Version(),
 	}
@@ -71,7 +72,7 @@ func (rpcapi *RPCAPI) Version(in struct{}, out *api.Version) error {
 }
 
 // Peers runs Cluster.Peers().
-func (rpcapi *RPCAPI) Peers(in struct{}, out *[]api.IDSerial) error {
+func (rpcapi *RPCAPI) Peers(ctx context.Context, in struct{}, out *[]api.IDSerial) error {
 	peers := rpcapi.c.Peers()
 	var sPeers []api.IDSerial
 	for _, p := range peers {
@@ -82,7 +83,7 @@ func (rpcapi *RPCAPI) Peers(in struct{}, out *[]api.IDSerial) error {
 }
 
 // PeerAdd runs Cluster.PeerAdd().
-func (rpcapi *RPCAPI) PeerAdd(in api.MultiaddrSerial, out *api.IDSerial) error {
+func (rpcapi *RPCAPI) PeerAdd(ctx context.Context, in api.MultiaddrSerial, out *api.IDSerial) error {
 	addr := in.ToMultiaddr()
 	id, err := rpcapi.c.PeerAdd(addr)
 	*out = id.ToSerial()
@@ -90,40 +91,40 @@ func (rpcapi *RPCAPI) PeerAdd(in api.MultiaddrSerial, out *api.IDSerial) error {
 }
 
 // ConnectGraph runs Cluster.GetConnectGraph().
-func (rpcapi *RPCAPI) ConnectGraph(in struct{}, out *api.ConnectGraphSerial) error {
+func (rpcapi *RPCAPI) ConnectGraph(ctx context.Context, in struct{}, out *api.ConnectGraphSerial) error {
 	graph, err := rpcapi.c.ConnectGraph()
 	*out = graph.ToSerial()
 	return err
 }
 
 // PeerRemove runs Cluster.PeerRm().
-func (rpcapi *RPCAPI) PeerRemove(in peer.ID, out *struct{}) error {
+func (rpcapi *RPCAPI) PeerRemove(ctx context.Context, in peer.ID, out *struct{}) error {
 	return rpcapi.c.PeerRemove(in)
 }
 
 // Join runs Cluster.Join().
-func (rpcapi *RPCAPI) Join(in api.MultiaddrSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) Join(ctx context.Context, in api.MultiaddrSerial, out *struct{}) error {
 	addr := in.ToMultiaddr()
 	err := rpcapi.c.Join(addr)
 	return err
 }
 
 // StatusAll runs Cluster.StatusAll().
-func (rpcapi *RPCAPI) StatusAll(in struct{}, out *[]api.GlobalPinInfoSerial) error {
+func (rpcapi *RPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]api.GlobalPinInfoSerial) error {
 	pinfos, err := rpcapi.c.StatusAll()
 	*out = globalPinInfoSliceToSerial(pinfos)
 	return err
 }
 
 // StatusAllLocal runs Cluster.StatusAllLocal().
-func (rpcapi *RPCAPI) StatusAllLocal(in struct{}, out *[]api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) StatusAllLocal(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	pinfos := rpcapi.c.StatusAllLocal()
 	*out = pinInfoSliceToSerial(pinfos)
 	return nil
 }
 
 // Status runs Cluster.Status().
-func (rpcapi *RPCAPI) Status(in api.PinSerial, out *api.GlobalPinInfoSerial) error {
+func (rpcapi *RPCAPI) Status(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo, err := rpcapi.c.Status(c)
 	*out = pinfo.ToSerial()
@@ -131,7 +132,7 @@ func (rpcapi *RPCAPI) Status(in api.PinSerial, out *api.GlobalPinInfoSerial) err
 }
 
 // StatusLocal runs Cluster.StatusLocal().
-func (rpcapi *RPCAPI) StatusLocal(in api.PinSerial, out *api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) StatusLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo := rpcapi.c.StatusLocal(c)
 	*out = pinfo.ToSerial()
@@ -139,21 +140,21 @@ func (rpcapi *RPCAPI) StatusLocal(in api.PinSerial, out *api.PinInfoSerial) erro
 }
 
 // SyncAll runs Cluster.SyncAll().
-func (rpcapi *RPCAPI) SyncAll(in struct{}, out *[]api.GlobalPinInfoSerial) error {
+func (rpcapi *RPCAPI) SyncAll(ctx context.Context, in struct{}, out *[]api.GlobalPinInfoSerial) error {
 	pinfos, err := rpcapi.c.SyncAll()
 	*out = globalPinInfoSliceToSerial(pinfos)
 	return err
 }
 
 // SyncAllLocal runs Cluster.SyncAllLocal().
-func (rpcapi *RPCAPI) SyncAllLocal(in struct{}, out *[]api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) SyncAllLocal(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	pinfos, err := rpcapi.c.SyncAllLocal()
 	*out = pinInfoSliceToSerial(pinfos)
 	return err
 }
 
 // Sync runs Cluster.Sync().
-func (rpcapi *RPCAPI) Sync(in api.PinSerial, out *api.GlobalPinInfoSerial) error {
+func (rpcapi *RPCAPI) Sync(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo, err := rpcapi.c.Sync(c)
 	*out = pinfo.ToSerial()
@@ -161,7 +162,7 @@ func (rpcapi *RPCAPI) Sync(in api.PinSerial, out *api.GlobalPinInfoSerial) error
 }
 
 // SyncLocal runs Cluster.SyncLocal().
-func (rpcapi *RPCAPI) SyncLocal(in api.PinSerial, out *api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) SyncLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo, err := rpcapi.c.SyncLocal(c)
 	*out = pinfo.ToSerial()
@@ -169,14 +170,14 @@ func (rpcapi *RPCAPI) SyncLocal(in api.PinSerial, out *api.PinInfoSerial) error 
 }
 
 // RecoverAllLocal runs Cluster.RecoverAllLocal().
-func (rpcapi *RPCAPI) RecoverAllLocal(in struct{}, out *[]api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) RecoverAllLocal(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	pinfos, err := rpcapi.c.RecoverAllLocal()
 	*out = pinInfoSliceToSerial(pinfos)
 	return err
 }
 
 // Recover runs Cluster.Recover().
-func (rpcapi *RPCAPI) Recover(in api.PinSerial, out *api.GlobalPinInfoSerial) error {
+func (rpcapi *RPCAPI) Recover(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo, err := rpcapi.c.Recover(c)
 	*out = pinfo.ToSerial()
@@ -184,7 +185,7 @@ func (rpcapi *RPCAPI) Recover(in api.PinSerial, out *api.GlobalPinInfoSerial) er
 }
 
 // RecoverLocal runs Cluster.RecoverLocal().
-func (rpcapi *RPCAPI) RecoverLocal(in api.PinSerial, out *api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) RecoverLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo, err := rpcapi.c.RecoverLocal(c)
 	*out = pinfo.ToSerial()
@@ -192,7 +193,7 @@ func (rpcapi *RPCAPI) RecoverLocal(in api.PinSerial, out *api.PinInfoSerial) err
 }
 
 // StateSync runs Cluster.StateSync().
-func (rpcapi *RPCAPI) StateSync(in struct{}, out *[]api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) StateSync(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	pinfos, err := rpcapi.c.StateSync()
 	*out = pinInfoSliceToSerial(pinfos)
 	return err
@@ -203,24 +204,24 @@ func (rpcapi *RPCAPI) StateSync(in struct{}, out *[]api.PinInfoSerial) error {
 */
 
 // Track runs PinTracker.Track().
-func (rpcapi *RPCAPI) Track(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) Track(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	return rpcapi.c.tracker.Track(in.ToPin())
 }
 
 // Untrack runs PinTracker.Untrack().
-func (rpcapi *RPCAPI) Untrack(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) Untrack(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	c := in.ToPin().Cid
 	return rpcapi.c.tracker.Untrack(c)
 }
 
 // TrackerStatusAll runs PinTracker.StatusAll().
-func (rpcapi *RPCAPI) TrackerStatusAll(in struct{}, out *[]api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) TrackerStatusAll(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	*out = pinInfoSliceToSerial(rpcapi.c.tracker.StatusAll())
 	return nil
 }
 
 // TrackerStatus runs PinTracker.Status().
-func (rpcapi *RPCAPI) TrackerStatus(in api.PinSerial, out *api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) TrackerStatus(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo := rpcapi.c.tracker.Status(c)
 	*out = pinfo.ToSerial()
@@ -228,14 +229,14 @@ func (rpcapi *RPCAPI) TrackerStatus(in api.PinSerial, out *api.PinInfoSerial) er
 }
 
 // TrackerRecoverAll runs PinTracker.RecoverAll().
-func (rpcapi *RPCAPI) TrackerRecoverAll(in struct{}, out *[]api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) TrackerRecoverAll(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	pinfos, err := rpcapi.c.tracker.RecoverAll()
 	*out = pinInfoSliceToSerial(pinfos)
 	return err
 }
 
 // TrackerRecover runs PinTracker.Recover().
-func (rpcapi *RPCAPI) TrackerRecover(in api.PinSerial, out *api.PinInfoSerial) error {
+func (rpcapi *RPCAPI) TrackerRecover(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
 	c := in.ToPin().Cid
 	pinfo, err := rpcapi.c.tracker.Recover(c)
 	*out = pinfo.ToSerial()
@@ -247,20 +248,20 @@ func (rpcapi *RPCAPI) TrackerRecover(in api.PinSerial, out *api.PinInfoSerial) e
 */
 
 // IPFSPin runs IPFSConnector.Pin().
-func (rpcapi *RPCAPI) IPFSPin(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) IPFSPin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	c := in.ToPin().Cid
 	r := in.ToPin().Recursive
 	return rpcapi.c.ipfs.Pin(c, r)
 }
 
 // IPFSUnpin runs IPFSConnector.Unpin().
-func (rpcapi *RPCAPI) IPFSUnpin(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) IPFSUnpin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	c := in.ToPin().Cid
 	return rpcapi.c.ipfs.Unpin(c)
 }
 
 // IPFSPinLsCid runs IPFSConnector.PinLsCid().
-func (rpcapi *RPCAPI) IPFSPinLsCid(in api.PinSerial, out *api.IPFSPinStatus) error {
+func (rpcapi *RPCAPI) IPFSPinLsCid(ctx context.Context, in api.PinSerial, out *api.IPFSPinStatus) error {
 	c := in.ToPin().Cid
 	b, err := rpcapi.c.ipfs.PinLsCid(c)
 	*out = b
@@ -268,41 +269,41 @@ func (rpcapi *RPCAPI) IPFSPinLsCid(in api.PinSerial, out *api.IPFSPinStatus) err
 }
 
 // IPFSPinLs runs IPFSConnector.PinLs().
-func (rpcapi *RPCAPI) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) error {
+func (rpcapi *RPCAPI) IPFSPinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
 	m, err := rpcapi.c.ipfs.PinLs(in)
 	*out = m
 	return err
 }
 
 // IPFSConnectSwarms runs IPFSConnector.ConnectSwarms().
-func (rpcapi *RPCAPI) IPFSConnectSwarms(in struct{}, out *struct{}) error {
+func (rpcapi *RPCAPI) IPFSConnectSwarms(ctx context.Context, in struct{}, out *struct{}) error {
 	err := rpcapi.c.ipfs.ConnectSwarms()
 	return err
 }
 
 // IPFSConfigKey runs IPFSConnector.ConfigKey().
-func (rpcapi *RPCAPI) IPFSConfigKey(in string, out *interface{}) error {
+func (rpcapi *RPCAPI) IPFSConfigKey(ctx context.Context, in string, out *interface{}) error {
 	res, err := rpcapi.c.ipfs.ConfigKey(in)
 	*out = res
 	return err
 }
 
 // IPFSFreeSpace runs IPFSConnector.FreeSpace().
-func (rpcapi *RPCAPI) IPFSFreeSpace(in struct{}, out *uint64) error {
+func (rpcapi *RPCAPI) IPFSFreeSpace(ctx context.Context, in struct{}, out *uint64) error {
 	res, err := rpcapi.c.ipfs.FreeSpace()
 	*out = res
 	return err
 }
 
 // IPFSRepoSize runs IPFSConnector.RepoSize().
-func (rpcapi *RPCAPI) IPFSRepoSize(in struct{}, out *uint64) error {
+func (rpcapi *RPCAPI) IPFSRepoSize(ctx context.Context, in struct{}, out *uint64) error {
 	res, err := rpcapi.c.ipfs.RepoSize()
 	*out = res
 	return err
 }
 
 // IPFSSwarmPeers runs IPFSConnector.SwarmPeers().
-func (rpcapi *RPCAPI) IPFSSwarmPeers(in struct{}, out *api.SwarmPeersSerial) error {
+func (rpcapi *RPCAPI) IPFSSwarmPeers(ctx context.Context, in struct{}, out *api.SwarmPeersSerial) error {
 	res, err := rpcapi.c.ipfs.SwarmPeers()
 	*out = res.ToSerial()
 	return err
@@ -313,29 +314,29 @@ func (rpcapi *RPCAPI) IPFSSwarmPeers(in struct{}, out *api.SwarmPeersSerial) err
 */
 
 // ConsensusLogPin runs Consensus.LogPin().
-func (rpcapi *RPCAPI) ConsensusLogPin(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) ConsensusLogPin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	c := in.ToPin()
 	return rpcapi.c.consensus.LogPin(c)
 }
 
 // ConsensusLogUnpin runs Consensus.LogUnpin().
-func (rpcapi *RPCAPI) ConsensusLogUnpin(in api.PinSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) ConsensusLogUnpin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	c := in.ToPin()
 	return rpcapi.c.consensus.LogUnpin(c)
 }
 
 // ConsensusAddPeer runs Consensus.AddPeer().
-func (rpcapi *RPCAPI) ConsensusAddPeer(in peer.ID, out *struct{}) error {
+func (rpcapi *RPCAPI) ConsensusAddPeer(ctx context.Context, in peer.ID, out *struct{}) error {
 	return rpcapi.c.consensus.AddPeer(in)
 }
 
 // ConsensusRmPeer runs Consensus.RmPeer().
-func (rpcapi *RPCAPI) ConsensusRmPeer(in peer.ID, out *struct{}) error {
+func (rpcapi *RPCAPI) ConsensusRmPeer(ctx context.Context, in peer.ID, out *struct{}) error {
 	return rpcapi.c.consensus.RmPeer(in)
 }
 
 // ConsensusPeers runs Consensus.Peers().
-func (rpcapi *RPCAPI) ConsensusPeers(in struct{}, out *[]peer.ID) error {
+func (rpcapi *RPCAPI) ConsensusPeers(ctx context.Context, in struct{}, out *[]peer.ID) error {
 	peers, err := rpcapi.c.consensus.Peers()
 	*out = peers
 	return err
@@ -346,14 +347,14 @@ func (rpcapi *RPCAPI) ConsensusPeers(in struct{}, out *[]peer.ID) error {
 */
 
 // PeerManagerAddPeer runs peerManager.addPeer().
-func (rpcapi *RPCAPI) PeerManagerAddPeer(in api.MultiaddrSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) PeerManagerAddPeer(ctx context.Context, in api.MultiaddrSerial, out *struct{}) error {
 	addr := in.ToMultiaddr()
 	err := rpcapi.c.peerManager.addPeer(addr, false)
 	return err
 }
 
 // PeerManagerImportAddresses runs peerManager.importAddresses().
-func (rpcapi *RPCAPI) PeerManagerImportAddresses(in api.MultiaddrsSerial, out *struct{}) error {
+func (rpcapi *RPCAPI) PeerManagerImportAddresses(ctx context.Context, in api.MultiaddrsSerial, out *struct{}) error {
 	addrs := in.ToMultiaddrs()
 	err := rpcapi.c.peerManager.importAddresses(addrs, false)
 	return err
@@ -364,13 +365,13 @@ func (rpcapi *RPCAPI) PeerManagerImportAddresses(in api.MultiaddrsSerial, out *s
 */
 
 // PeerMonitorLogMetric runs PeerMonitor.LogMetric().
-func (rpcapi *RPCAPI) PeerMonitorLogMetric(in api.Metric, out *struct{}) error {
+func (rpcapi *RPCAPI) PeerMonitorLogMetric(ctx context.Context, in api.Metric, out *struct{}) error {
 	rpcapi.c.monitor.LogMetric(in)
 	return nil
 }
 
 // PeerMonitorLastMetrics runs PeerMonitor.LastMetrics().
-func (rpcapi *RPCAPI) PeerMonitorLastMetrics(in string, out *[]api.Metric) error {
+func (rpcapi *RPCAPI) PeerMonitorLastMetrics(ctx context.Context, in string, out *[]api.Metric) error {
 	*out = rpcapi.c.monitor.LastMetrics(in)
 	return nil
 }
@@ -383,7 +384,7 @@ func (rpcapi *RPCAPI) PeerMonitorLastMetrics(in string, out *[]api.Metric) error
 // This is necessary for a peer to figure out which of its multiaddresses the
 // peers are seeing (also when crossing NATs). It should be called from
 // the peer the IN parameter indicates.
-func (rpcapi *RPCAPI) RemoteMultiaddrForPeer(in peer.ID, out *api.MultiaddrSerial) error {
+func (rpcapi *RPCAPI) RemoteMultiaddrForPeer(ctx context.Context, in peer.ID, out *api.MultiaddrSerial) error {
 	conns := rpcapi.c.host.Network().ConnsToPeer(in)
 	if len(conns) == 0 {
 		return errors.New("no connections to: " + in.Pretty())

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -37,21 +38,21 @@ func NewMockRPCClientWithHost(t *testing.T, h host.Host) *rpc.Client {
 	return c
 }
 
-func (mock *mockService) Pin(in api.PinSerial, out *struct{}) error {
+func (mock *mockService) Pin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	if in.Cid == ErrorCid {
 		return ErrBadCid
 	}
 	return nil
 }
 
-func (mock *mockService) Unpin(in api.PinSerial, out *struct{}) error {
+func (mock *mockService) Unpin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	if in.Cid == ErrorCid {
 		return ErrBadCid
 	}
 	return nil
 }
 
-func (mock *mockService) Pins(in struct{}, out *[]api.PinSerial) error {
+func (mock *mockService) Pins(ctx context.Context, in struct{}, out *[]api.PinSerial) error {
 	*out = []api.PinSerial{
 		{
 			Cid: TestCid1,
@@ -66,7 +67,7 @@ func (mock *mockService) Pins(in struct{}, out *[]api.PinSerial) error {
 	return nil
 }
 
-func (mock *mockService) PinGet(in api.PinSerial, out *api.PinSerial) error {
+func (mock *mockService) PinGet(ctx context.Context, in api.PinSerial, out *api.PinSerial) error {
 	if in.Cid == ErrorCid {
 		return errors.New("expected error when using ErrorCid")
 	}
@@ -74,7 +75,7 @@ func (mock *mockService) PinGet(in api.PinSerial, out *api.PinSerial) error {
 	return nil
 }
 
-func (mock *mockService) ID(in struct{}, out *api.IDSerial) error {
+func (mock *mockService) ID(ctx context.Context, in struct{}, out *api.IDSerial) error {
 	//_, pubkey, _ := crypto.GenerateKeyPair(
 	//	DefaultConfigCrypto,
 	//	DefaultConfigKeyLength)
@@ -92,33 +93,33 @@ func (mock *mockService) ID(in struct{}, out *api.IDSerial) error {
 	return nil
 }
 
-func (mock *mockService) Version(in struct{}, out *api.Version) error {
+func (mock *mockService) Version(ctx context.Context, in struct{}, out *api.Version) error {
 	*out = api.Version{
 		Version: "0.0.mock",
 	}
 	return nil
 }
 
-func (mock *mockService) Peers(in struct{}, out *[]api.IDSerial) error {
+func (mock *mockService) Peers(ctx context.Context, in struct{}, out *[]api.IDSerial) error {
 	id := api.IDSerial{}
-	mock.ID(in, &id)
+	mock.ID(ctx, in, &id)
 
 	*out = []api.IDSerial{id}
 	return nil
 }
 
-func (mock *mockService) PeerAdd(in api.MultiaddrSerial, out *api.IDSerial) error {
+func (mock *mockService) PeerAdd(ctx context.Context, in api.MultiaddrSerial, out *api.IDSerial) error {
 	id := api.IDSerial{}
-	mock.ID(struct{}{}, &id)
+	mock.ID(ctx, struct{}{}, &id)
 	*out = id
 	return nil
 }
 
-func (mock *mockService) PeerRemove(in peer.ID, out *struct{}) error {
+func (mock *mockService) PeerRemove(ctx context.Context, in peer.ID, out *struct{}) error {
 	return nil
 }
 
-func (mock *mockService) ConnectGraph(in struct{}, out *api.ConnectGraphSerial) error {
+func (mock *mockService) ConnectGraph(ctx context.Context, in struct{}, out *api.ConnectGraphSerial) error {
 	*out = api.ConnectGraphSerial{
 		ClusterID: TestPeerID1.Pretty(),
 		IPFSLinks: map[string][]string{
@@ -140,7 +141,7 @@ func (mock *mockService) ConnectGraph(in struct{}, out *api.ConnectGraphSerial) 
 	return nil
 }
 
-func (mock *mockService) StatusAll(in struct{}, out *[]api.GlobalPinInfoSerial) error {
+func (mock *mockService) StatusAll(ctx context.Context, in struct{}, out *[]api.GlobalPinInfoSerial) error {
 	c1, _ := cid.Decode(TestCid1)
 	c2, _ := cid.Decode(TestCid2)
 	c3, _ := cid.Decode(TestCid3)
@@ -182,11 +183,11 @@ func (mock *mockService) StatusAll(in struct{}, out *[]api.GlobalPinInfoSerial) 
 	return nil
 }
 
-func (mock *mockService) StatusAllLocal(in struct{}, out *[]api.PinInfoSerial) error {
-	return mock.TrackerStatusAll(in, out)
+func (mock *mockService) StatusAllLocal(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
+	return mock.TrackerStatusAll(ctx, in, out)
 }
 
-func (mock *mockService) Status(in api.PinSerial, out *api.GlobalPinInfoSerial) error {
+func (mock *mockService) Status(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
 	if in.Cid == ErrorCid {
 		return ErrBadCid
 	}
@@ -205,54 +206,54 @@ func (mock *mockService) Status(in api.PinSerial, out *api.GlobalPinInfoSerial) 
 	return nil
 }
 
-func (mock *mockService) StatusLocal(in api.PinSerial, out *api.PinInfoSerial) error {
-	return mock.TrackerStatus(in, out)
+func (mock *mockService) StatusLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
+	return mock.TrackerStatus(ctx, in, out)
 }
 
-func (mock *mockService) SyncAll(in struct{}, out *[]api.GlobalPinInfoSerial) error {
-	return mock.StatusAll(in, out)
+func (mock *mockService) SyncAll(ctx context.Context, in struct{}, out *[]api.GlobalPinInfoSerial) error {
+	return mock.StatusAll(ctx, in, out)
 }
 
-func (mock *mockService) SyncAllLocal(in struct{}, out *[]api.PinInfoSerial) error {
-	return mock.StatusAllLocal(in, out)
+func (mock *mockService) SyncAllLocal(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
+	return mock.StatusAllLocal(ctx, in, out)
 }
 
-func (mock *mockService) Sync(in api.PinSerial, out *api.GlobalPinInfoSerial) error {
-	return mock.Status(in, out)
+func (mock *mockService) Sync(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
+	return mock.Status(ctx, in, out)
 }
 
-func (mock *mockService) SyncLocal(in api.PinSerial, out *api.PinInfoSerial) error {
-	return mock.StatusLocal(in, out)
+func (mock *mockService) SyncLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
+	return mock.StatusLocal(ctx, in, out)
 }
 
-func (mock *mockService) StateSync(in struct{}, out *[]api.PinInfoSerial) error {
+func (mock *mockService) StateSync(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	*out = make([]api.PinInfoSerial, 0, 0)
 	return nil
 }
 
-func (mock *mockService) RecoverAllLocal(in struct{}, out *[]api.PinInfoSerial) error {
-	return mock.TrackerRecoverAll(in, out)
+func (mock *mockService) RecoverAllLocal(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
+	return mock.TrackerRecoverAll(ctx, in, out)
 }
 
-func (mock *mockService) Recover(in api.PinSerial, out *api.GlobalPinInfoSerial) error {
-	return mock.Status(in, out)
+func (mock *mockService) Recover(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
+	return mock.Status(ctx, in, out)
 }
 
-func (mock *mockService) RecoverLocal(in api.PinSerial, out *api.PinInfoSerial) error {
-	return mock.TrackerRecover(in, out)
+func (mock *mockService) RecoverLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
+	return mock.TrackerRecover(ctx, in, out)
 }
 
 /* Tracker methods */
 
-func (mock *mockService) Track(in api.PinSerial, out *struct{}) error {
+func (mock *mockService) Track(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	return nil
 }
 
-func (mock *mockService) Untrack(in api.PinSerial, out *struct{}) error {
+func (mock *mockService) Untrack(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	return nil
 }
 
-func (mock *mockService) TrackerStatusAll(in struct{}, out *[]api.PinInfoSerial) error {
+func (mock *mockService) TrackerStatusAll(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	c1, _ := cid.Decode(TestCid1)
 	c3, _ := cid.Decode(TestCid3)
 
@@ -273,7 +274,7 @@ func (mock *mockService) TrackerStatusAll(in struct{}, out *[]api.PinInfoSerial)
 	return nil
 }
 
-func (mock *mockService) TrackerStatus(in api.PinSerial, out *api.PinInfoSerial) error {
+func (mock *mockService) TrackerStatus(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
 	if in.Cid == ErrorCid {
 		return ErrBadCid
 	}
@@ -288,12 +289,12 @@ func (mock *mockService) TrackerStatus(in api.PinSerial, out *api.PinInfoSerial)
 	return nil
 }
 
-func (mock *mockService) TrackerRecoverAll(in struct{}, out *[]api.PinInfoSerial) error {
+func (mock *mockService) TrackerRecoverAll(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	*out = make([]api.PinInfoSerial, 0, 0)
 	return nil
 }
 
-func (mock *mockService) TrackerRecover(in api.PinSerial, out *api.PinInfoSerial) error {
+func (mock *mockService) TrackerRecover(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
 	in2 := in.ToPin()
 	*out = api.PinInfo{
 		Cid:    in2.Cid,
@@ -306,21 +307,21 @@ func (mock *mockService) TrackerRecover(in api.PinSerial, out *api.PinInfoSerial
 
 /* PeerManager methods */
 
-func (mock *mockService) PeerManagerAddPeer(in api.MultiaddrSerial, out *struct{}) error {
+func (mock *mockService) PeerManagerAddPeer(ctx context.Context, in api.MultiaddrSerial, out *struct{}) error {
 	return nil
 }
 
 /* IPFSConnector methods */
 
-func (mock *mockService) IPFSPin(in api.PinSerial, out *struct{}) error {
+func (mock *mockService) IPFSPin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	return nil
 }
 
-func (mock *mockService) IPFSUnpin(in api.PinSerial, out *struct{}) error {
+func (mock *mockService) IPFSUnpin(ctx context.Context, in api.PinSerial, out *struct{}) error {
 	return nil
 }
 
-func (mock *mockService) IPFSPinLsCid(in api.PinSerial, out *api.IPFSPinStatus) error {
+func (mock *mockService) IPFSPinLsCid(ctx context.Context, in api.PinSerial, out *api.IPFSPinStatus) error {
 	if in.Cid == TestCid1 || in.Cid == TestCid3 {
 		*out = api.IPFSPinStatusRecursive
 	} else {
@@ -329,7 +330,7 @@ func (mock *mockService) IPFSPinLsCid(in api.PinSerial, out *api.IPFSPinStatus) 
 	return nil
 }
 
-func (mock *mockService) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus) error {
+func (mock *mockService) IPFSPinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
 	m := map[string]api.IPFSPinStatus{
 		TestCid1: api.IPFSPinStatusRecursive,
 		TestCid3: api.IPFSPinStatusRecursive,
@@ -338,16 +339,16 @@ func (mock *mockService) IPFSPinLs(in string, out *map[string]api.IPFSPinStatus)
 	return nil
 }
 
-func (mock *mockService) IPFSConnectSwarms(in struct{}, out *struct{}) error {
+func (mock *mockService) IPFSConnectSwarms(ctx context.Context, in struct{}, out *struct{}) error {
 	return nil
 }
 
-func (mock *mockService) IPFSSwarmPeers(in struct{}, out *api.SwarmPeersSerial) error {
+func (mock *mockService) IPFSSwarmPeers(ctx context.Context, in struct{}, out *api.SwarmPeersSerial) error {
 	*out = []string{TestPeerID2.Pretty(), TestPeerID3.Pretty()}
 	return nil
 }
 
-func (mock *mockService) IPFSConfigKey(in string, out *interface{}) error {
+func (mock *mockService) IPFSConfigKey(ctx context.Context, in string, out *interface{}) error {
 	switch in {
 	case "Datastore/StorageMax":
 		*out = "100KB"
@@ -357,27 +358,27 @@ func (mock *mockService) IPFSConfigKey(in string, out *interface{}) error {
 	return nil
 }
 
-func (mock *mockService) IPFSRepoSize(in struct{}, out *uint64) error {
+func (mock *mockService) IPFSRepoSize(ctx context.Context, in struct{}, out *uint64) error {
 	// since we have two pins. Assume each is 1KB.
 	*out = 2000
 	return nil
 }
 
-func (mock *mockService) IPFSFreeSpace(in struct{}, out *uint64) error {
+func (mock *mockService) IPFSFreeSpace(ctx context.Context, in struct{}, out *uint64) error {
 	// RepoSize is 2KB, StorageMax is 100KB
 	*out = 98000
 	return nil
 }
 
-func (mock *mockService) ConsensusAddPeer(in peer.ID, out *struct{}) error {
+func (mock *mockService) ConsensusAddPeer(ctx context.Context, in peer.ID, out *struct{}) error {
 	return errors.New("mock rpc cannot redirect")
 }
 
-func (mock *mockService) ConsensusRmPeer(in peer.ID, out *struct{}) error {
+func (mock *mockService) ConsensusRmPeer(ctx context.Context, in peer.ID, out *struct{}) error {
 	return errors.New("mock rpc cannot redirect")
 }
 
-func (mock *mockService) ConsensusPeers(in struct{}, out *[]peer.ID) error {
+func (mock *mockService) ConsensusPeers(ctx context.Context, in struct{}, out *[]peer.ID) error {
 	*out = []peer.ID{TestPeerID1, TestPeerID2, TestPeerID3}
 	return nil
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -39,11 +39,11 @@ func TestRPCMockValid(t *testing.T) {
 			t.Errorf("%s out param should be an error", name)
 		}
 
-		if nin := mType.NumIn(); nin != oType.NumIn() || nin != 3 {
-			t.Errorf("%s: num in parameter mismatch: %d vs. %d", name, nin, oType.NumIn())
+		if nin := mType.NumIn(); nin != oType.NumIn() || nin != 4 {
+			t.Fatalf("%s: num in parameter mismatch: %d vs. %d", name, nin, oType.NumIn())
 		}
 
-		for j := 1; j < 3; j++ {
+		for j := 1; j < 4; j++ {
 			mn := mType.In(j).String()
 			on := oType.In(j).String()
 			if mn != on {


### PR DESCRIPTION
Bubble up libp2p 5.0.14 across all deps.

@ZenGround0 this should be what ipfs uses right now so it shoud be OK with your sharding rebase.

Note: contexts introduced but simply ignored. Will start not ignoring them in other PRs. Here it was just a side effect.