### PR TITLE
Feat/rest/client: auto-handling of libp2p endpoints

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -42,7 +42,7 @@ type Config struct {
 	// (takes precedence over host:port). It this address contains
 	// an /ipfs/, /p2p/ or /dnsaddr, the API will be contacted
 	// through a libp2p tunnel, thus getting encryption for
-	// free. The latter overrides any SSL configurations.
+	// free. Using the libp2p tunnel will ignore any configurations.
 	APIAddr ma.Multiaddr
 
 	// PeerAddr is deprecated. It's aliased to APIAddr

--- a/api/rest/client/client_test.go
+++ b/api/rest/client/client_test.go
@@ -79,7 +79,7 @@ func testClientHTTP(t *testing.T, api *rest.API) *Client {
 
 func testClientLibp2p(t *testing.T, api *rest.API) *Client {
 	cfg := &Config{
-		PeerAddr:          peerMAddr(api),
+		APIAddr:           peerMAddr(api),
 		ProtectorKey:      make([]byte, 32),
 		DisableKeepAlives: true,
 	}
@@ -187,14 +187,12 @@ func TestDNSMultiaddress(t *testing.T) {
 }
 
 func TestPeerAddress(t *testing.T) {
-	addr2, _ := ma.NewMultiaddr("/dns4/localhost/tcp/1234")
 	peerAddr, _ := ma.NewMultiaddr("/dns4/localhost/tcp/1234/ipfs/QmP7R7gWEnruNePxmCa9GBa4VmUNexLVnb1v47R8Gyo3LP")
 	cfg := &Config{
-		APIAddr:           addr2,
+		APIAddr:           peerAddr,
 		Host:              "localhost",
 		Port:              "9094",
 		DisableKeepAlives: true,
-		PeerAddr:          peerAddr,
 	}
 	c, err := NewClient(cfg)
 	if err != nil {

--- a/api/rest/client/transports.go
+++ b/api/rest/client/transports.go
@@ -41,7 +41,7 @@ func (c *Client) defaultTransport() {
 func (c *Client) enableLibp2p() error {
 	c.defaultTransport()
 
-	pid, addr, err := api.Libp2pMultiaddrSplit(c.config.PeerAddr)
+	pid, addr, err := api.Libp2pMultiaddrSplit(c.config.APIAddr)
 	if err != nil {
 		return err
 	}

--- a/ipfs-cluster-ctl/main.go
+++ b/ipfs-cluster-ctl/main.go
@@ -140,24 +140,16 @@ requires authorization. implies --https, which you can disable with --force-http
 		addr, err := ma.NewMultiaddr(c.String("host"))
 		checkErr("parsing host multiaddress", err)
 
-		// Is this a peer address?
-		pid, err := addr.ValueForProtocol(ma.P_IPFS)
-		if pid != "" && err == nil {
-			logger.Debugf("Using libp2p-http to %s", addr)
-			cfg.PeerAddr = addr
-			if hexSecret := c.String("secret"); hexSecret != "" {
-				secret, err := hex.DecodeString(hexSecret)
-				checkErr("parsing secret", err)
-				cfg.ProtectorKey = secret
-			}
-		} else {
-			logger.Debugf("Using http(s) to %s", addr)
-			cfg.APIAddr = addr
+		cfg.APIAddr = addr
+		if hexSecret := c.String("secret"); hexSecret != "" {
+			secret, err := hex.DecodeString(hexSecret)
+			checkErr("parsing secret", err)
+			cfg.ProtectorKey = secret
 		}
 
 		cfg.Timeout = time.Duration(c.Int("timeout")) * time.Second
 
-		if cfg.PeerAddr != nil && c.Bool("https") {
+		if client.IsPeerAddress(cfg.APIAddr) && c.Bool("https") {
 			logger.Warning("Using libp2p-http. SSL flags will be ignored")
 		}
 


### PR DESCRIPTION
This removes PeerAddr and uses APIAddr directly, figuring out if it is
a Peer multiaddress or not.

PeerAddr is actually kept for compatiblity.

It also fixes a bad panic when resolving returned 0 results

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>