### PR TITLE
Update go-dot: Fix field type

### DIFF
--- a/ipfs-cluster-ctl/graph.go
+++ b/ipfs-cluster-ctl/graph.go
@@ -74,7 +74,7 @@ type dotWriter struct {
 	ipfsNodes    map[string]*dot.VertexDescription
 
 	w        io.Writer
-	dotGraph dot.DotGraph
+	dotGraph dot.Graph
 
 	ipfsEdges        map[string][]string
 	clusterEdges     map[string][]string


### PR DESCRIPTION
"github.com/zenground0/go-dot" defined the type as `Graph`, not `DotGraph`