### PR TITLE
Fix: API constants should explicit their type

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -32,7 +32,7 @@ var logger = logging.Logger("apitypes")
 // TrackerStatus values
 const (
 	// IPFSStatus should never take this value
-	TrackerStatusBug = iota
+	TrackerStatusBug TrackerStatus = iota
 	// The cluster node is offline or not responding
 	TrackerStatusClusterError
 	// An error occurred pinning
@@ -90,7 +90,7 @@ func TrackerStatusFromString(str string) TrackerStatus {
 
 // IPFSPinStatus values
 const (
-	IPFSPinStatusBug = iota
+	IPFSPinStatusBug IPFSPinStatus = iota
 	IPFSPinStatusError
 	IPFSPinStatusDirect
 	IPFSPinStatusRecursive


### PR DESCRIPTION
Otherwise, they are int. This forces API users to do manual variable
type declaration when initializing something to one of these constants

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>