### PR TITLE
Fix #465: Do not test coverage in forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ jobs:
         - make deps
         - go test -v -coverprofile=coverage.out -covermode=count ./...
     - script:
+        if: fork = false
         - go get -u github.com/mattn/goveralls
         - go get -u golang.org/x/tools/cmd/cover
         - make deps
         - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
-        if: fork = false
     - script:
         - go get -u github.com/mattn/goveralls
         - go get -u golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,19 @@ cache:
 
 install: true
 
+stages:
+  - name: coverage
+    if: fork = false
+
+jobs:
+  include:
+    - stage: coverage
+      script:
+        - go get -u github.com/mattn/goveralls
+        - go get -u golang.org/x/tools/cmd/cover
+        - make deps
+        - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+
 jobs:
   include:
     - stage: "build and test (1: tests (all) | 2: coverage | 3: tests (w/basic monitor) | 4: checks | 5: docker | 6: sharness)"
@@ -20,12 +33,6 @@ jobs:
         - go get -u golang.org/x/tools/cmd/cover
         - make deps
         - go test -v -coverprofile=coverage.out -covermode=count ./...
-    - script:
-        if: fork = false
-        - go get -u github.com/mattn/goveralls
-        - go get -u golang.org/x/tools/cmd/cover
-        - make deps
-        - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
     - script:
         - go get -u github.com/mattn/goveralls
         - go get -u golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,17 @@ install: true
 
 jobs:
   include:
-    - stage: "build and test (1: tests+coverage (all) | 2: tests (w/basic monitor) | 3: checks | 4: docker | 5: sharness)"
+    - stage: "build and test (1: tests (all) | 2: coverage | 3: tests (w/basic monitor) | 4: checks | 5: docker | 6: sharness)"
       script:
-        - go get -u github.com/mattn/goveralls
         - go get -u golang.org/x/tools/cmd/cover
         - make deps
         - go test -v -coverprofile=coverage.out -covermode=count ./...
+    - script:
+        - go get -u github.com/mattn/goveralls
+        - go get -u golang.org/x/tools/cmd/cover
+        - make deps
         - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+        if: fork = false
     - script:
         - go get -u github.com/mattn/goveralls
         - go get -u golang.org/x/tools/cmd/cover


### PR DESCRIPTION
PRs from forks of the repository consistently fail the Travis CI
testing, as they don't have access to the secure token. Fix to skip that
test if the PR is from a fork.

License: MIT
Signed-off-by: Lilith McMullen <iggnsthe@live.com>