### PR TITLE
api/rest: change *cid.Cid to cid.Cid in client iface

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-ipfs-cmdkit/files"
+
 	"github.com/ipfs/ipfs-cluster/api"
 
 	cid "github.com/ipfs/go-cid"
@@ -46,7 +47,7 @@ type Client interface {
 	// PeerAdd adds a new peer to the cluster.
 	PeerAdd(pid peer.ID) (api.ID, error)
 	// PeerRm removes a current peer from the cluster
-	PeerRm(id peer.ID) error
+	PeerRm(pid peer.ID) error
 
 	// Add imports files to the cluster from the given paths.
 	Add(paths []string, params *api.AddParams, out chan<- *api.AddedOutput) error
@@ -55,20 +56,20 @@ type Client interface {
 
 	// Pin tracks a Cid with the given replication factor and a name for
 	// human-friendliness.
-	Pin(ci *cid.Cid, replicationFactorMin, replicationFactorMax int, name string) error
+	Pin(ci cid.Cid, replicationFactorMin, replicationFactorMax int, name string) error
 	// Unpin untracks a Cid from cluster.
-	Unpin(ci *cid.Cid) error
+	Unpin(ci cid.Cid) error
 
 	// Allocations returns the consensus state listing all tracked items
 	// and the peers that should be pinning them.
 	Allocations(filter api.PinType) ([]api.Pin, error)
 	// Allocation returns the current allocations for a given Cid.
-	Allocation(ci *cid.Cid) (api.Pin, error)
+	Allocation(ci cid.Cid) (api.Pin, error)
 
 	// Status returns the current ipfs state for a given Cid. If local is true,
 	// the information affects only the current peer, otherwise the information
 	// is fetched from all cluster peers.
-	Status(ci *cid.Cid, local bool) (api.GlobalPinInfo, error)
+	Status(ci cid.Cid, local bool) (api.GlobalPinInfo, error)
 	// StatusAll gathers Status() for all tracked items.
 	StatusAll(local bool) ([]api.GlobalPinInfo, error)
 
@@ -76,7 +77,7 @@ type Client interface {
 	// by the ipfs daemon, and returns it. If local is true, this operation
 	// only happens on the current peer, otherwise it happens on every
 	// cluster peer.
-	Sync(ci *cid.Cid, local bool) (api.GlobalPinInfo, error)
+	Sync(ci cid.Cid, local bool) (api.GlobalPinInfo, error)
 	// SyncAll triggers Sync() operations for all tracked items. It only
 	// returns informations for items that were de-synced or have an error
 	// state. If local is true, the operation is limited to the current
@@ -86,7 +87,7 @@ type Client interface {
 	// Recover retriggers pin or unpin ipfs operations for a Cid in error
 	// state.  If local is true, the operation is limited to the current
 	// peer, otherwise it happens on every cluster peer.
-	Recover(ci *cid.Cid, local bool) (api.GlobalPinInfo, error)
+	Recover(ci cid.Cid, local bool) (api.GlobalPinInfo, error)
 	// RecoverAll triggers Recover() operations on all tracked items. If
 	// local is true, the operation is limited to the current peer.
 	// Otherwise, it happens everywhere.

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -62,7 +62,7 @@ func (c *defaultClient) PeerRm(id peer.ID) error {
 
 // Pin tracks a Cid with the given replication factor and a name for
 // human-friendliness.
-func (c *defaultClient) Pin(ci *cid.Cid, replicationFactorMin, replicationFactorMax int, name string) error {
+func (c *defaultClient) Pin(ci cid.Cid, replicationFactorMin, replicationFactorMax int, name string) error {
 	escName := url.QueryEscape(name)
 	err := c.do(
 		"POST",
@@ -81,7 +81,7 @@ func (c *defaultClient) Pin(ci *cid.Cid, replicationFactorMin, replicationFactor
 }
 
 // Unpin untracks a Cid from cluster.
-func (c *defaultClient) Unpin(ci *cid.Cid) error {
+func (c *defaultClient) Unpin(ci cid.Cid) error {
 	return c.do("DELETE", fmt.Sprintf("/pins/%s", ci.String()), nil, nil, nil)
 }
 
@@ -118,7 +118,7 @@ func (c *defaultClient) Allocations(filter api.PinType) ([]api.Pin, error) {
 }
 
 // Allocation returns the current allocations for a given Cid.
-func (c *defaultClient) Allocation(ci *cid.Cid) (api.Pin, error) {
+func (c *defaultClient) Allocation(ci cid.Cid) (api.Pin, error) {
 	var pin api.PinSerial
 	err := c.do("GET", fmt.Sprintf("/allocations/%s", ci.String()), nil, nil, &pin)
 	return pin.ToPin(), err
@@ -127,7 +127,7 @@ func (c *defaultClient) Allocation(ci *cid.Cid) (api.Pin, error) {
 // Status returns the current ipfs state for a given Cid. If local is true,
 // the information affects only the current peer, otherwise the information
 // is fetched from all cluster peers.
-func (c *defaultClient) Status(ci *cid.Cid, local bool) (api.GlobalPinInfo, error) {
+func (c *defaultClient) Status(ci cid.Cid, local bool) (api.GlobalPinInfo, error) {
 	var gpi api.GlobalPinInfoSerial
 	err := c.do("GET", fmt.Sprintf("/pins/%s?local=%t", ci.String(), local), nil, nil, &gpi)
 	return gpi.ToGlobalPinInfo(), err
@@ -147,7 +147,7 @@ func (c *defaultClient) StatusAll(local bool) ([]api.GlobalPinInfo, error) {
 // Sync makes sure the state of a Cid corresponds to the state reported by
 // the ipfs daemon, and returns it. If local is true, this operation only
 // happens on the current peer, otherwise it happens on every cluster peer.
-func (c *defaultClient) Sync(ci *cid.Cid, local bool) (api.GlobalPinInfo, error) {
+func (c *defaultClient) Sync(ci cid.Cid, local bool) (api.GlobalPinInfo, error) {
 	var gpi api.GlobalPinInfoSerial
 	err := c.do("POST", fmt.Sprintf("/pins/%s/sync?local=%t", ci.String(), local), nil, nil, &gpi)
 	return gpi.ToGlobalPinInfo(), err
@@ -170,7 +170,7 @@ func (c *defaultClient) SyncAll(local bool) ([]api.GlobalPinInfo, error) {
 // Recover retriggers pin or unpin ipfs operations for a Cid in error state.
 // If local is true, the operation is limited to the current peer, otherwise
 // it happens on every cluster peer.
-func (c *defaultClient) Recover(ci *cid.Cid, local bool) (api.GlobalPinInfo, error) {
+func (c *defaultClient) Recover(ci cid.Cid, local bool) (api.GlobalPinInfo, error) {
 	var gpi api.GlobalPinInfoSerial
 	err := c.do("POST", fmt.Sprintf("/pins/%s/recover?local=%t", ci.String(), local), nil, nil, &gpi)
 	return gpi.ToGlobalPinInfo(), err
@@ -295,7 +295,7 @@ func (sf *statusFilter) pollStatus(ctx context.Context, c Client, fp StatusFilte
 			sf.Err <- ctx.Err()
 			return
 		case <-ticker.C:
-			gblPinInfo, err := c.Status(&fp.Cid, fp.Local)
+			gblPinInfo, err := c.Status(fp.Cid, fp.Local)
 			if err != nil {
 				sf.Err <- err
 				return

--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -137,7 +137,7 @@ func TestPin(t *testing.T) {
 
 	testF := func(t *testing.T, c Client) {
 		ci, _ := cid.Decode(test.TestCid1)
-		err := c.Pin(&ci, 6, 7, "hello")
+		err := c.Pin(ci, 6, 7, "hello")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -152,7 +152,7 @@ func TestUnpin(t *testing.T) {
 
 	testF := func(t *testing.T, c Client) {
 		ci, _ := cid.Decode(test.TestCid1)
-		err := c.Unpin(&ci)
+		err := c.Unpin(ci)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -184,7 +184,7 @@ func TestAllocation(t *testing.T) {
 
 	testF := func(t *testing.T, c Client) {
 		ci, _ := cid.Decode(test.TestCid1)
-		pin, err := c.Allocation(&ci)
+		pin, err := c.Allocation(ci)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -202,7 +202,7 @@ func TestStatus(t *testing.T) {
 
 	testF := func(t *testing.T, c Client) {
 		ci, _ := cid.Decode(test.TestCid1)
-		pin, err := c.Status(&ci, false)
+		pin, err := c.Status(ci, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -238,7 +238,7 @@ func TestSync(t *testing.T) {
 
 	testF := func(t *testing.T, c Client) {
 		ci, _ := cid.Decode(test.TestCid1)
-		pin, err := c.Sync(&ci, false)
+		pin, err := c.Sync(ci, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -274,7 +274,7 @@ func TestRecover(t *testing.T) {
 
 	testF := func(t *testing.T, c Client) {
 		ci, _ := cid.Decode(test.TestCid1)
-		pin, err := c.Recover(&ci, false)
+		pin, err := c.Recover(ci, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -420,7 +420,7 @@ func TestWaitFor(t *testing.T) {
 				}
 			}
 		}()
-		err := c.Pin(&ci, 0, 0, "test")
+		err := c.Pin(ci, 0, 0, "test")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -494,7 +494,7 @@ peers should pin this content.
 							rplMax = rpl
 						}
 
-						cerr := globalClient.Pin(&ci, rplMin, rplMax, c.String("name"))
+						cerr := globalClient.Pin(ci, rplMin, rplMax, c.String("name"))
 						if cerr != nil {
 							formatResponse(c, nil, cerr)
 							return nil
@@ -539,7 +539,7 @@ although unpinning operations in the cluster may take longer or fail.
 						cidStr := c.Args().First()
 						ci, err := cid.Decode(cidStr)
 						checkErr("parsing cid", err)
-						cerr := globalClient.Unpin(&ci)
+						cerr := globalClient.Unpin(ci)
 						if cerr != nil {
 							formatResponse(c, nil, cerr)
 							return nil
@@ -583,7 +583,7 @@ The filter only takes effect when listing all pins. The possible values are:
 						if cidStr != "" {
 							ci, err := cid.Decode(cidStr)
 							checkErr("parsing cid", err)
-							resp, cerr := globalClient.Allocation(&ci)
+							resp, cerr := globalClient.Allocation(ci)
 							formatResponse(c, resp, cerr)
 						} else {
 							var filter api.PinType
@@ -624,7 +624,7 @@ contacted cluster peer. By default, status will be fetched from all peers.
 				if cidStr != "" {
 					ci, err := cid.Decode(cidStr)
 					checkErr("parsing cid", err)
-					resp, cerr := globalClient.Status(&ci, c.Bool("local"))
+					resp, cerr := globalClient.Status(ci, c.Bool("local"))
 					formatResponse(c, resp, cerr)
 				} else {
 					resp, cerr := globalClient.StatusAll(c.Bool("local"))
@@ -660,7 +660,7 @@ operations on the contacted peer. By default, all peers will sync.
 				if cidStr != "" {
 					ci, err := cid.Decode(cidStr)
 					checkErr("parsing cid", err)
-					resp, cerr := globalClient.Sync(&ci, c.Bool("local"))
+					resp, cerr := globalClient.Sync(ci, c.Bool("local"))
 					formatResponse(c, resp, cerr)
 				} else {
 					resp, cerr := globalClient.SyncAll(c.Bool("local"))
@@ -692,7 +692,7 @@ operations on the contacted peer (as opposed to on every peer).
 				if cidStr != "" {
 					ci, err := cid.Decode(cidStr)
 					checkErr("parsing cid", err)
-					resp, cerr := globalClient.Recover(&ci, c.Bool("local"))
+					resp, cerr := globalClient.Recover(ci, c.Bool("local"))
 					formatResponse(c, resp, cerr)
 				} else {
 					resp, cerr := globalClient.RecoverAll(c.Bool("local"))
@@ -877,7 +877,7 @@ func handlePinResponseFormatFlags(
 
 	if status.Cid == cid.Undef { // no status from "wait"
 		time.Sleep(time.Second)
-		status, cerr = globalClient.Status(&ci, false)
+		status, cerr = globalClient.Status(ci, false)
 	}
 	formatResponse(c, status, cerr)
 }


### PR DESCRIPTION
#523 added a new interface and was written before the `*cid.Cid` to `cid.Cid` PR so rebasing didn't update anything. 

@hsanjuan Could you please prioritize this PR? Thanks in advance.