### PR TITLE
As a User I want to deploy ipfs-cluster quickly in kubernetes so I can get stuff done

### DIFF
--- a/charts/ipfs-cluster/.helmignore
+++ b/charts/ipfs-cluster/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/ipfs-cluster/Chart.yaml
+++ b/charts/ipfs-cluster/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: ipfs-cluster
+version: 0.1.0

--- a/charts/ipfs-cluster/Chart.yaml
+++ b/charts/ipfs-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for Kubernetes
+description: ipfs-cluster helm chart 
 name: ipfs-cluster
 version: 0.1.0

--- a/charts/ipfs-cluster/templates/NOTES.txt
+++ b/charts/ipfs-cluster/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ipfs-cluster.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "ipfs-cluster.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ipfs-cluster.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ipfs-cluster.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/ipfs-cluster/templates/NOTES.txt
+++ b/charts/ipfs-cluster/templates/NOTES.txt
@@ -1,19 +1,25 @@
-1. Get the application URL by running these commands:
+Congrats your ipfs-cluster is getting deployed...
+
+You will be able to access your ipfs-cluster by:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+  $ ipfs-cluster-ctl -l /dns4/{{ . }}{{ $.Values.ingress.path }}/tcp/9094
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ipfs-cluster.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  $ export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ipfs-cluster.fullname" . }}-bootstrap)
+  $ export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  $ ipfs-cluster-ctl -l /ip4/$NODE_IP/tcp/$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "ipfs-cluster.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ipfs-cluster.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  $ export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ipfs-cluster.fullname" . }}-bootstrap -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  $ ipfs-cluster-ctl -l /ip4/$SERVICE_IP/tcp/9094
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc -w {{ template "ipfs-cluster.fullname" . }}-bootstrap'
+
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ipfs-cluster.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  $ export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ipfs-cluster.name" . }}-bootstrap,release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  $ kubectl port-forward $POD_NAME 9094:9094 &
+  $ ipfs-cluster-ctl id
 {{- end }}
+
+Please be patient while all the components are getting deployed!

