### PR TITLE
Gx-go 1.8.0 it's WAY faster.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 gx_version=v0.13.0
-gx-go_version=v1.7.0
+gx-go_version=v1.8.0
 
 deptools=deptools
 


### PR DESCRIPTION
License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>