### PR TITLE
Fix: TestClustersPeerRejoin was failing a lot since DHT feature.

### DIFF
--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -535,7 +535,7 @@ func TestClustersPeerRejoin(t *testing.T) {
 
 	// add all clusters
 	for i := 1; i < len(clusters); i++ {
-		_, err := clusters[0].PeerAdd(clusters[i].id)
+		err := clusters[i].Join(clusterAddr(clusters[0]))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This uses Join rather than PeerAdd. Join ensures a DHT bootstrap
after successfully joining.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>