--- a/charts/ipfs-cluster/templates/_helpers.tpl
+++ b/charts/ipfs-cluster/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ipfs-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ipfs-cluster.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ipfs-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/ipfs-cluster/templates/bootstrap-service.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-service.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ipfs-cluster.fullname" . }}-bootstrap
+  labels:
+    app: {{ template "ipfs-cluster.name" . }}
+    chart: {{ template "ipfs-cluster.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: swarm
+      targetPort: swarm
+      port: 4001
+    - name: swarm-udp
+      targetPort: swarm-udp
+      port: 4002
+    - name: ws
+      targetPort: ws
+      port: 8081
+    - name: http
+      targetPort: http
+      port: 8080
+    - name: ipfs-cluster-4
+      targetPort: ipfs-cluster-4
+      port: 9094
+    - name: ipfs-cluster-5
+      targetPort: ipfs-cluster-5
+      port: 9095
+    - name: ipfs-cluster-6
+      targetPort: ipfs-cluster-6
+      port: 9096
+  selector:
+    app: {{ template "ipfs-cluster.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/ipfs-cluster/templates/bootstrap-service.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "ipfs-cluster.fullname" . }}-bootstrap
   labels:
-    app: {{ template "ipfs-cluster.name" . }}
+    app: {{ template "ipfs-cluster.name" . }}-bootstrap
     chart: {{ template "ipfs-cluster.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -32,5 +32,5 @@ spec:
       targetPort: ipfs-cluster-6
       port: 9096
   selector:
-    app: {{ template "ipfs-cluster.name" . }}
+    app: {{ template "ipfs-cluster.name" . }}-bootstrap
     release: {{ .Release.Name }}

--- a/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
           readinessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 7
+            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 15
           volumeMounts:

--- a/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: ipfs
-          image: "ipfs/go-ipfs:{{ .Values.image.tag }}"
+          image: "ipfs/go-ipfs:{{ .Values.image.ipfsTag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: swarm

--- a/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
@@ -65,6 +65,9 @@ spec:
         - name: ipfs-cluster
           image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ template "ipfs-cluster.fullname" . }}-env
           ports:
             - name: ipfs-cluster-4
               containerPort: 9094

--- a/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "ipfs-cluster.fullname" . }}-bootstrap
   labels:
-    app: {{ template "ipfs-cluster.name" . }}
+    app: {{ template "ipfs-cluster.name" . }}-bootstrap
     chart: {{ template "ipfs-cluster.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -12,12 +12,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "ipfs-cluster.name" . }}
+      app: {{ template "ipfs-cluster.name" . }}-bootstrap
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "ipfs-cluster.name" . }}
+        app: {{ template "ipfs-cluster.name" . }}-bootstrap
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "ipfs-cluster.fullname" . }}-bootstrap
+  labels:
+    app: {{ template "ipfs-cluster.name" . }}
+    chart: {{ template "ipfs-cluster.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  serviceName: {{ template "ipfs-cluster.fullname" . }}-bootstrap
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "ipfs-cluster.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "ipfs-cluster.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: ipfs
+          image: "ipfs/go-ipfs:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: swarm
+              protocol: TCP
+              containerPort: 4001
+            - name: swarm-udp
+              protocol: UDP
+              containerPort: 4002
+            - name: ws
+              protocol: TCP
+              containerPort: 8081
+            - name: http
+              protocol: TCP
+              containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: swarm
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 7
+            timeoutSeconds: 5
+            periodSeconds: 15
+          volumeMounts:
+            - mountPath: /data/ipfs
+              name: ipfs-storage
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+
+        - name: ipfs-cluster
+          image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: ipfs-cluster-4
+              containerPort: 9094
+              protocol: TCP
+            - name: ipfs-cluster-5
+              containerPort: 9095
+              protocol: TCP
+            - name: ipfs-cluster-6
+              containerPort: 9096
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 9094
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: 9094
+            initialDelaySeconds: 20
+            timeoutSeconds: 5
+            periodSeconds: 15
+          volumeMounts:
+            - mountPath: /data/ipfs-cluster
+              name: cluster-storage
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+
+
+  volumeClaimTemplates:
+    - metadata:
+        name: cluster-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: ipfs-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
@@ -105,7 +105,7 @@ spec:
         persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
         resources:
           requests:
-            storage: 1Gi
+            storage: {{ .Values.persistence.clusterSize }}
     - metadata:
         name: ipfs-storage
       spec:
@@ -113,7 +113,7 @@ spec:
         persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size }}
+            storage: {{ .Values.persistence.ipfsSize }}
 
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/bootstrap-statefulset.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "ipfs-cluster.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "5001"
+    prometheus.io/path: "debug/metrics/prometheus"
 spec:
   serviceName: {{ template "ipfs-cluster.fullname" . }}-bootstrap
   replicas: 1
@@ -31,6 +35,9 @@ spec:
             - name: swarm-udp
               protocol: UDP
               containerPort: 4002
+            - name: api
+              protocol: UDP
+              containerPort: 5001
             - name: ws
               protocol: TCP
               containerPort: 8081

--- a/charts/ipfs-cluster/templates/cluster-secret.yaml
+++ b/charts/ipfs-cluster/templates/cluster-secret.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "hera-instances.fullname" . }}-env
+  name: {{ template "ipfs-cluster.fullname" . }}-env
   labels:
