### PR TITLE
Issue #536 New make target for PR check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,4 +108,6 @@ docker:
 	docker exec tmp-make-cluster-test sh -c "ipfs-cluster-service -v"
 	docker kill tmp-make-cluster-test
 
+prcheck: deps check service ctl test intall test_sharness
+
 .PHONY: all gx deps test test_sharness clean_sharness rw rwundo publish service ctl install clean gx-clean docker

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ problematic_test = TestClustersReplicationRealloc
 
 export PATH := $(deptools):$(PATH)
 
-all: service ctl
+all: build
 clean: rwundo clean_sharness
 	$(MAKE) -C ipfs-cluster-service clean
 	$(MAKE) -C ipfs-cluster-ctl clean

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,6 @@ docker:
 	docker exec tmp-make-cluster-test sh -c "ipfs-cluster-service -v"
 	docker kill tmp-make-cluster-test
 
-prcheck: deps check service ctl test install test_sharness
+prcheck: deps check service ctl test
 
 .PHONY: all gx deps test test_sharness clean_sharness rw rwundo publish service ctl install clean gx-clean docker

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,6 @@ docker:
 	docker exec tmp-make-cluster-test sh -c "ipfs-cluster-service -v"
 	docker kill tmp-make-cluster-test
 
-prcheck: deps check service ctl test intall test_sharness
+prcheck: deps check service ctl test install test_sharness
 
 .PHONY: all gx deps test test_sharness clean_sharness rw rwundo publish service ctl install clean gx-clean docker


### PR DESCRIPTION
This PR adds a single make target that can run and check if I am
ready to push my PR, i.e, `make prcheck`

Fixes #536 