### PR TITLE
rest/client: Add WaitFor utility function

### DIFF
--- a/sharness/t0030-ctl-pin.sh
+++ b/sharness/t0030-ctl-pin.sh
@@ -21,6 +21,34 @@ test_expect_success IPFS,CLUSTER "unpin data from cluster with ctl" '
     ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
 '
 
+test_expect_success IPFS,CLUSTER "wait for data to pin to cluster with ctl" '
+    cid=`docker exec ipfs sh -c "dd if=/dev/urandom bs=1024 count=2048 | ipfs add -q"`
+    ipfs-cluster-ctl pin add --wait "$cid" | grep -q -i "PINNED" &&
+    ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
+    ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED"
+'
+
+test_expect_success IPFS,CLUSTER "wait for data to unpin from cluster with ctl" '
+    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".[] | .cid" | head -1`
+    ipfs-cluster-ctl pin rm --wait "$cid" | grep -q -i "UNPINNED" &&
+    !(ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid") &&
+    ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
+'
+
+test_expect_success IPFS,CLUSTER "wait for data to pin to cluster with ctl with timeout" '
+    cid=`docker exec ipfs sh -c "dd if=/dev/urandom bs=1024 count=2048 | ipfs add -q"`
+    ipfs-cluster-ctl pin add --wait --wait-timeout 2s "$cid" | grep -q -i "PINNED" &&
+    ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
+    ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED"
+'
+
+test_expect_success IPFS,CLUSTER "wait for data to unpin from cluster with ctl with timeout" '
+    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".[] | .cid" | head -1`
+    ipfs-cluster-ctl pin rm --wait --wait-timeout 2s "$cid" | grep -q -i "UNPINNED" &&
+    !(ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid") &&
+    ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
+'
+
 test_clean_ipfs
 test_clean_cluster
 


### PR DESCRIPTION
Putting this up early, as there are a few things I am unsure about.

1) api/rest/client/methods.go:193
```diff
+				// TODO(ajl): check I can override api.TrackerStatusBug here for
+				// error reporting purposes or return an error chan,
+				// not sure which is the best option.
+				statusCh <- api.TrackerStatusBug
```

2) The use of `goto` to simplify the for loop wait logic. See api/rest/client/methods.go:201 and api/rest/client/methods.go:207.

3) The `pin` test works but not in current configuration combined with the `unpin` test. 

Thoughts and suggestions would be greatly appreciated 👍 