### PR TITLE
Fix #548: Re-enable keep-alives. Set Connection: Close when adding.

### DIFF
--- a/adder/adderutils/adderutils.go
+++ b/adder/adderutils/adderutils.go
@@ -44,6 +44,10 @@ func AddMultipartHTTPHandler(
 	w.Header().Add("Content-Type", "application/json")
 	// Browsers should not cache when streaming content.
 	w.Header().Add("Cache-Control", "no-cache")
+	// We need to ask the clients to close the connection
+	// (no keep-alive) of things break badly when adding.
+	// https://github.com/ipfs/go-ipfs-cmds/pull/116
+	w.Header().Set("Connection", "close")
 	w.WriteHeader(http.StatusOK)
 
 	var wg sync.WaitGroup

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -115,7 +115,9 @@ func NewAPIWithHost(cfg *Config, h host.Host) (*API, error) {
 	}
 
 	// See: https://github.com/ipfs/go-ipfs/issues/5168
-	s.SetKeepAlivesEnabled(false)
+	// See: https://github.com/ipfs/ipfs-cluster/issues/548
+	// on why this is re-enabled.
+	s.SetKeepAlivesEnabled(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -158,6 +158,8 @@ func NewConnector(cfg *Config) (*Connector, error) {
 	}
 
 	// See: https://github.com/ipfs/go-ipfs/issues/5168
+	// See: https://github.com/ipfs/ipfs-cluster/issues/548
+	// on why this is re-enabled.
 	s.SetKeepAlivesEnabled(false) // A reminder that this can be changed
 
 	c := &http.Client{} // timeouts are handled by context timeouts


### PR DESCRIPTION
This is a workaround to have clients behave properly with the /add
endpoint by asking them to close connections when done, effectively
disabling keep-alive for this.

This means we don't need to disable keep-alives fully on all servers,
since the rest of endpoints are not affected (they are not streaming
endpoints).

Reference https://github.com/ipfs/go-ipfs/issues/5168

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>