### PR TITLE
fix #423: Remove lock file when daemon force quits

### DIFF
--- a/ipfs-cluster-service/daemon.go
+++ b/ipfs-cluster-service/daemon.go
@@ -198,6 +198,7 @@ Note that this may corrupt the local cluster state.
 `)
 	case 3:
 		out("exiting cluster NOW")
+		locker.tryUnlock()
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
Fixes #423 by running `locker.tryUnlock()`

License: MIT
Signed-off-by: Lilith McMullen <iggnsthe@live.com>