### PR TITLE
Fix: do not fail when running daemon --upgrade and no state exists

### DIFF
--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -451,7 +451,9 @@ func daemon(c *cli.Context) error {
 	// Run any migrations
 	if c.Bool("upgrade") {
 		err := upgrade()
-		checkErr("upgrading state", err)
+		if err != errNoSnapshot {
+			checkErr("upgrading state", err)
+		} // otherwise continue
 	}
 
 	// Execution lock


### PR DESCRIPTION
Surfaced by #394 