### PR TITLE
Fix #466: Hijack repo/stat in the proxy and return aggregates from the cluster

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -888,3 +888,9 @@ type Error struct {
 func (e *Error) Error() string {
 	return fmt.Sprintf("%s (%d)", e.Message, e.Code)
 }
+
+// IPFSRepoStat wraps information about the IPFS repository.
+type IPFSRepoStat struct {
+	RepoSize   uint64
+	StorageMax uint64
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -98,10 +98,12 @@ func (ipfs *mockConnector) SwarmPeers() (api.SwarmPeers, error) {
 	return []peer.ID{test.TestPeerID4, test.TestPeerID5}, nil
 }
 
+func (ipfs *mockConnector) RepoStat() (api.IPFSRepoStat, error) {
+	return api.IPFSRepoStat{RepoSize: 100, StorageMax: 1000}, nil
+}
+
 func (ipfs *mockConnector) ConnectSwarms() error                          { return nil }
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
-func (ipfs *mockConnector) FreeSpace() (uint64, error)                    { return 100, nil }
-func (ipfs *mockConnector) RepoSize() (uint64, error)                     { return 0, nil }
 
 func (ipfs *mockConnector) BlockPut(nwm api.NodeWithMeta) error {
 	ipfs.blocks.Store(nwm.Cid, nwm.Data)

--- a/informer/disk/config.go
+++ b/informer/disk/config.go
@@ -60,7 +60,7 @@ func (cfg *Config) Validate() error {
 		return errors.New("disk.metric_ttl is invalid")
 	}
 
-	if _, ok := metricToRPC[cfg.Type]; !ok {
+	if cfg.Type.String() == "" {
 		return errors.New("disk.metric_type is invalid")
 	}
 	return nil

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -7,11 +7,11 @@ import (
 
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 
+	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"
 )
 
 type badRPCService struct {
-	nthCall int
 }
 
 func badRPCClient(t *testing.T) *rpc.Client {
@@ -24,35 +24,7 @@ func badRPCClient(t *testing.T) *rpc.Client {
 	return c
 }
 
-// func (mock *badRPCService) IPFSConfigKey(in string, out *interface{}) error {
-// 	mock.nthCall++
-// 	switch mock.nthCall {
-// 	case 1:
-// 		return errors.New("fake error the first time you use this mock")
-// 	case 2:
-// 		// don't set out
-// 		return nil
-// 	case 3:
-// 		// don't set to string
-// 		*out = 3
-// 	case 4:
-// 		// non parseable string
-// 		*out = "abc"
-// 	default:
-// 		*out = "10KB"
-// 	}
-// 	return nil
-// }
-
-func (mock *badRPCService) IPFSRepoSize(ctx context.Context, in struct{}, out *uint64) error {
-	*out = 2
-	mock.nthCall++
-	return errors.New("fake error")
-}
-
-func (mock *badRPCService) IPFSFreeSpace(ctx context.Context, in struct{}, out *uint64) error {
-	*out = 2
-	mock.nthCall++
+func (mock *badRPCService) IPFSRepoStat(ctx context.Context, in struct{}, out *api.IPFSRepoStat) error {
 	return errors.New("fake error")
 }
 

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -84,12 +84,9 @@ type IPFSConnector interface {
 	// ConfigKey returns the value for a configuration key.
 	// Subobjects are reached with keypaths as "Parent/Child/GrandChild...".
 	ConfigKey(keypath string) (interface{}, error)
-	// FreeSpace returns the amount of remaining space on the repo, calculated from
-	//"repo stat"
-	FreeSpace() (uint64, error)
-	// RepoSize returns the current repository size as expressed
-	// by "repo stat".
-	RepoSize() (uint64, error)
+	// RepoStat returns the current repository size and max limit as
+	// provided by "repo stat".
+	RepoStat() (api.IPFSRepoStat, error)
 	// BlockPut directly adds a block of data to the IPFS repo
 	BlockPut(api.NodeWithMeta) error
 	// BlockGet retrieves the raw data of an IPFS block

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmSXkfCpd7nWZahenZ544zsJV29VPooaJnQZfKu5qgga8E",
+      "hash": "QmW56LEPdtdETprHG5h5qcJpp6qNYuytzyqbEctGdbGfSF",
       "name": "go-libp2p-gorpc",
-      "version": "1.0.16"
+      "version": "1.0.17"
     },
     {
       "author": "libp2p",

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -322,16 +322,9 @@ func (rpcapi *RPCAPI) IPFSConfigKey(ctx context.Context, in string, out *interfa
 	return err
 }
 
-// IPFSFreeSpace runs IPFSConnector.FreeSpace().
-func (rpcapi *RPCAPI) IPFSFreeSpace(ctx context.Context, in struct{}, out *uint64) error {
-	res, err := rpcapi.c.ipfs.FreeSpace()
-	*out = res
-	return err
-}
-
-// IPFSRepoSize runs IPFSConnector.RepoSize().
-func (rpcapi *RPCAPI) IPFSRepoSize(ctx context.Context, in struct{}, out *uint64) error {
-	res, err := rpcapi.c.ipfs.RepoSize()
+// IPFSRepoStat runs IPFSConnector.RepoStat().
+func (rpcapi *RPCAPI) IPFSRepoStat(ctx context.Context, in struct{}, out *api.IPFSRepoStat) error {
+	res, err := rpcapi.c.ipfs.RepoStat()
 	*out = res
 	return err
 }

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -392,15 +392,13 @@ func (mock *mockService) IPFSConfigKey(ctx context.Context, in string, out *inte
 	return nil
 }
 
-func (mock *mockService) IPFSRepoSize(ctx context.Context, in struct{}, out *uint64) error {
-	// since we have two pins. Assume each is 1KB.
-	*out = 2000
-	return nil
-}
-
-func (mock *mockService) IPFSFreeSpace(ctx context.Context, in struct{}, out *uint64) error {
-	// RepoSize is 2KB, StorageMax is 100KB
-	*out = 98000
+func (mock *mockService) IPFSRepoStat(ctx context.Context, in struct{}, out *api.IPFSRepoStat) error {
+	// since we have two pins. Assume each is 1000B.
+	stat := api.IPFSRepoStat{
+		StorageMax: 100000,
+		RepoSize:   2000,
+	}
+	*out = stat
 	return nil
 }
 


### PR DESCRIPTION
Removes IPFSRepoSize and IPFSFreeSpace methods, consolidates them in IPFSRepoStat().

#466