-    app: {{ template "hera-instances.name" . }}
-    chart: {{ template "hera-instances.chart" . }}
+    app: {{ template "ipfs-cluster.name" . }}
+    chart: {{ template "ipfs-cluster.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/charts/ipfs-cluster/templates/cluster-secret.yaml
+++ b/charts/ipfs-cluster/templates/cluster-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "hera-instances.fullname" . }}-env
+  labels:
+    app: {{ template "hera-instances.name" . }}
+    chart: {{ template "hera-instances.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+{{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end -}}

--- a/charts/ipfs-cluster/templates/cluster-service.yaml
+++ b/charts/ipfs-cluster/templates/cluster-service.yaml
@@ -9,9 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-  {{- end }}
   ports:
     - name: swarm
       targetPort: swarm

--- a/charts/ipfs-cluster/templates/cluster-service.yaml
+++ b/charts/ipfs-cluster/templates/cluster-service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ipfs-cluster.fullname" . }}
+  labels:
+    app: {{ template "ipfs-cluster.name" . }}
+    chart: {{ template "ipfs-cluster.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: swarm
+      targetPort: swarm
+      port: 4001
+    - name: swarm-udp
+      targetPort: swarm-udp
+      port: 4002
+    - name: ws
+      targetPort: ws
+      port: 8081
+    - name: http
+      targetPort: http
+      port: 8080
+    - name: ipfs-cluster-4
+      targetPort: ipfs-cluster-4
+      port: 9094
+    - name: ipfs-cluster-5
+      targetPort: ipfs-cluster-5
+      port: 9095
+    - name: ipfs-cluster-6
+      targetPort: ipfs-cluster-6
+      port: 9096
+  selector:
+    app: {{ template "ipfs-cluster.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -14,6 +14,10 @@ data:
     echo "Erin an Lorenzo are sorry about this!"
   entrypoint.sh: |
     #!/bin/sh
+    # This is a custom entrypoint for k8s designed to connect to the bootstrap
+    # node running in the cluster. It has been set up using a configmap to
+    # allow changes on the fly.
+
     BOOTSTRAP_MULTIADDR=$(cat /data/ipfs-cluster/bootsrapp_id)
     BOOTSTRAP_ADDR=/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9094/ipfs/$BOOTSTRAP_MULTIADDR
 

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -7,11 +7,19 @@ data:
     #!/bin/sh
     set -e
     set -x
-    apk -U add curl jq sed
-    MULTIADDR=$(curl http://{{ template "ipfs-cluster.fullname" . }}-bootstrap:9094/id | jq .id -r)
-    echo "$MULTIADDR" > /data/ipfs-cluster/bootsrapp_id
-    # sed -i -e "s;\"bootstrap\": \[\];\"bootstrap\": [\"/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9096/ipfs/${MULTIADDR}\"];" /data/ipfs-cluster/service.json
     echo "Erin an Lorenzo are sorry about this!"
+    apk -U add curl jq sed
+
+    # ensures that the bootstrap_id file is not there
+    rm /data/ipfs-cluster/bootsrapp_id || true
+    # Tries to download the ID from the bootstrap node
+    curl http://{{ template "ipfs-cluster.fullname" . }}-bootstrap:9094/id | jq .id -r > /data/ipfs-cluster/bootsrapp_id
+
+    # If the file is not there, forces an exit 1, causing the initContainer to
+    # fail miserabily
+    if [ ! -f /data/ipfs-cluster/bootsrapp_id ]; then
+      exit 1
+    fi
   entrypoint.sh: |
     #!/bin/sh
     # This is a custom entrypoint for k8s designed to connect to the bootstrap

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -38,4 +38,4 @@ data:
 
     # Only ipfs user can get here
     ipfs-cluster-service --version
-    exec ipfs-cluster-service daemon --upgrade --bootstrap $BOOTSTRAP_ADDR
+    exec ipfs-cluster-service daemon --upgrade --bootstrap $BOOTSTRAP_ADDR --leave

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -9,6 +9,6 @@ data:
     set -x
     apk -U add curl jq sed
     MULTIADDR=$(curl http://{{ template "ipfs-cluster.fullname" . }}-bootstrap:9094/id | jq .id -r)
-    echo "$MULTIADDR" >> /data/ipfs-cluster/bootsrapp_id
+    echo "$MULTIADDR" > /data/ipfs-cluster/bootsrapp_id
     # sed -i -e "s;\"bootstrap\": \[\];\"bootstrap\": [\"/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9096/ipfs/${MULTIADDR}\"];" /data/ipfs-cluster/service.json
     echo "Erin an Lorenzo are sorry about this!"

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -5,6 +5,8 @@ metadata:
 data:
   bootstrap-script.sh: |
     #!/bin/sh
+    set -e
+    set -x
     apk -U add curl jq sed
     MULTIADDR=$(curl http://{{ template "ipfs-cluster.fullname" . }}-bootstrap:9094/id | jq .id -r)
     echo "$MULTIADDR" >> /data/ipfs-cluster/bootsrapp_id

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -7,7 +7,7 @@ data:
     #!/bin/sh
     set -e
     set -x
-    echo "Erin an Lorenzo are sorry about this!"
+    echo "Erin an Lorenzo are sorry about this! Please share some <3 "
     apk -U add curl jq sed
 
     # ensures that the bootstrap_id file is not there

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -12,3 +12,25 @@ data:
     echo "$MULTIADDR" > /data/ipfs-cluster/bootsrapp_id
     # sed -i -e "s;\"bootstrap\": \[\];\"bootstrap\": [\"/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9096/ipfs/${MULTIADDR}\"];" /data/ipfs-cluster/service.json
     echo "Erin an Lorenzo are sorry about this!"
+  entrypoint.sh: |
+    #!/bin/sh
+    BOOTSTRAP_MULTIADDR=$(cat /data/ipfs-cluster/bootsrapp_id)
+    BOOTSTRAP_ADDR=/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9094/ipfs/$BOOTSTRAP_MULTIADDR
+
+    set -e
+    user=ipfs
+
+    if [ -n "$DOCKER_DEBUG" ]; then
+       set -x
+    fi
+
+    if [ `id -u` -eq 0 ]; then
+        echo "Changing user to $user"
+        # ensure directories are writable
+        su-exec "$user" test -w "${IPFS_CLUSTER_PATH}" || chown -R -- "$user" "${IPFS_CLUSTER_PATH}"
+        exec su-exec "$user" "$0" $@
+    fi
+
+    # Only ipfs user can get here
+    ipfs-cluster-service --version
+    exec ipfs-cluster-service daemon --upgrade --bootstrap $BOOTSTRAP_ADDR

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -19,20 +19,13 @@ data:
     # allow changes on the fly.
 
     BOOTSTRAP_MULTIADDR=$(cat /data/ipfs-cluster/bootsrapp_id)
-    BOOTSTRAP_ADDR=/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9094/ipfs/$BOOTSTRAP_MULTIADDR
+    BOOTSTRAP_ADDR=/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9096/ipfs/$BOOTSTRAP_MULTIADDR
 
     set -e
     user=ipfs
 
     if [ -n "$DOCKER_DEBUG" ]; then
        set -x
-    fi
-
-    if [ `id -u` -eq 0 ]; then
-        echo "Changing user to $user"
-        # ensure directories are writable
-        su-exec "$user" test -w "${IPFS_CLUSTER_PATH}" || chown -R -- "$user" "${IPFS_CLUSTER_PATH}"
-        exec su-exec "$user" "$0" $@
     fi
 
     # Only ipfs user can get here

--- a/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
+++ b/charts/ipfs-cluster/templates/cluster-setup-confmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "ipfs-cluster.fullname" . }}-set-bootstrap-conf
+data:
+  bootstrap-script.sh: |
+    #!/bin/sh
+    apk -U add curl jq sed
+    MULTIADDR=$(curl http://{{ template "ipfs-cluster.fullname" . }}-bootstrap:9094/id | jq .id -r)
+    echo "$MULTIADDR" >> /data/ipfs-cluster/bootsrapp_id
+    # sed -i -e "s;\"bootstrap\": \[\];\"bootstrap\": [\"/dns4/{{ template "ipfs-cluster.fullname" . }}-bootstrap/tcp/9096/ipfs/${MULTIADDR}\"];" /data/ipfs-cluster/service.json
+    echo "Erin an Lorenzo are sorry about this!"

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -59,13 +59,13 @@ spec:
           livenessProbe:
             tcpSocket:
               port: swarm
-            initialDelaySeconds: 5
+            initialDelaySeconds: 7
             timeoutSeconds: 5
             periodSeconds: 15
           readinessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 7
+            initialDelaySeconds: 15
             timeoutSeconds: 5
             periodSeconds: 15
           volumeMounts:

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -32,6 +32,9 @@ spec:
         - name: create-conf
           image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
           args: ["version"]
+          envFrom:
+            - secretRef:
+                name: {{ template "ipfs-cluster.fullname" . }}-env
           volumeMounts:
             - name: cluster-storage
               mountPath: /data/ipfs-cluster

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "ipfs-cluster.fullname" . }}
+  labels:
+    app: {{ template "ipfs-cluster.name" . }}
+    chart: {{ template "ipfs-cluster.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  serviceName: {{ template "ipfs-cluster.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "ipfs-cluster.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "ipfs-cluster.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: ipfs
+          image: "ipfs/go-ipfs:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: swarm
+              protocol: TCP
+              containerPort: 4001
+            - name: swarm-udp
+              protocol: UDP
+              containerPort: 4002
+            - name: ws
+              protocol: TCP
+              containerPort: 8081
+            - name: http
+              protocol: TCP
+              containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: swarm
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 20
+            timeoutSeconds: 5
+            periodSeconds: 15
+          volumeMounts:
+            - mountPath: /data/ipfs
+              name: ipfs-storage
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+
+        - name: ipfs-cluster
+          image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: ipfs-cluster-4
+              containerPort: 9094
+              protocol: TCP
+            - name: ipfs-cluster-5
+              containerPort: 9095
+              protocol: TCP
+            - name: ipfs-cluster-6
+              containerPort: 9096
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 9094
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: 9094
+            initialDelaySeconds: 20
+            timeoutSeconds: 5
+            periodSeconds: 15
+          volumeMounts:
+            - mountPath: /data/ipfs-cluster
+              name: cluster-storage
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+
+
+  volumeClaimTemplates:
+    - metadata:
+        name: cluster-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: ipfs-storage
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
               mountPath: /custom
       containers:
         - name: ipfs
-          image: "ipfs/go-ipfs:{{ .Values.image.tag }}"
+          image: "ipfs/go-ipfs:{{ .Values.image.ipfsTag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: swarm

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "ipfs-cluster.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "5001"
+    prometheus.io/path: "debug/metrics/prometheus"
 spec:
   serviceName: {{ template "ipfs-cluster.fullname" . }}
   {{- if gt .Values.replicaCount 1.0 }}
@@ -50,6 +54,9 @@ spec:
             - name: swarm-udp
               protocol: UDP
               containerPort: 4002
+            - name: api
+              protocol: TCP
+              containerPort: 5001
             - name: ws
               protocol: TCP
               containerPort: 8081

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -85,6 +85,9 @@ spec:
           image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "/custom/entrypoint.sh"]
+          envFrom:
+            - secretRef:
+                name: {{ template "hera-instances.fullname" . }}-env
           ports:
             - name: ipfs-cluster-4
               containerPort: 9094

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -9,7 +9,11 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   serviceName: {{ template "ipfs-cluster.fullname" . }}
+  {{- if gt .Values.replicaCount 1.0 }}
   replicas: {{ .Values.replicaCount }}
+  {{- else }}
+  replicas: 0
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "ipfs-cluster.name" . }}
@@ -20,6 +24,21 @@ spec:
         app: {{ template "ipfs-cluster.name" . }}
         release: {{ .Release.Name }}
     spec:
+      initContainers:
+        - name: create-conf
+          image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
+          volumeMounts:
+            - name: cluster-storage
+              mountPath: /data/ipfs-cluster
+          args: ["version"]
+        - name: get-bootstrap-multiaddr
+          image: "alpine:latest"
+          volumeMounts:
+            - name: cluster-storage
+              mountPath: /data/ipfs-cluster
+            - name: bootstrap-script
+              mountPath: /bootstrap-script.sh
+          command: ["sh", "/bootstrap-script.sh"]
       containers:
         - name: ipfs
           image: "ipfs/go-ipfs:{{ .Values.image.tag }}"
@@ -40,13 +59,13 @@ spec:
           livenessProbe:
             tcpSocket:
               port: swarm
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 15
           readinessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 20
+            initialDelaySeconds: 7
             timeoutSeconds: 5
             periodSeconds: 15
           volumeMounts:
@@ -85,6 +104,23 @@ spec:
               name: cluster-storage
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      volumes:
+      - name: bootstrap-script
+        configMap:
+          name: {{ template "ipfs-cluster.fullname" . }}-set-bootstrap-conf
+
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 
 
   volumeClaimTemplates:
@@ -104,16 +140,3 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size }}
-
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -77,6 +77,7 @@ spec:
         - name: ipfs-cluster
           image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "/custom/entrypoint.sh"]
           ports:
             - name: ipfs-cluster-4
               containerPort: 9094

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -87,7 +87,7 @@ spec:
           command: ["sh", "/custom/entrypoint.sh"]
           envFrom:
             - secretRef:
-                name: {{ template "hera-instances.fullname" . }}-env
+                name: {{ template "ipfs-cluster.fullname" . }}-env
           ports:
             - name: ipfs-cluster-4
               containerPort: 9094

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -27,18 +27,18 @@ spec:
       initContainers:
         - name: create-conf
           image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
+          args: ["version"]
           volumeMounts:
             - name: cluster-storage
               mountPath: /data/ipfs-cluster
-          args: ["version"]
         - name: get-bootstrap-multiaddr
           image: "alpine:latest"
+          command: ["sh", "/custom/bootstrap-script.sh"]
           volumeMounts:
             - name: cluster-storage
               mountPath: /data/ipfs-cluster
             - name: bootstrap-script
-              mountPath: /bootstrap-script.sh
-          command: ["sh", "/bootstrap-script.sh"]
+              mountPath: /custom
       containers:
         - name: ipfs
           image: "ipfs/go-ipfs:{{ .Values.image.tag }}"
@@ -102,6 +102,8 @@ spec:
           volumeMounts:
             - mountPath: /data/ipfs-cluster
               name: cluster-storage
+            - name: bootstrap-script
+              mountPath: /custom
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/charts/ipfs-cluster/templates/cluster-statefulset.yaml
+++ b/charts/ipfs-cluster/templates/cluster-statefulset.yaml
@@ -12,7 +12,11 @@ metadata:
     prometheus.io/port: "5001"
     prometheus.io/path: "debug/metrics/prometheus"
 spec:
+  # Deploy this in parallel
+  podManagementPolicy: Parallel
   serviceName: {{ template "ipfs-cluster.fullname" . }}
+  # If we have one single node, just use the bootstrap node and scale This
+  # to 0 replicas.
   {{- if gt .Values.replicaCount 1.0 }}
   replicas: {{ .Values.replicaCount }}
   {{- else }}
@@ -28,6 +32,12 @@ spec:
         app: {{ template "ipfs-cluster.name" . }}
         release: {{ .Release.Name }}
     spec:
+      # Init containers are used to prepare the clusters:
+      # The firest container `create-conf` will just ensure that the
+      # service.json is populated
+      # The second container `get-bootstrap-multiaddr` will run a custom script
+      # designed to extract the multiaddr of the bootstrap node in order to
+      # connect to it. Plz check the config map to know more how it works.
       initContainers:
         - name: create-conf
           image: "ipfs/ipfs-cluster:{{ .Values.image.tag }}"
@@ -147,7 +157,7 @@ spec:
         persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
         resources:
           requests:
-            storage: 1Gi
+            storage: {{ .Values.persistence.clusterSize }}
     - metadata:
         name: ipfs-storage
       spec:
@@ -155,4 +165,4 @@ spec:
         persistentVolumeReclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size }}
