### PR TITLE
[WIP] Add basic tracing

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -73,6 +73,8 @@ type Config struct {
 
 	// LogLevel defines the verbosity of the logging facility
 	LogLevel string
+
+	Context context.Context
 }
 
 // Client provides methods to interact with the ipfs-cluster API. Use
@@ -91,6 +93,9 @@ type Client struct {
 // NewClient initializes a client given a Config.
 func NewClient(cfg *Config) (*Client, error) {
 	ctx := context.Background()
+	if cfg.Context != nil {
+		ctx = cfg.Context
+	}
 	client := &Client{
 		ctx:    ctx,
 		config: cfg,

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -15,6 +15,7 @@ import (
 	//	_ "net/http/pprof"
 
 	logging "github.com/ipfs/go-log"
+	writer "github.com/ipfs/go-log/writer"
 	ma "github.com/multiformats/go-multiaddr"
 	cli "github.com/urfave/cli"
 
@@ -196,6 +197,11 @@ func main() {
 			Name:  "alloc, a",
 			Value: "disk-freespace",
 			Usage: "allocation strategy to use [disk-freespace,disk-reposize,numpin].",
+		},
+		cli.StringFlag{
+			Name:  "trace-out",
+			Value: "",
+			Usage: "output path for tracing result. If not provided, results will be written to std.",
 		},
 	}
 
@@ -444,6 +450,14 @@ func run(c *cli.Context) error {
 
 func daemon(c *cli.Context) error {
 	logger.Info("Initializing. For verbose output run with \"-l debug\". Please wait...")
+
+	writerCloser := os.Stdout
+	if c.String("trace-out") != "" {
+		f, err := os.OpenFile(c.String("trace-out"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		checkErr("opening trace output file", err)
+		writerCloser = f
+	}
+	writer.WriterGroup.AddWriter(writerCloser)
 
 	// Load all the configurations
 	cfgMgr, cfgs := makeConfigs()


### PR DESCRIPTION
This PR tries to add tracing by using `go-log`'s `EventLogger`. As of yet, it only adds a few sample spans, and mostly traces are isolated to their components.

Notes:
* `EventLogger` modifications required by this PR have been merged into master, but not yet published to gx, therefore please make sure you use the master branch of `go-log` for testing.
* Tracing is enabled by default, and the spans are printed to stdout as soon as they're produced. `--trace-out` flag for both `ctl` and `service` allow one to redirect tracing output to a file.
* This patch passes the context from `ctl` to the rpc client as config which gets stored on the struct. This is bad practice, in future, ctx should be rather passed to every function.
* For some reason `ctl` doesn't print the root span, which I traced to `go-log/writer.logRoutine`, probably the channels get closed somewhere. To be fixed.

Implements #287 