### PR TITLE
Allow running peers with different cluster versions in the same cluster

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -99,11 +99,7 @@ func NewCluster(
 		listenAddrs += fmt.Sprintf("        %s/ipfs/%s\n", addr, host.ID().Pretty())
 	}
 
-	if c := Commit; len(c) >= 8 {
-		logger.Infof("IPFS Cluster v%s-%s listening on:\n%s\n", Version, Commit[0:8], listenAddrs)
-	} else {
-		logger.Infof("IPFS Cluster v%s listening on:\n%s\n", Version, listenAddrs)
-	}
+	logger.Infof("IPFS Cluster v%s listening on:\n%s\n", Version, listenAddrs)
 
 	// Note, we already loaded peers from peerstore into the host
 	// in daemon.go.
@@ -529,8 +525,7 @@ func (c *Cluster) ID() api.ID {
 		Addresses:             addrs,
 		ClusterPeers:          peers,
 		ClusterPeersAddresses: c.peerManager.PeersAddresses(peers),
-		Version:               Version,
-		Commit:                Commit,
+		Version:               Version.String(),
 		RPCProtocolVersion:    RPCProtocol,
 		IPFS:                  ipfsID,
 		Peername:              c.config.Peername,
@@ -1082,7 +1077,7 @@ func (c *Cluster) AddFile(reader *multipart.Reader, params *api.AddParams) (cid.
 
 // Version returns the current IPFS Cluster version.
 func (c *Cluster) Version() string {
-	return Version
+	return Version.String()
 }
 
 // Peers returns the IDs of the members of this Cluster.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -225,7 +225,7 @@ func TestClusterID(t *testing.T) {
 	if id.ID == "" {
 		t.Error("expected a cluster ID")
 	}
-	if id.Version != Version {
+	if id.Version != Version.String() {
 		t.Error("version should match current version")
 	}
 	//if id.PublicKey == nil {
@@ -771,7 +771,7 @@ func TestVersion(t *testing.T) {
 	cl, _, _, _, _ := testingCluster(t)
 	defer cleanRaft()
 	defer cl.Shutdown()
-	if cl.Version() != Version {
+	if cl.Version() != Version.String() {
 		t.Error("bad Version()")
 	}
 }

--- a/ipfs-cluster-service/main.go
+++ b/ipfs-cluster-service/main.go
@@ -11,11 +11,12 @@ import (
 
 	//	_ "net/http/pprof"
 
-	logging "github.com/ipfs/go-log"
-	cli "github.com/urfave/cli"
-
 	ipfscluster "github.com/ipfs/ipfs-cluster"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
+
+	semver "github.com/blang/semver"
+	logging "github.com/ipfs/go-log"
+	cli "github.com/urfave/cli"
 )
 
 // ProgramName of this application
@@ -109,8 +110,10 @@ var (
 )
 
 func init() {
-	// Set the right commit. The only way I could make this work
-	ipfscluster.Commit = commit
+	// Set build information.
+	if build, err := semver.NewBuildVersion(commit); err == nil {
+		ipfscluster.Version.Build = []string{"git" + build}
+	}
 
 	// We try guessing user's home from the HOME variable. This
 	// allows HOME hacks for things like Snapcraft builds. HOME
@@ -156,7 +159,7 @@ func main() {
 	app.Usage = "IPFS Cluster node"
 	app.Description = Description
 	//app.Copyright = "© Protocol Labs, Inc."
-	app.Version = ipfscluster.Version
+	app.Version = ipfscluster.Version.String()
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "config, c",
@@ -405,11 +408,6 @@ the mth data folder (m currently defaults to 5)
 			Name:  "version",
 			Usage: "Print the ipfs-cluster version",
 			Action: func(c *cli.Context) error {
-				if c := ipfscluster.Commit; len(c) >= 8 {
-					fmt.Printf("%s-%s\n", ipfscluster.Version, c)
-					return nil
-				}
-
 				fmt.Printf("%s\n", ipfscluster.Version)
 				return nil
 			},

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -17,11 +17,7 @@ import (
 	rpc "github.com/hsanjuan/go-libp2p-gorpc"
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-peer"
-	protocol "github.com/libp2p/go-libp2p-protocol"
 )
-
-// RPCProtocol is used to send libp2p messages between cluster peers
-var RPCProtocol = protocol.ID("/ipfscluster/" + Version + "/rpc")
 
 // Component represents a piece of ipfscluster. Cluster components
 // usually run their own goroutines (a http server for example). They

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -385,7 +385,7 @@ func TestClustersVersion(t *testing.T) {
 	defer shutdownClusters(t, clusters, mock)
 	f := func(t *testing.T, c *Cluster) {
 		v := c.Version()
-		if v != Version {
+		if v != Version.String() {
 			t.Error("Bad version")
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -147,6 +147,12 @@
       "hash": "QmRkrpnhZqDxTxwGCsDbuZMr7uCFZHH6SGfrcjgEQwxF3t",
       "name": "go-mfs",
       "version": "0.1.1"
+    },
+    {
+      "author": "blang",
+      "hash": "QmYRGECuvQnRX73fcvPnGbYijBcGN2HbKZQ7jh26qmLiHG",
+      "name": "semver",
+      "version": "3.5.1"
     }
   ],
   "gxVersion": "0.11.0",

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ if [ -z $version ]; then
 fi
 
 make gx-clean
-sed -i "s/const Version.*$/const Version = \"$version\"/" version.go
+sed -i "s/Version = semver\.MustParse.*$/Version = semver.MustParse(\"$version\")/" version.go
 sed -i "s/const Version.*$/const Version = \"$version\"/" ipfs-cluster-ctl/main.go
 git commit -S -a -m "Release $version"
 lastver=`git tag -l | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1`

--- a/version.go
+++ b/version.go
@@ -1,8 +1,17 @@
 package ipfscluster
 
+import (
+	"fmt"
+
+	semver "github.com/blang/semver"
+	protocol "github.com/libp2p/go-libp2p-protocol"
+)
+
 // Version is the current cluster version. Version alignment between
 // components, apis and tools ensures compatibility among them.
-const Version = "0.5.0"
+var Version = semver.MustParse("0.5.0")
 
-// Commit is the current build commit of cluster. See Makefile.
-var Commit = "00000000" // actual commit set during builds.
+// RPCProtocol is used to send libp2p messages between cluster peers
+var RPCProtocol = protocol.ID(
+	fmt.Sprintf("/ipfscluster/%d.%d/rpc", Version.Major, Version.Minor),
+)


### PR DESCRIPTION
This patch modifies the RPC protocol tag to use Major and Minor parts of the
version and not all of it.

This means all peers on the 0.5.x can run in the same cluster.

As cluster has become more mature and I see less risks in letting peers from
similar versions run together. This is useful when upgrading too.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>