### PR TITLE
Add disable_repinning cluster option

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -397,6 +397,10 @@ func (c *Cluster) watchPeers() {
 
 // find all Cids pinned to a given peer and triggers re-pins on them.
 func (c *Cluster) repinFromPeer(p peer.ID) {
+	if c.config.DisableRepinning {
+		return
+	}
+
 	cState, err := c.consensus.State()
 	if err != nil {
 		logger.Warning(err)

--- a/cluster.go
+++ b/cluster.go
@@ -398,6 +398,7 @@ func (c *Cluster) watchPeers() {
 // find all Cids pinned to a given peer and triggers re-pins on them.
 func (c *Cluster) repinFromPeer(p peer.ID) {
 	if c.config.DisableRepinning {
+		logger.Warningf("repinning is disabled. Will not re-allocate cids from %s", p.Pretty())
 		return
 	}
 

--- a/cluster_config.go
+++ b/cluster_config.go
@@ -31,6 +31,7 @@ const (
 	DefaultPeerWatchInterval   = 5 * time.Second
 	DefaultReplicationFactor   = -1
 	DefaultLeaveOnShutdown     = false
+	DefaultDisableRepinning    = false
 )
 
 // Config is the configuration object containing customizable variables to
@@ -115,6 +116,12 @@ type Config struct {
 	// file. This also affects how soon we realize that we have
 	// been removed from a cluster.
 	PeerWatchInterval time.Duration
+
+	// If true, DisableRepinning, ensures that no repinning happens
+	// when a node goes down.
+	// This is useful when doing certain types of maintainance, or simply
+	// when not wanting to rely on the monitoring system which needs a revamp.
+	DisableRepinning bool
 }
 
 // configJSON represents a Cluster configuration as it will look when it is
@@ -136,6 +143,7 @@ type configJSON struct {
 	ReplicationFactorMax int      `json:"replication_factor_max"`
 	MonitorPingInterval  string   `json:"monitor_ping_interval"`
 	PeerWatchInterval    string   `json:"peer_watch_interval"`
+	DisableRepinning     bool     `json:"disable_repinning"`
 }
 
 // ConfigKey returns a human-readable string to identify
@@ -269,6 +277,7 @@ func (cfg *Config) setDefaults() {
 	cfg.ReplicationFactorMax = DefaultReplicationFactor
 	cfg.MonitorPingInterval = DefaultMonitorPingInterval
 	cfg.PeerWatchInterval = DefaultPeerWatchInterval
+	cfg.DisableRepinning = DefaultDisableRepinning
 }
 
 // LoadJSON receives a raw json-formatted configuration and
@@ -374,6 +383,7 @@ func (cfg *Config) LoadJSON(raw []byte) error {
 	config.SetIfNotDefault(peerWatchInterval, &cfg.PeerWatchInterval)
 
 	cfg.LeaveOnShutdown = jcfg.LeaveOnShutdown
+	cfg.DisableRepinning = jcfg.DisableRepinning
 
 	return cfg.Validate()
 }
@@ -423,6 +433,7 @@ func (cfg *Config) ToJSON() (raw []byte, err error) {
 	jcfg.IPFSSyncInterval = cfg.IPFSSyncInterval.String()
 	jcfg.MonitorPingInterval = cfg.MonitorPingInterval.String()
 	jcfg.PeerWatchInterval = cfg.PeerWatchInterval.String()
+	jcfg.DisableRepinning = cfg.DisableRepinning
 
 	raw, err = json.MarshalIndent(jcfg, "", "    ")
 	return

--- a/cluster_config_test.go
+++ b/cluster_config_test.go
@@ -23,7 +23,8 @@ var ccfgTestJSON = []byte(`
         "ipfs_sync_interval": "2m10s",
         "replication_factor_min": 5,
         "replication_factor_max": 5,
-        "monitor_ping_interval": "2s"
+        "monitor_ping_interval": "2s",
+        "disable_repinning": true
 }
 `)
 
@@ -44,6 +45,10 @@ func TestLoadJSON(t *testing.T) {
 
 	if cfg.ReplicationFactorMin != 5 {
 		t.Error("expected replication factor min == 5")
+	}
+
+	if !cfg.DisableRepinning {
+		t.Error("expected disable_repinning to be true")
 	}
 
 	j := &configJSON{}

--- a/config_test.go
+++ b/config_test.go
@@ -23,7 +23,8 @@ var testingClusterCfg = []byte(`{
     "ipfs_sync_interval": "2m10s",
     "replication_factor": -1,
     "monitor_ping_interval": "150ms",
-    "peer_watch_interval": "100ms"
+    "peer_watch_interval": "100ms",
+    "disable_repinning": false
 }
 `)
 


### PR DESCRIPTION
This PR adds the option `disable_repinning` along with its default value, and test values. `repinFromPeer` returns if this option is true.

I'm having problems with running the tests to ensure everything is passing. I get `ipfscluster_test.go:69: bootstrap unsuccessful`, does anyone know what might be the cause?