### PR TITLE
speed up building docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ deptools
 sharness/lib/sharness
 sharness/test-results
 sharness/trash*
+vendor/
 
 raftFolderFromTest*
 peerstore

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
 
 COPY . $SRC_PATH
 WORKDIR $SRC_PATH
-RUN make install
+RUN make docker_install
 
 ENV SUEXEC_VERSION v0.2
 ENV TINI_VERSION v0.16.1

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ install: deps
 	$(MAKE) -C ipfs-cluster-service install
 	$(MAKE) -C ipfs-cluster-ctl install
 
+docker_install: docker_deps
+	$(MAKE) -C ipfs-cluster-service install
+	$(MAKE) -C ipfs-cluster-ctl install
+
 build: deps
 	go build -ldflags "-X ipfscluster.Commit=$(shell git rev-parse HEAD)"
 	$(MAKE) -C ipfs-cluster-service build
@@ -62,6 +66,13 @@ gx: $(gx_bin) $(gx-go_bin)
 
 deps: gx
 	$(gx_bin) install --global
+	$(gx-go_bin) rewrite
+
+# Run this target before building the docker image 
+# and then gx won't attempt to pull all deps 
+# from the network each time
+docker_deps: gx
+	$(gx_bin) install --local
 	$(gx-go_bin) rewrite
 
 check:


### PR DESCRIPTION
By using gx install --local, deps are copied into
the build context and therefore only stale deps
will get pulled from the network on image build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ipfs/ipfs-cluster/529)
<!-- Reviewable:end -->
