### PR TITLE
fix #428: Use a regexp to match for indirect status in IPFSPinStatusF…

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -10,10 +10,10 @@ package api
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
-	"regexp"
 
 	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"

--- a/api/types.go
+++ b/api/types.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"regexp"
 
 	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
@@ -103,10 +104,12 @@ type IPFSPinStatus int
 // IPFSPinStatusFromString parses a string and returns the matching
 // IPFSPinStatus.
 func IPFSPinStatusFromString(t string) IPFSPinStatus {
+	// Since indirect statuses are of the form "indirect through <cid>", use a regexp to match
+	var ind, _ = regexp.MatchString("^indirect", t)
 	// TODO: This is only used in the http_connector to parse
 	// ipfs-daemon-returned values. Maybe it should be extended.
 	switch {
-	case t == "indirect":
+	case ind:
 		return IPFSPinStatusIndirect
 	case t == "direct":
 		return IPFSPinStatusDirect


### PR DESCRIPTION
…romString()

Since indirect pins are of the form `indirect through <cid>`, let's use
a regexp to match them instead of an equality operator.

License: MIT
Signed-off-by: Lilith McMullen <iggnsthe@live.com>