### PR TITLE
State change for sharding support

### DIFF
--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -77,9 +77,9 @@ func (c *Client) Unpin(ci *cid.Cid) error {
 
 // Allocations returns the consensus state listing all tracked items and
 // the peers that should be pinning them.
-func (c *Client) Allocations() ([]api.Pin, error) {
+func (c *Client) Allocations(pinType api.PinType) ([]api.Pin, error) {
 	var pins []api.PinSerial
-	err := c.do("GET", "/allocations", nil, &pins)
+	err := c.do("GET", fmt.Sprintf("/allocations?pintype=%s", pinType.String()), nil, &pins)
 	result := make([]api.Pin, len(pins))
 	for i, p := range pins {
 		result[i] = p.ToPin()

--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
+	types "github.com/ipfs/ipfs-cluster/api"
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ipfs/ipfs-cluster/test"
@@ -108,7 +109,7 @@ func TestAllocations(t *testing.T) {
 	c, api := testClient(t)
 	defer api.Shutdown()
 
-	pins, err := c.Allocations()
+	pins, err := c.Allocations(types.PinType(types.AllType))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -646,13 +646,33 @@ func (api *API) unpinHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// filterOutPin returns true if the given pin should be filtered out according
+// to the input filter type
+func (api *API) filterOutPin(filter types.PinType, pin types.Pin) bool {
+	if filter == types.AllType {
+		return false
+	}
+	return pin.Type != filter
+}
+
 func (api *API) allocationsHandler(w http.ResponseWriter, r *http.Request) {
+	queryValues := r.URL.Query()
+	pintype := queryValues.Get("pintype")
+	filter := types.PinTypeFromString(pintype)
 	var pins []types.PinSerial
-	err := api.rpcClient.Call("",
+	err := api.rpcClient.Call(
+		"",
 		"Cluster",
 		"Pins",
 		struct{}{},
-		&pins)
+		&pins,
+	)
+	for i, pinS := range pins {
+		if api.filterOutPin(filter, pinS.ToPin()) {
+			// remove this pin from output
+			pins = append(pins[:i], pins[i+1:]...)
+		}
+	}
 	sendResponse(w, err, pins)
 }
 
@@ -820,7 +840,8 @@ func parseCidOrError(w http.ResponseWriter, r *http.Request) types.PinSerial {
 	}
 
 	pin := types.PinSerial{
-		Cid: hash,
+		Cid:  hash,
+		Type: types.DataType,
 	}
 
 	queryValues := r.URL.Query()

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -226,7 +226,7 @@ func TestAPIAllocationsEndpoint(t *testing.T) {
 	defer rest.Shutdown()
 
 	var resp []api.PinSerial
-	makeGet(t, apiURL(rest)+"/allocations", &resp)
+	makeGet(t, apiURL(rest)+"/allocations?a=false", &resp)
 	if len(resp) != 3 ||
 		resp[0].Cid != test.TestCid1 || resp[1].Cid != test.TestCid2 ||
 		resp[2].Cid != test.TestCid3 {

--- a/api/types.go
+++ b/api/types.go
@@ -48,6 +48,9 @@ const (
 	TrackerStatusUnpinned
 	// The IPFS deamon is not pinning the item but it is being tracked
 	TrackerStatusRemote
+	// The IPFS daemon is not pinning the item through this cid but it is
+	// tracked in a cluster dag
+	TrackerStatusSharded
 )
 
 // TrackerStatus represents the status of a tracked Cid in the PinTracker
@@ -515,22 +518,109 @@ func StringsToPeers(strs []string) []peer.ID {
 	return peers
 }
 
+// CidsToStrings encodes cid.Cids to strings.
+func CidsToStrings(cids []*cid.Cid) []string {
+	strs := make([]string, len(cids))
+	for i, c := range cids {
+		strs[i] = c.String()
+	}
+	return strs
+}
+
+// StringsToCidSet decodes cid.Cids from strings.
+func StringsToCidSet(strs []string) *cid.Set {
+	cids := cid.NewSet()
+	for _, str := range strs {
+		c, err := cid.Decode(str)
+		if err != nil {
+			logger.Error(str, err)
+		}
+		cids.Add(c)
+	}
+	return cids
+}
+
+// PinType values
+const (
+	DataType = iota + 1
+	MetaType
+	CdagType
+	ShardType
+)
+
+// AllType is a PinType used for filtering all pin types
+const AllType = -1
+
+// PinType specifies which of four possible interpretations a pin represents.
+// DataType pins are the simplest and represent a pin in the pinset used to
+// directly track user data.  ShardType pins are metadata pins that track
+// many nodes in a user's data DAG.  ShardType pins have a parent pin, and in
+// general can have many parents.  ClusterDAG, or Cdag for short, pins are also
+// metadata pins that do not directly track user data DAGs but rather other
+// metadata pins.  CdagType pins have at least one parent.  Finally MetaType
+// pins always track the cid of the root of a user-tracked data DAG.  However
+// MetaType pins are not stored directly in the ipfs pinset.  Instead the
+// underlying DAG is tracked via the metadata pins underneath the root of a
+// CdagType pin
+type PinType int
+
+// PinTypeFromString is the inverse of String.  It returns the PinType value
+// corresponding to the input string
+func PinTypeFromString(str string) PinType {
+	switch str {
+	case "pin":
+		return DataType
+	case "meta-pin":
+		return MetaType
+	case "clusterdag-pin":
+		return CdagType
+	case "shard-pin":
+		return ShardType
+	case "all":
+		return AllType
+	default:
+		return PinType(0) // invalid string
+	}
+}
+
+// String returns a printable value to identify the PinType
+func (pT *PinType) String() string {
+	switch *pT {
+	case DataType:
+		return "pin"
+	case MetaType:
+		return "meta-pin"
+	case CdagType:
+		return "clusterdag-pin"
+	case ShardType:
+		return "shard-pin"
+	case AllType:
+		return "all"
+	default:
+		panic("String() called on invalid shard type")
+	}
+}
+
 // Pin is an argument that carries a Cid. It may carry more things in the
 // future.
 type Pin struct {
 	Cid                  *cid.Cid
 	Name                 string
+	Type                 PinType
 	Allocations          []peer.ID
 	ReplicationFactorMin int
 	ReplicationFactorMax int
 	Recursive            bool
+	Parents              *cid.Set
+	Clusterdag           *cid.Cid
 }
 
 // PinCid is a shortcut to create a Pin only with a Cid.  Default is for pin to
-// be recursive
+// be recursive and the pin to be of DataType
 func PinCid(c *cid.Cid) Pin {
 	return Pin{
 		Cid:         c,
+		Type:        DataType,
 		Allocations: []peer.ID{},
 		Recursive:   true,
 	}
@@ -540,10 +630,13 @@ func PinCid(c *cid.Cid) Pin {
 type PinSerial struct {
 	Cid                  string   `json:"cid"`
 	Name                 string   `json:"name"`
+	Type                 int      `json:"type"`
 	Allocations          []string `json:"allocations"`
 	ReplicationFactorMin int      `json:"replication_factor_min"`
 	ReplicationFactorMax int      `json:"replication_factor_max"`
 	Recursive            bool     `json:"recursive"`
+	Parents              []string `json:"parents"`
+	Clusterdag           string   `json:"clusterdag"`
 }
 
 // ToSerial converts a Pin to PinSerial.
@@ -552,17 +645,28 @@ func (pin Pin) ToSerial() PinSerial {
 	if pin.Cid != nil {
 		c = pin.Cid.String()
 	}
+	cdag := ""
+	if pin.Clusterdag != nil {
+		cdag = pin.Clusterdag.String()
+	}
 
 	n := pin.Name
 	allocs := PeersToStrings(pin.Allocations)
+	var parents []string
+	if pin.Parents != nil {
+		parents = CidsToStrings(pin.Parents.Keys())
+	}
 
 	return PinSerial{
 		Cid:                  c,
 		Name:                 n,
 		Allocations:          allocs,
+		Type:                 int(pin.Type),
 		ReplicationFactorMin: pin.ReplicationFactorMin,
 		ReplicationFactorMax: pin.ReplicationFactorMax,
 		Recursive:            pin.Recursive,
+		Parents:              parents,
+		Clusterdag:           cdag,
 	}
 }
 
@@ -578,6 +682,10 @@ func (pin Pin) Equals(pin2 Pin) bool {
 	}
 
 	if pin1s.Name != pin2s.Name {
+		return false
+	}
+
+	if pin1s.Type != pin2s.Type {
 		return false
 	}
 
@@ -599,6 +707,18 @@ func (pin Pin) Equals(pin2 Pin) bool {
 	if pin1s.ReplicationFactorMin != pin2s.ReplicationFactorMin {
 		return false
 	}
+
+	if pin1s.Clusterdag != pin2s.Clusterdag {
+		return false
+	}
+
+	sort.Strings(pin1s.Parents)
+	sort.Strings(pin2s.Parents)
+
+	if strings.Join(pin1s.Parents, ",") != strings.Join(pin2s.Parents, ",") {
+		return false
+	}
+
 	return true
 }
 
@@ -608,14 +728,24 @@ func (pins PinSerial) ToPin() Pin {
 	if err != nil {
 		logger.Error(pins.Cid, err)
 	}
+	var cdag *cid.Cid
+	if pins.Clusterdag != "" {
+		cdag, err = cid.Decode(pins.Clusterdag)
+		if err != nil {
+			logger.Error(pins.Clusterdag, err)
+		}
+	}
 
 	return Pin{
 		Cid:                  c,
 		Name:                 pins.Name,
 		Allocations:          StringsToPeers(pins.Allocations),
+		Type:                 PinType(pins.Type),
 		ReplicationFactorMin: pins.ReplicationFactorMin,
 		ReplicationFactorMax: pins.ReplicationFactorMax,
 		Recursive:            pins.Recursive,
+		Parents:              StringsToCidSet(pins.Parents),
+		Clusterdag:           cdag,
 	}
 }
 

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -15,6 +16,9 @@ var testMAddr, _ = ma.NewMultiaddr("/ip4/1.2.3.4")
 var testMAddr2, _ = ma.NewMultiaddr("/dns4/a.b.c.d")
 var testMAddr3, _ = ma.NewMultiaddr("/ip4/127.0.0.1/tcp/8081/ws/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd")
 var testCid1, _ = cid.Decode("QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq")
+var testCid2, _ = cid.Decode("QmYCLpFCj9Av8NFjkQogvtXspnTDFWaizLpVFEijHTH4eV")
+var testCid3, _ = cid.Decode("QmZmdA3UZKuHuy9FrWsxJ82q21nbEh97NUnxTzF5EHxZia")
+var testCid4, _ = cid.Decode("QmZbNfi13Sb2WUDMjiW1ZNhnds5KDk6mJB5hP9B5h9m5CJ")
 var testPeerID1, _ = peer.IDB58Decode("QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabc")
 var testPeerID2, _ = peer.IDB58Decode("QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabd")
 var testPeerID3, _ = peer.IDB58Decode("QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa")
@@ -183,19 +187,37 @@ func TestPinConv(t *testing.T) {
 		}
 	}()
 
+	parents := cid.NewSet()
+	parents.Add(testCid2)
 	c := Pin{
 		Cid:                  testCid1,
 		Allocations:          []peer.ID{testPeerID1},
 		ReplicationFactorMax: -1,
 		ReplicationFactorMin: -1,
+		Recursive:            true,
+		Parents:              parents,
+		Name:                 "A test pin",
+		Type:                 CdagType,
+		Clusterdag:           testCid4,
 	}
 
 	newc := c.ToSerial().ToPin()
 	if c.Cid.String() != newc.Cid.String() ||
 		c.Allocations[0] != newc.Allocations[0] ||
 		c.ReplicationFactorMin != newc.ReplicationFactorMin ||
-		c.ReplicationFactorMax != newc.ReplicationFactorMax {
-		t.Error("mismatch")
+		c.ReplicationFactorMax != newc.ReplicationFactorMax ||
+		c.Recursive != newc.Recursive ||
+		c.Parents.Len() != newc.Parents.Len() ||
+		c.Parents.Keys()[0].String() != newc.Parents.Keys()[0].String() ||
+		c.Name != newc.Name || c.Type != newc.Type ||
+		c.Clusterdag.String() != newc.Clusterdag.String() {
+
+		fmt.Printf("c: %v\ncnew: %v\n", c, newc)
+		t.Fatal("mismatch")
+	}
+
+	if !c.Equals(newc) {
+		t.Error("all pin fields are equal but Equals returns false")
 	}
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/consensus/raft"
+	"github.com/ipfs/ipfs-cluster/sharder"
 	"github.com/ipfs/ipfs-cluster/state"
 
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
@@ -19,6 +20,7 @@ import (
 	ipnet "github.com/libp2p/go-libp2p-interface-pnet"
 	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
+	p2praft "github.com/libp2p/go-libp2p-raft"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	basichost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	ma "github.com/multiformats/go-multiaddr"
@@ -960,8 +962,8 @@ func (c *Cluster) Pins() []api.Pin {
 		logger.Error(err)
 		return []api.Pin{}
 	}
-
 	return cState.List()
+
 }
 
 // PinGet returns information for a single Cid managed by Cluster.
@@ -999,14 +1001,92 @@ func (c *Cluster) Pin(pin api.Pin) error {
 	return err
 }
 
+// validate pin ensures that the metadata accompanying the cid is
+// self-consistent.  This amounts to verifying that the data structure matches
+// the expected form of the pinType carried in the pin.
+func (c *Cluster) validatePin(pin api.Pin, rplMin, rplMax int) error {
+	switch pin.Type {
+	case api.DataType:
+		if pin.Clusterdag != nil ||
+			(pin.Parents != nil && pin.Parents.Len() != 0) {
+			return errors.New("data pins should not reference other pins")
+		}
+	case api.ShardType:
+		if !pin.Recursive {
+			return errors.New("must pin shards recursively")
+		}
+		// In general multiple clusterdags may reference the same shard
+		// and sharder sessions typically update a shard pin's metadata.
+		// Hence we check for an existing shard and carefully update.
+		cState, err := c.consensus.State()
+		if err != nil && err != p2praft.ErrNoState {
+			return err
+		}
+		if err == p2praft.ErrNoState || !cState.Has(pin.Cid) {
+			break
+		}
+
+		// State already tracks pin's CID
+		existing := cState.Get(pin.Cid)
+		// For now all repins of the same shard must use the same
+		// replmax and replmin.  It is unclear what the best UX is here
+		// especially if the same Shard is referenced in multiple
+		// clusterdags.  This simplistic policy avoids complexity and
+		// suits existing needs for shard pins.
+		if existing.ReplicationFactorMin != rplMin ||
+			existing.ReplicationFactorMax != rplMax {
+			return errors.New("shard update with wrong repl factors")
+		}
+	case api.CdagType:
+		if pin.Recursive {
+			return errors.New("must pin roots directly")
+		}
+		if pin.Clusterdag == nil {
+			return errors.New("roots must reference a dag")
+		}
+		if pin.Parents.Len() > 1 {
+			return errors.New("cdag nodes are referenced once")
+		}
+	case api.MetaType:
+		if len(pin.Allocations) != 0 {
+			return errors.New("meta pin should not specify allocations")
+		}
+	default:
+		return errors.New("unrecognized pin type")
+	}
+	return nil
+}
+
+// updatePinParents modifies the api.Pin input to give it the correct parents
+// so that previous additions to the pins parents are maintained after this
+// pin is committed to consensus.  If this pin carries new parents they are
+// merged with those already existing for this CID
+func (c *Cluster) updatePinParents(pin *api.Pin) error {
+	cState, err := c.consensus.State()
+	if err != nil && err != p2praft.ErrNoState {
+		return err
+	}
+	// first pin of this cid, nothing to update
+	if err == p2praft.ErrNoState || !cState.Has(pin.Cid) {
+		return nil
+	}
+	existing := cState.Get(pin.Cid)
+	// no existing parents this pin is up to date
+	if existing.Parents == nil || len(existing.Parents.Keys()) == 0 {
+		return nil
+	}
+	for _, c := range existing.Parents.Keys() {
+		pin.Parents.Add(c)
+	}
+	return nil
+}
+
 // pin performs the actual pinning and supports a blacklist to be
 // able to evacuate a node and returns whether the pin was submitted
 // to the consensus layer or skipped (due to error or to the fact
 // that it was already valid).
 func (c *Cluster) pin(pin api.Pin, blacklist []peer.ID, prioritylist []peer.ID) (bool, error) {
-	if pin.Cid == nil {
-		return false, errors.New("bad pin object")
-	}
+	// Determine repl factors
 	rplMin := pin.ReplicationFactorMin
 	rplMax := pin.ReplicationFactorMax
 	if rplMin == 0 {
@@ -1018,7 +1098,24 @@ func (c *Cluster) pin(pin api.Pin, blacklist []peer.ID, prioritylist []peer.ID) 
 		pin.ReplicationFactorMax = rplMax
 	}
 
+	// Validate pin
+	if pin.Cid == nil {
+		return false, errors.New("bad pin object")
+	}
 	if err := isReplicationFactorValid(rplMin, rplMax); err != nil {
+		return false, err
+	}
+	err := c.validatePin(pin, rplMin, rplMax)
+	if err != nil {
+		return false, err
+	}
+	if pin.Type == api.MetaType {
+		return true, c.consensus.LogPin(pin)
+	}
+
+	// Ensure parents do not overwrite existing and merge non-intersecting
+	err = c.updatePinParents(&pin)
+	if err != nil {
 		return false, err
 	}
 
@@ -1056,16 +1153,93 @@ func (c *Cluster) pin(pin api.Pin, blacklist []peer.ID, prioritylist []peer.ID) 
 // of underlying IPFS daemon unpinning operations.
 func (c *Cluster) Unpin(h *cid.Cid) error {
 	logger.Info("IPFS cluster unpinning:", h)
-
-	pin := api.Pin{
-		Cid: h,
-	}
-
-	err := c.consensus.LogUnpin(pin)
+	cState, err := c.consensus.State()
 	if err != nil {
 		return err
 	}
-	return nil
+
+	if !cState.Has(h) {
+		return errors.New("cannot unpin pin uncommitted to state")
+	}
+	pin := cState.Get(h)
+
+	switch pin.Type {
+	case api.DataType:
+		return c.consensus.LogUnpin(pin)
+	case api.ShardType:
+		err := "unpinning shard cid %s before unpinning parent"
+		return errors.New(err)
+	case api.MetaType:
+		// Unpin cluster dag and referenced shards
+		err := c.unpinClusterDag(pin)
+		if err != nil {
+			return err
+		}
+		return c.consensus.LogUnpin(pin)
+	case api.CdagType:
+		err := "unpinning cluster dag root %s before unpinning parent"
+		return errors.New(err)
+	default:
+		return errors.New("unrecognized pin type")
+	}
+}
+
+// unpinClusterDag unpins the clusterDAG metadata node and the shard metadata
+// nodes that it references.  It handles the case where multiple parents
+// reference the same metadata node, only unpinning those nodes without
+// existing references
+func (c *Cluster) unpinClusterDag(metaPin api.Pin) error {
+	if metaPin.Clusterdag == nil {
+		return errors.New("metaPin not linked to clusterdag")
+	}
+
+	cdagBytes, err := c.ipfs.BlockGet(metaPin.Clusterdag)
+	if err != nil {
+		return err
+	}
+	cdag, err := sharder.CborDataToNode(cdagBytes, "cbor")
+	if err != nil {
+		return err
+	}
+
+	// traverse all shards of cdag
+	for _, shardLink := range cdag.Links() {
+		err = c.unpinShard(metaPin.Clusterdag, shardLink.Cid)
+		if err != nil {
+			return err
+		}
+	}
+
+	// by invariant in Pin cdag has only one parent and can be unpinned
+	cdagWrap := api.PinCid(metaPin.Clusterdag)
+	return c.consensus.LogUnpin(cdagWrap)
+}
+
+func (c *Cluster) unpinShard(cdagCid, shardCid *cid.Cid) error {
+	cState, err := c.consensus.State()
+	if err != nil {
+		return err
+	}
+	if !cState.Has(cdagCid) || !cState.Has(shardCid) {
+		return errors.New("nodes of the clusterdag are not committed to the state")
+	}
+	shardPin := cState.Get(shardCid)
+	if shardPin.Parents == nil || !shardPin.Parents.Has(cdagCid) {
+		return errors.New("clusterdag references shard node but shard node does not reference clusterdag as parent")
+	}
+	// Remove the parent from the shardPin
+	for _, c := range shardPin.Parents.Keys() { //parents non-nil by check above
+		if c.String() == cdagCid.String() {
+			shardPin.Parents.Remove(c)
+			break
+		}
+	}
+
+	// Recommit state if other references exist
+	if shardPin.Parents.Len() > 0 {
+		return c.consensus.LogPin(shardPin)
+	}
+	return c.consensus.LogUnpin(shardPin)
 }
 
 // Version returns the current IPFS Cluster version.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -89,7 +89,18 @@ func (ipfs *mockConnector) ConnectSwarms() error                          { retu
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
 func (ipfs *mockConnector) FreeSpace() (uint64, error)                    { return 100, nil }
 func (ipfs *mockConnector) RepoSize() (uint64, error)                     { return 0, nil }
-func (ipfs *mockConnector) BlockPut(bwf api.NodeWithMeta) (string, error) { return "", nil }
+func (ipfs *mockConnector) BlockPut(nwm api.NodeWithMeta) (string, error) { return "", nil }
+
+func (ipfs *mockConnector) BlockGet(c *cid.Cid) ([]byte, error) {
+	switch c.String() {
+	case test.TestShardCid:
+		return test.TestShardData, nil
+	case test.TestCdagCid:
+		return test.TestCdagData, nil
+	default:
+		return nil, errors.New("block not found")
+	}
+}
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, *mapstate.MapState, *maptracker.MapPinTracker) {
 	clusterCfg, _, _, consensusCfg, trackerCfg, monCfg, _, sharderCfg := testingConfigs()
@@ -217,6 +228,103 @@ func TestClusterPin(t *testing.T) {
 	}
 }
 
+func pinDirectShard(t *testing.T, cl *Cluster) {
+	cShard, _ := cid.Decode(test.TestShardCid)
+	cCdag, _ := cid.Decode(test.TestCdagCid)
+	cMeta, _ := cid.Decode(test.TestMetaRootCid)
+	parents := cid.NewSet()
+	parents.Add(cCdag)
+	shardPin := api.Pin{
+		Cid:                  cShard,
+		Type:                 api.ShardType,
+		ReplicationFactorMin: -1,
+		ReplicationFactorMax: -1,
+		Recursive:            true,
+		Parents:              parents,
+	}
+	err := cl.Pin(shardPin)
+	if err != nil {
+		t.Fatal("pin should have worked:", err)
+	}
+
+	parents = cid.NewSet()
+	parents.Add(cMeta)
+	cdagPin := api.Pin{
+		Cid:                  cCdag,
+		Type:                 api.CdagType,
+		ReplicationFactorMin: -1,
+		ReplicationFactorMax: -1,
+		Recursive:            false,
+		Parents:              parents,
+		Clusterdag:           cShard,
+	}
+	err = cl.Pin(cdagPin)
+	if err != nil {
+		t.Fatal("pin should have worked:", err)
+	}
+
+	metaPin := api.Pin{
+		Cid:        cMeta,
+		Type:       api.MetaType,
+		Clusterdag: cCdag,
+	}
+	err = cl.Pin(metaPin)
+	if err != nil {
+		t.Fatal("pin should have worked:", err)
+	}
+}
+
+func TestClusterPinMeta(t *testing.T) {
+	cl, _, _, _, _ := testingCluster(t)
+	defer cleanRaft()
+	defer cl.Shutdown()
+
+	pinDirectShard(t, cl)
+}
+
+func TestClusterUnpinShardFail(t *testing.T) {
+	cl, _, _, _, _ := testingCluster(t)
+	defer cleanRaft()
+	defer cl.Shutdown()
+
+	pinDirectShard(t, cl)
+	// verify pins
+	if len(cl.Pins()) != 3 {
+		t.Fatal("should have 3 pins")
+	}
+	// Unpinning metadata should fail
+	cShard, _ := cid.Decode(test.TestShardCid)
+	cCdag, _ := cid.Decode(test.TestCdagCid)
+
+	err := cl.Unpin(cShard)
+	if err == nil {
+		t.Error("should error when unpinning shard")
+	}
+	err = cl.Unpin(cCdag)
+	if err == nil {
+		t.Error("should error when unpinning cluster dag")
+	}
+}
+
+func TestClusterUnpinMeta(t *testing.T) {
+	cl, _, _, _, _ := testingCluster(t)
+	defer cleanRaft()
+	defer cl.Shutdown()
+
+	pinDirectShard(t, cl)
+	// verify pins
+	if len(cl.Pins()) != 3 {
+		t.Fatal("should have 3 pins")
+	}
+	// Unpinning from root should work
+	cMeta, _ := cid.Decode(test.TestMetaRootCid)
+
+	err := cl.Unpin(cMeta)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestClusterPins(t *testing.T) {
 	cl, _, _, _, _ := testingCluster(t)
 	defer cleanRaft()
@@ -269,12 +377,23 @@ func TestClusterUnpin(t *testing.T) {
 	defer cl.Shutdown()
 
 	c, _ := cid.Decode(test.TestCid1)
+	// Unpin should error without pin being committed to state
 	err := cl.Unpin(c)
+	if err == nil {
+		t.Error("unpin should have failed")
+	}
+
+	// Unpin after pin should succeed
+	err = cl.Pin(api.PinCid(c))
 	if err != nil {
 		t.Fatal("pin should have worked:", err)
 	}
+	err = cl.Unpin(c)
+	if err != nil {
+		t.Error("unpin should have worked:", err)
+	}
 
-	// test an error case
+	// test another error case
 	cl.consensus.Shutdown()
 	err = cl.Unpin(c)
 	if err == nil {

--- a/consensus/raft/consensus_test.go
+++ b/consensus/raft/consensus_test.go
@@ -134,6 +134,51 @@ func TestConsensusUnpin(t *testing.T) {
 	}
 }
 
+func TestConsensusUpdate(t *testing.T) {
+	cc := testingConsensus(t, 1)
+	defer cleanRaft(1)
+	defer cc.Shutdown()
+
+	// Pin first
+	c1, _ := cid.Decode(test.TestCid1)
+	pin := api.Pin{
+		Cid:                  c1,
+		Type:                 api.ShardType,
+		ReplicationFactorMin: -1,
+		ReplicationFactorMax: -1,
+		Parents:              nil,
+	}
+	err := cc.LogPin(pin)
+	if err != nil {
+		t.Fatal("the initial operation did not make it to the log:", err)
+	}
+	time.Sleep(250 * time.Millisecond)
+
+	// Update pin
+	c2, _ := cid.Decode(test.TestCid2)
+	pin.Parents = cid.NewSet()
+	pin.Parents.Add(c2)
+	err = cc.LogPin(pin)
+	if err != nil {
+		t.Error("the update op did not make it to the log:", err)
+	}
+
+	time.Sleep(250 * time.Millisecond)
+	st, err := cc.State()
+	if err != nil {
+		t.Fatal("error getting state:", err)
+	}
+
+	pins := st.List()
+	if len(pins) != 1 || pins[0].Cid.String() != test.TestCid1 {
+		t.Error("the added pin should be in the state")
+	}
+	if pins[0].Parents == nil || pins[0].Parents.Len() != 1 ||
+		!pins[0].Parents.Has(c2) {
+		t.Error("pin updated incorrectly")
+	}
+}
+
 func TestConsensusAddPeer(t *testing.T) {
 	cc := testingConsensus(t, 1)
 	cc2 := testingConsensus(t, 2)

--- a/consensus/raft/log_op.go
+++ b/consensus/raft/log_op.go
@@ -61,7 +61,6 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 			op.Cid,
 			&struct{}{},
 			nil)
-
 	default:
 		logger.Error("unknown LogOp type. Ignoring")
 	}

--- a/ipfs-cluster-ctl/formatters.go
+++ b/ipfs-cluster-ctl/formatters.go
@@ -181,6 +181,28 @@ func textFormatPrintPin(obj *api.PinSerial) {
 			obj.ReplicationFactorMin, obj.ReplicationFactorMax,
 			sortAlloc)
 	}
+	var recStr string
+	if obj.Recursive {
+		recStr = "Recursive"
+	} else {
+		recStr = "Non-recursive"
+	}
+	fmt.Printf("| %s | ", recStr)
+
+	pinType := obj.ToPin().Type
+	typeStr := pinType.String()
+	var infoStr string
+	switch pinType {
+	case api.DataType:
+		infoStr = typeStr
+	case api.MetaType:
+		infoStr = fmt.Sprintf("%s-- clusterDAG=%s",typeStr, obj.Clusterdag)
+	case api.CdagType, api.ShardType:
+		infoStr = typeStr
+	default:
+		infoStr = ""
+	}
+	fmt.Printf("| %s ", infoStr)
 }
 
 func textFormatPrintAddedOutput(obj *api.AddedOutput) {

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -417,9 +417,16 @@ which peers they are currently allocated. This list does not include
 any monitoring information about the IPFS status of the CIDs, it
 merely represents the list of pins which are part of the shared state of
 the cluster. For IPFS-status information about the pins, use "status".
+Metadata CIDs used to track sharded files are hidden by default.  To view
+all CIDs call with the -a flag.
 `,
 					ArgsUsage: "[CID]",
-					Flags:     []cli.Flag{},
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "all, a",
+							Usage: "display hidden CIDs",
+						},
+					},
 					Action: func(c *cli.Context) error {
 						cidStr := c.Args().First()
 						if cidStr != "" {
@@ -428,7 +435,11 @@ the cluster. For IPFS-status information about the pins, use "status".
 							resp, cerr := globalClient.Allocation(ci)
 							formatResponse(c, resp, cerr)
 						} else {
-							resp, cerr := globalClient.Allocations()
+							filter := api.PinType(api.DataType)
+							if c.Bool("all") {
+								filter = api.PinType(api.AllType)
+							}
+							resp, cerr := globalClient.Allocations(filter)
 							formatResponse(c, resp, cerr)
 						}
 						return nil
@@ -443,7 +454,7 @@ the cluster. For IPFS-status information about the pins, use "status".
 This command retrieves the status of the CIDs tracked by IPFS
 Cluster, including which member is pinning them and any errors.
 If a CID is provided, the status will be only fetched for a single
-item.
+item.  Metadata CIDs are included in the status response
 
 The status of a CID may not be accurate. A manual sync can be triggered
 with "sync".

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -90,6 +90,8 @@ type IPFSConnector interface {
 	RepoSize() (uint64, error)
 	// BlockPut directly adds a block of data to the IPFS repo
 	BlockPut(api.NodeWithMeta) (string, error)
+	// BlockGet retrieves the raw data of an IPFS block
+	BlockGet(*cid.Cid) ([]byte, error)
 }
 
 // Peered represents a component which needs to be aware of the peers

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -384,18 +384,22 @@ func TestClustersPin(t *testing.T) {
 	pinList := clusters[0].Pins()
 
 	for i := 0; i < nPins; i++ {
+		// test re-unpin fails
 		j := rand.Intn(nClusters) // choose a random cluster peer
 		err := clusters[j].Unpin(pinList[i].Cid)
 		if err != nil {
 			t.Errorf("error unpinning %s: %s", pinList[i].Cid, err)
 		}
-		// test re-unpin
-		err = clusters[j].Unpin(pinList[i].Cid)
-		if err != nil {
-			t.Errorf("error re-unpinning %s: %s", pinList[i].Cid, err)
-		}
-
 	}
+	delay()
+	for i := 0; i < nPins; i++ {
+		j := rand.Intn(nClusters) // choose a random cluster peer
+		err := clusters[j].Unpin(pinList[i].Cid)
+		if err == nil {
+			t.Errorf("expected error re-unpinning %s: %s", pinList[i].Cid, err)
+		}
+	}
+
 	delay()
 
 	funpinned := func(t *testing.T, c *Cluster) {
@@ -944,6 +948,7 @@ func TestClustersReplicationFactorMaxLower(t *testing.T) {
 		Cid:                  h,
 		ReplicationFactorMax: 2,
 		ReplicationFactorMin: 1,
+		Type:                 api.DataType,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -946,3 +946,9 @@ func (ipfs *Connector) BlockPut(b api.NodeWithMeta) (string, error) {
 	}
 	return keyRaw.Key, nil
 }
+
+// BlockGet retrieves an ipfs block with the given cid
+func (ipfs *Connector) BlockGet(c *cid.Cid) ([]byte, error) {
+	url := "block/get?arg=" + c.String()
+	return ipfs.post(url, "", nil)
+}

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -585,6 +585,20 @@ func TestBlockPut(t *testing.T) {
 	}
 }
 
+func TestBlockGet(t *testing.T) {
+	ipfs, mock := testIPFSConnector(t)
+	defer mock.Close()
+	defer ipfs.Shutdown()
+	shardCid, err := cid.Decode(test.TestShardCid)
+	data, err := ipfs.BlockGet(shardCid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, test.TestShardData) {
+		t.Fatal("unexpected data returned")
+	}
+}
+
 func TestRepoSize(t *testing.T) {
 	ipfs, mock := testIPFSConnector(t)
 	defer mock.Close()

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmeQA8UUz7MFqhJfEbo7MphMaSBnBcid4ByBECLcZakTtJ",
+      "hash": "QmY5WCJgFTUqeemp2b9nHskfsji7hy2nvEFiHH9WH29FVf",
       "name": "go-libp2p-raft",
-      "version": "1.2.2"
+      "version": "1.2.3"
     },
     {
       "author": "whyrusleeping",

--- a/pintracker/maptracker/maptracker.go
+++ b/pintracker/maptracker/maptracker.go
@@ -237,6 +237,10 @@ func (mpt *MapPinTracker) unpin(c api.Pin) error {
 // possibly trigerring Pin operations on the IPFS daemon.
 func (mpt *MapPinTracker) Track(c api.Pin) error {
 	logger.Debugf("tracking %s", c.Cid)
+	if c.Type == api.MetaType {
+		mpt.set(c.Cid, api.TrackerStatusSharded)
+		return nil
+	}
 	if mpt.isRemote(c) {
 		if mpt.get(c.Cid).Status == api.TrackerStatusPinned {
 			mpt.unpin(c)

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -200,7 +200,7 @@ func (rpcapi *RPCAPI) StateSync(ctx context.Context, in struct{}, out *[]api.Pin
 }
 
 // GetInformerMetrics runs Cluster.GetInformerMetrics().
-func (rpcapi *RPCAPI) GetInformerMetrics(in struct{}, out *[]api.Metric) error {
+func (rpcapi *RPCAPI) GetInformerMetrics(ctx context.Context, in struct{}, out *[]api.Metric) error {
 	metrics, err := rpcapi.c.getInformerMetrics()
 	*out = metrics
 	return err
@@ -211,7 +211,7 @@ func (rpcapi *RPCAPI) GetInformerMetrics(in struct{}, out *[]api.Metric) error {
 */
 
 // Allocate runs Allocator.Allocate().
-func (rpcapi *RPCAPI) Allocate(in api.AllocateInfo, out *[]peer.ID) error {
+func (rpcapi *RPCAPI) Allocate(ctx context.Context, in api.AllocateInfo, out *[]peer.ID) error {
 	c := in.GetCid()
 	peers, err := rpcapi.c.allocator.Allocate(
 		c,
@@ -334,8 +334,16 @@ func (rpcapi *RPCAPI) IPFSSwarmPeers(ctx context.Context, in struct{}, out *api.
 }
 
 // IPFSBlockPut runs IPFSConnector.BlockPut().
-func (rpcapi *RPCAPI) IPFSBlockPut(in api.NodeWithMeta, out *string) error {
+func (rpcapi *RPCAPI) IPFSBlockPut(ctx context.Context, in api.NodeWithMeta, out *string) error {
 	res, err := rpcapi.c.ipfs.BlockPut(in)
+	*out = res
+	return err
+}
+
+// IPFSBlockGet runs IPFSConnector.BlockGet().
+func (rpcapi *RPCAPI) IPFSBlockGet(ctx context.Context, in api.PinSerial, out *[]byte) error {
+	c := in.ToPin().Cid
+	res, err := rpcapi.c.ipfs.BlockGet(c)
 	*out = res
 	return err
 }
@@ -378,14 +386,14 @@ func (rpcapi *RPCAPI) ConsensusPeers(ctx context.Context, in struct{}, out *[]pe
 */
 
 // SharderAddNode runs Sharder.AddNode(node).
-func (rpcapi *RPCAPI) SharderAddNode(in api.NodeWithMeta, out *string) error {
+func (rpcapi *RPCAPI) SharderAddNode(ctx context.Context, in api.NodeWithMeta, out *string) error {
 	shardID, err := rpcapi.c.sharder.AddNode(in.Size, in.Data, in.Cid, in.ID)
 	*out = shardID
 	return err
 }
 
 // SharderFinalize runs Sharder.Finalize().
-func (rpcapi *RPCAPI) SharderFinalize(in string, out *struct{}) error {
+func (rpcapi *RPCAPI) SharderFinalize(ctx context.Context, in string, out *struct{}) error {
 	return rpcapi.c.sharder.Finalize(in)
 }
 

--- a/state/mapstate/migrate.go
+++ b/state/mapstate/migrate.go
@@ -116,6 +116,9 @@ func (st *mapStateV3) next() migrateable {
 			ReplicationFactorMin: v.ReplicationFactorMin,
 			ReplicationFactorMax: v.ReplicationFactorMax,
 			Recursive:            true,
+			Type:                 api.DataType,
+			Parents:              nil,
+			Clusterdag:           "",
 		}
 	}
 	return &mst4

--- a/test/cids.go
+++ b/test/cids.go
@@ -1,6 +1,10 @@
 package test
 
-import peer "github.com/libp2p/go-libp2p-peer"
+import (
+	"encoding/hex"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+)
 
 // Common variables used all around tests.
 var (
@@ -11,7 +15,15 @@ var (
 	TestCid4Data = "Cid4Data" // Cid resulting from block put NOT ipfs add
 	// ErrorCid is meant to be used as a Cid which causes errors. i.e. the
 	// ipfs mock fails when pinning this CID.
-	ErrorCid       = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmc"
+	ErrorCid = "QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmc"
+	// Shard and Cdag Cids
+	TestShardCid    = "zdpuAoiNm1ntWx6jpgcReTiCWFHJSTpvTw4bAAn9p6yDnznqh"
+	TestCdagCid     = "zdpuApF6HZBu8rscHSVJ7ra3VSYWc5dJnnxt42bGKyZ1a4qPo"
+	TestMetaRootCid = "QmYCLpFCj9Av8NFjkQogvtXspnTDFWaizLpVFEijHTH4eV"
+
+	TestShardData, _ = hex.DecodeString("a16130d82a58230012209273fd63ec94bed5abb219b2d9cb010cabe4af7b0177292d4335eff50464060a")
+	TestCdagData, _  = hex.DecodeString("a16130d82a5825000171122030e9b9b4f1bc4b5a3759a93b4e77983cd053f84174e1b0cd628dc6c32fb0da14")
+
 	TestPeerID1, _ = peer.IDB58Decode("QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabc")
 	TestPeerID2, _ = peer.IDB58Decode("QmUZ13osndQ5uL4tPWHXe3iBgBgq9gfewcBMSCAuMBsDJ6")
 	TestPeerID3, _ = peer.IDB58Decode("QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa")

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -265,6 +265,23 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		}
 		j, _ := json.Marshal(resp)
 		w.Write(j)
+	case "block/get":
+		query := r.URL.Query()
+		arg, ok := query["arg"]
+		if !ok {
+			goto ERROR
+		}
+		if len(arg) != 1 {
+			goto ERROR
+		}
+		switch arg[0] {
+		case TestShardCid:
+			w.Write(TestShardData)
+		case TestCdagCid:
+			w.Write(TestCdagData)
+		default:
+			goto ERROR
+		}
 	case "repo/stat":
 		len := len(m.pinMap.List())
 		resp := mockRepoStatResp{

--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 
+	cid "github.com/ipfs/go-cid"
 	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
@@ -170,6 +171,15 @@ func logError(fmtstr string, args ...interface{}) error {
 func containsPeer(list []peer.ID, peer peer.ID) bool {
 	for _, p := range list {
 		if p == peer {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCid(list []*cid.Cid, ci *cid.Cid) bool {
+	for _, c := range list {
+		if c.String() == ci.String() {
 			return true
 		}
 	}


### PR DESCRIPTION
@hsanjuan This is my stab at the new state format after our discussion last week.  Could I get some feedback on the representation of the different "PinTypes"?  Some questions:
* Are you in favor of the datatype's structure?
* Are any of the new names used confusing?
* Are you ok with a single Child field (queries for children of metadata nodes must go through ipfs)?
* Is the pattern of updating the Log, to account for the fact that shard pins will only know of their parents after they are pinned, acceptable?
* Any problems with the addition of a new trackerStatus to denote metapins?  Local and remote didn't seem quite right because potentially some shards are local and some are remote.
* should the `status` command display to the user a field to distinguish if a pin is metadata (cdag or shard) or data?

TODO:
[ ] ipfsconn method for retrieving clusterdag index + tests for this method
[ ] Finish Unpin functionality, including multiple parent awareness and replication factor resetting if max/min changes after one parent unpins
[ ] Pin and Unpin testing against each PinType
[ ] only display metadata pins when requested (ls -a)
[ ] state format migration to new PinSerial type