+            storage: {{ .Values.persistence.ipfsSize }}

--- a/charts/ipfs-cluster/templates/ingress.yaml
+++ b/charts/ipfs-cluster/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ipfs-cluster.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "ipfs-cluster.name" . }}
+    chart: {{ template "ipfs-cluster.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/ipfs-cluster/values.yaml
+++ b/charts/ipfs-cluster/values.yaml
@@ -8,6 +8,9 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+secretEnv:
+  CLUSTER_SECRET: CHANGE_ME_OK?
+
 service:
   type: LoadBalancer
 

--- a/charts/ipfs-cluster/values.yaml
+++ b/charts/ipfs-cluster/values.yaml
@@ -1,0 +1,47 @@
+# Default values for ipfs-cluster.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: LoadBalancer
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+persistence:
+  reclaimPolicy: Retain
+  size: 10Gi
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/ipfs-cluster/values.yaml
+++ b/charts/ipfs-cluster/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 image:
   tag: latest
+  ipfsTag: latest
   pullPolicy: IfNotPresent
 
 secretEnv:

--- a/charts/ipfs-cluster/values.yaml
+++ b/charts/ipfs-cluster/values.yaml
@@ -1,7 +1,5 @@
-# Default values for ipfs-cluster.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
+# How many nodes do we want to set up? If bigger than 1 it will deploy a
+# bootstrap node need for raft.
 replicaCount: 1
 
 image:
@@ -9,6 +7,7 @@ image:
   ipfsTag: latest
   pullPolicy: IfNotPresent
 
+# Insert here the secret environment that will be used by ipfs-cluster
 secretEnv:
   CLUSTER_SECRET: CHANGE_ME_OK?
 
@@ -22,15 +21,18 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   path: /
   hosts:
-    - chart-example.local
+    - ipfs.rocks
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
 persistence:
-  reclaimPolicy: Retain
-  size: 10Gi
+  reclaimPolicy: Delete
+  # ClusterSize specifies the persistent volume size for ipfs-cluster data
+  clusterSize: 1Gi
+  # ClusterSize specifies the persistent volume size for go-ipfs data
+  ipfsSize: 10Gi
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -28,6 +28,11 @@ else
         sed -i "s;/ip4/127\.0\.0\.1/tcp/5001;$IPFS_API;" "${IPFS_CLUSTER_PATH}/service.json"
     fi
 
+    # If CLUSTER_BOOTSTRAP is defined, add the value in the service.json
+    if [ ! -z "$CLUSTER_BOOTSTRAP" ]; then
+      sed -i -e "s;\"bootstrap\": \[\];\"bootstrap\": [\"${CLUSTER_BOOTSTRAP}\"];" "${IPFS_CLUSTER_PATH}/service.json"
+    fi
+
     echo "Warning: By default, the API and Proxy endpoints will listen on 0.0.0.0!"
     sed -i 's;127\.0\.0\.1/tcp/9094;0.0.0.0/tcp/9094;' "${IPFS_CLUSTER_PATH}/service.json"
     sed -i 's;127\.0\.0\.1/tcp/9095;0.0.0.0/tcp/9095;' "${IPFS_CLUSTER_PATH}/service.json"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -28,11 +28,6 @@ else
         sed -i "s;/ip4/127\.0\.0\.1/tcp/5001;$IPFS_API;" "${IPFS_CLUSTER_PATH}/service.json"
     fi
 
-    # If CLUSTER_BOOTSTRAP is defined, add the value in the service.json
-    if [ ! -z "$CLUSTER_BOOTSTRAP" ]; then
-      sed -i -e "s;\"bootstrap\": \[\];\"bootstrap\": [\"${CLUSTER_BOOTSTRAP}\"];" "${IPFS_CLUSTER_PATH}/service.json"
-    fi
-
     echo "Warning: By default, the API and Proxy endpoints will listen on 0.0.0.0!"
     sed -i 's;127\.0\.0\.1/tcp/9094;0.0.0.0/tcp/9094;' "${IPFS_CLUSTER_PATH}/service.json"
     sed -i 's;127\.0\.0\.1/tcp/9095;0.0.0.0/tcp/9095;' "${IPFS_CLUSTER_PATH}/service.json"


### PR DESCRIPTION
Hello!
Here is my small contribution to enable a **helm chart to deploy ipfs-cluster on kubernetes**.
I am not sure where I should write a small how-to / quick intro, but I hope to showcase this tomorrow during the dev meeting. Some of this code has been adapted from Siderus' custom helm chart: _giving back to the community is important_ 😉

To quickly play with this:

0. Grab a k8s cluster (suggested Docker Edge for Mac / Windows, and enables kubernetes)
1. Install [helm](https://helm.sh) - and run `helm init --upgrade` from your fav shell 
2. Run:

```
helm upgrade --install siderus-ipfs-cluster ./charts/ipfs-cluster --recreate-pods \
    --set replicaCount=2 \
    --set secretEnv.CLUSTER_SECRET=$(openssl rand -hex 32)
```
Where `replicaCount` will define how many ipfs nodes should be deployed. Alternatively you can specify your own values in a file. Wait ~30 seconds, it depends from the cloud provider and the configuration of your own kubernetes cluster, but min is 25 seconds.

You can just check out the status by running:
```
kubectl get pods -w
```

Once the bootstrap node is running you can already follow the instructions in the output of the helm command to connect to the ipfs-cluster. If you are running on Docker Edge for Mac / Windows, you don't need to specify a custom host on `ipfs-cluster-ctl` as the type `LoadBalancer` is bound to localhost (aka, just run `ipfs-cluster-ctl` if you are on Docker Edge)

**NOTE**: Due to raft, if the amount of nodes are bigger than 1, it gets easier to deploy 1 extra bootstrap nodes. So if you want 2 nodes, this will set up 3 nodes (1 bootstrap + 2 actual nodes). This could be space for improvements for a next update.


@eefahy @hsanjuan 