### PR TITLE
Fix/data folder

### DIFF
--- a/consensus/raft/config.go
+++ b/consensus/raft/config.go
@@ -20,7 +20,7 @@ var configKey = "raft"
 
 // Configuration defaults
 var (
-	DefaultDataSubFolder        = "ipfs-cluster-data"
+	DefaultDataSubFolder        = "raft"
 	DefaultWaitForLeaderTimeout = 15 * time.Second
 	DefaultCommitRetries        = 1
 	DefaultNetworkTimeout       = 10 * time.Second

--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -119,6 +119,20 @@ func newRaftWrapper(
 // makeDataFolder creates the folder that is meant
 // to store Raft data.
 func makeDataFolder(folder string) error {
+	// TODO(hector): Remove raft datafolder migration hack
+	// in the future
+	baseDir := filepath.Dir(folder)
+	legacyFolder := filepath.Join(baseDir, "ipfs-cluster-data")
+
+	if _, err := os.Stat(legacyFolder); err == nil {
+		// legacy data folder exists. Rename
+		logger.Warningf("Renaming legacy data folder: %s -> %s", legacyFolder, folder)
+		err := os.Rename(legacyFolder, folder)
+		if err != nil {
+			return err
+		}
+	}
+
 	err := os.MkdirAll(folder, 0700)
 	if err != nil {
 		return err

--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -72,7 +72,7 @@ test_cluster_init() {
         echo "cluster init FAIL: error on ipfs cluster init"
         exit 1
     fi
-    rm -rf "test-config/ipfs-cluster-data"
+    rm -rf "test-config/raft"
     if [ -n "$custom_config_files" ]; then
         cp -f ${custom_config_files}/* "test-config"
     fi

--- a/sharness/t0051-service-state-upgrade-from-old.sh
+++ b/sharness/t0051-service-state-upgrade-from-old.sh
@@ -18,7 +18,7 @@ test_expect_success IPFS,CLUSTER,V1STATE,JQ "cluster-service loads v1 state corr
      ipfs-cluster-ctl pin add "$cid2" &&
      cluster_kill &&
      sleep 15 &&
-     SNAP_DIR=`find test-config/ipfs-cluster-data/snapshots/ -maxdepth 1 -mindepth 1 | head -n 1` &&
+     SNAP_DIR=`find test-config/raft/snapshots/ -maxdepth 1 -mindepth 1 | head -n 1` &&
      cp v1State "$SNAP_DIR/state.bin" &&
      cat "$SNAP_DIR/meta.json" | jq --arg CRC "$V1_CRC" '"'"'.CRC = $CRC'"'"' > tmp.json &&
      cp tmp.json "$SNAP_DIR/meta.json" &&


### PR DESCRIPTION
The ipfs-cluster-data folder is renamed to Raft, as it contains Raft data.

This has been bugging me for a while.