### PR TITLE
StateSync(): some improvements

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -160,7 +160,7 @@ func TestClusterStateSync(t *testing.T) {
 	cl, _, _, st, _ := testingCluster(t)
 	defer cleanRaft()
 	defer cl.Shutdown()
-	_, err := cl.StateSync()
+	err := cl.StateSync()
 	if err == nil {
 		t.Fatal("expected an error as there is no state to sync")
 	}
@@ -171,7 +171,7 @@ func TestClusterStateSync(t *testing.T) {
 		t.Fatal("pin should have worked:", err)
 	}
 
-	_, err = cl.StateSync()
+	err = cl.StateSync()
 	if err != nil {
 		t.Fatal("sync after pinning should have worked:", err)
 	}
@@ -179,7 +179,7 @@ func TestClusterStateSync(t *testing.T) {
 	// Modify state on the side so the sync does not
 	// happen on an empty slide
 	st.Rm(c)
-	_, err = cl.StateSync()
+	err = cl.StateSync()
 	if err != nil {
 		t.Fatal("sync with recover should have worked:", err)
 	}

--- a/ipfs-cluster-service/daemon.go
+++ b/ipfs-cluster-service/daemon.go
@@ -125,7 +125,7 @@ func createCluster(
 	)
 	checkErr("creating consensus component", err)
 
-	tracker := maptracker.NewMapPinTracker(cfgs.trackerCfg, cfgs.clusterCfg.ID)
+	tracker := maptracker.NewMapPinTracker(cfgs.trackerCfg, host.ID())
 	mon := setupMonitor(c.String("monitor"), host, cfgs.monCfg, cfgs.pubsubmonCfg)
 	informer, alloc := setupAllocation(c.String("alloc"), cfgs.diskInfCfg, cfgs.numpinInfCfg)
 

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -192,13 +192,6 @@ func (rpcapi *RPCAPI) RecoverLocal(ctx context.Context, in api.PinSerial, out *a
 	return err
 }
 
-// StateSync runs Cluster.StateSync().
-func (rpcapi *RPCAPI) StateSync(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
-	pinfos, err := rpcapi.c.StateSync()
-	*out = pinInfoSliceToSerial(pinfos)
-	return err
-}
-
 /*
    Tracker component methods
 */

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -226,11 +226,6 @@ func (mock *mockService) SyncLocal(ctx context.Context, in api.PinSerial, out *a
 	return mock.StatusLocal(ctx, in, out)
 }
 
-func (mock *mockService) StateSync(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
-	*out = make([]api.PinInfoSerial, 0, 0)
-	return nil
-}
-
 func (mock *mockService) RecoverAllLocal(ctx context.Context, in struct{}, out *[]api.PinInfoSerial) error {
 	return mock.TrackerRecoverAll(ctx, in, out)
 }


### PR DESCRIPTION
This commit:

* Does not collect and return changed items when doing StateSync (they are
not used)
* Removes the StateSync RPC method (no longer used)
* Uses tracker.StatusAll() rather than requesting Status on each Cid (should
be faster with upcoming pintracker)
* Does not launch a go-routine to track every item. Track is an async
operation. This likely causes 1000s goroutines to be started with no good
reason.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>