### PR TITLE
Add endpoints output: improvements and compliance

### DIFF
--- a/adder/adderutils/adderutils.go
+++ b/adder/adderutils/adderutils.go
@@ -21,13 +21,16 @@ import (
 var logger = logging.Logger("adder")
 
 // AddMultipartHTTPHandler is a helper function to add content
-// uploaded using a multipart request.
+// uploaded using a multipart request. The outputTransform parameter
+// allows to customize the http response output format to something
+// else than api.AddedOutput objects.
 func AddMultipartHTTPHandler(
 	ctx context.Context,
 	rpc *rpc.Client,
 	params *api.AddParams,
 	reader *multipart.Reader,
 	w http.ResponseWriter,
+	outputTransform func(*api.AddedOutput) interface{},
 ) (cid.Cid, error) {
 	var dags adder.ClusterDAGService
 	output := make(chan *api.AddedOutput, 200)
@@ -41,23 +44,35 @@ func AddMultipartHTTPHandler(
 	enc := json.NewEncoder(w)
 	// This must be application/json otherwise go-ipfs client
 	// will break.
-	w.Header().Add("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
 	// Browsers should not cache when streaming content.
-	w.Header().Add("Cache-Control", "no-cache")
+	w.Header().Set("Cache-Control", "no-cache")
+	// Custom header which breaks js-ipfs-api if not set
+	// https://github.com/ipfs-shipyard/ipfs-companion/issues/600
+	w.Header().Set("X-Chunked-Output", "1")
+
+	// Used by go-ipfs to signal errors half-way through the stream.
+	w.Header().Set("Trailer", "X-Stream-Error")
+
 	// We need to ask the clients to close the connection
 	// (no keep-alive) of things break badly when adding.
 	// https://github.com/ipfs/go-ipfs-cmds/pull/116
 	w.Header().Set("Connection", "close")
 	w.WriteHeader(http.StatusOK)
 
+	if outputTransform == nil {
+		outputTransform = func(in *api.AddedOutput) interface{} { return in }
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		for v := range output {
-			err := enc.Encode(v)
+			err := enc.Encode(outputTransform(v))
 			if err != nil {
 				logger.Error(err)
+				break
 			}
 			if flush {
 				flusher.Flush()
@@ -67,6 +82,10 @@ func AddMultipartHTTPHandler(
 
 	add := adder.New(dags, params, output)
 	root, err := add.FromMultipart(ctx, reader)
+	if err != nil {
+		// Set trailer with error
+		w.Header().Set("X-Stream-Error", err.Error())
+	}
 	wg.Wait()
 	return root, err
 }

--- a/adder/ipfsadd/add.go
+++ b/adder/ipfsadd/add.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	gopath "path"
-	"strconv"
 
 	"github.com/ipfs/ipfs-cluster/api"
 
@@ -390,9 +389,9 @@ func outputDagnode(out chan *api.AddedOutput, name string, dn ipld.Node) error {
 	}
 
 	out <- &api.AddedOutput{
-		Hash: dn.Cid().String(),
+		Cid:  dn.Cid().String(),
 		Name: name,
-		Size: strconv.FormatUint(s, 10),
+		Size: s,
 	}
 
 	return nil
@@ -413,7 +412,7 @@ func (i *progressReader) Read(p []byte) (int, error) {
 		i.lastProgress = i.bytes
 		i.out <- &api.AddedOutput{
 			Name:  i.file.FileName(),
-			Bytes: i.bytes,
+			Bytes: uint64(i.bytes),
 		}
 	}
 

--- a/adder/sharding/dag_service.go
+++ b/adder/sharding/dag_service.go
@@ -111,8 +111,8 @@ func (dgs *DAGService) Finalize(ctx context.Context, dataRoot cid.Cid) (cid.Cid,
 
 	dgs.sendOutput(&api.AddedOutput{
 		Name: fmt.Sprintf("%s-clusterDAG", dgs.pinOpts.Name),
-		Hash: clusterDAG.String(),
-		Size: fmt.Sprintf("%d", dgs.totalSize),
+		Cid:  clusterDAG.String(),
+		Size: dgs.totalSize,
 	})
 
 	// Pin the ClusterDAG
@@ -270,8 +270,8 @@ func (dgs *DAGService) flushCurrentShard(ctx context.Context) (cid.Cid, error) {
 	dgs.currentShard = nil
 	dgs.sendOutput(&api.AddedOutput{
 		Name: fmt.Sprintf("shard-%d", lens),
-		Hash: shardCid.String(),
-		Size: fmt.Sprintf("%d", shard.Size()),
+		Cid:  shardCid.String(),
+		Size: shard.Size(),
 	})
 
 	return shard.LastLink(), nil

--- a/adder/sharding/dag_service_test.go
+++ b/adder/sharding/dag_service_test.go
@@ -76,7 +76,7 @@ func makeAdder(t *testing.T, params *api.AddParams) (*adder.Adder, *testRPC) {
 
 	go func() {
 		for v := range out {
-			t.Logf("Output: Name: %s. Cid: %s. Size: %s", v.Name, v.Hash, v.Size)
+			t.Logf("Output: Name: %s. Cid: %s. Size: %d", v.Name, v.Cid, v.Size)
 		}
 	}()
 

--- a/api/add.go
+++ b/api/add.go
@@ -13,11 +13,10 @@ var DefaultShardSize = uint64(100 * 1024 * 1024) // 100 MB
 // AddedOutput carries information for displaying the standard ipfs output
 // indicating a node of a file has been added.
 type AddedOutput struct {
-	Error
-	Name  string
-	Hash  string `json:",omitempty"`
-	Bytes int64  `json:",omitempty"`
-	Size  string `json:",omitempty"`
+	Name  string `json:"name"`
+	Cid   string `json:"cid,omitempty"`
+	Bytes uint64 `json:"bytes,omitempty"`
+	Size  uint64 `json:"size,omitempty"`
 }
 
 // AddParams contains all of the configurable parameters needed to specify the

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -416,6 +416,8 @@ func (c *defaultClient) AddMultiFile(
 	headers["Content-Type"] = "multipart/form-data; boundary=" + multiFileR.Boundary()
 	queryStr := params.ToQueryString()
 
+	// our handler decodes an AddedOutput and puts it
+	// in the out channel.
 	handler := func(dec *json.Decoder) error {
 		if out == nil {
 			return nil
@@ -425,9 +427,7 @@ func (c *defaultClient) AddMultiFile(
 		if err != nil {
 			return err
 		}
-		select {
-		case out <- &obj:
-		}
+		out <- &obj
 		return nil
 	}
 

--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -459,7 +459,7 @@ func TestAddMultiFile(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for v := range out {
-				t.Logf("output: Name: %s. Hash: %s", v.Name, v.Hash)
+				t.Logf("output: Name: %s. Hash: %s", v.Name, v.Cid)
 			}
 		}()
 

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -516,27 +516,15 @@ func (api *API) addHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = adderutils.AddMultipartHTTPHandler(
+	// any errors sent as trailer
+	adderutils.AddMultipartHTTPHandler(
 		api.ctx,
 		api.rpcClient,
 		params,
 		reader,
 		w,
+		nil,
 	)
-
-	if err != nil {
-		errorResp := types.AddedOutput{
-			Error: types.Error{
-				Code:    http.StatusInternalServerError,
-				Message: err.Error(),
-			},
-		}
-		enc := json.NewEncoder(w)
-
-		if err := enc.Encode(errorResp); err != nil {
-			logger.Error(err)
-		}
-	}
 
 	return
 }

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -199,11 +199,7 @@ func textFormatPrintPin(obj *api.PinSerial) {
 }
 
 func textFormatPrintAddedOutput(obj *api.AddedOutput) {
-	if obj.Error.Message != "" {
-		fmt.Println(obj.Error.Error())
-		return
-	}
-	fmt.Printf("added %s %s\n", obj.Hash, obj.Name)
+	fmt.Printf("added %s %s\n", obj.Cid, obj.Name)
 }
 
 func textFormatPrintError(obj *api.Error) {

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -401,13 +401,13 @@ If you prefer faster adding, add directly to the local IPFS and trigger a
 
 						// Print last hash only
 						if c.Bool("quieter") {
-							last = v.Hash
+							last = v.Cid
 							continue
 						}
 
 						// Print hashes only
 						if c.Bool("quiet") {
-							fmt.Println(v.Hash)
+							fmt.Println(v.Cid)
 							continue
 						}
 

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -573,7 +573,7 @@ func TestProxyAdd(t *testing.T) {
 				t.Fatalf("Bad response status: got = %d, want = %d", res.StatusCode, http.StatusOK)
 			}
 
-			var resp api.AddedOutput
+			var resp ipfsAddResp
 			dec := json.NewDecoder(res.Body)
 			for dec.More() {
 				err := dec.Decode(&resp)


### PR DESCRIPTION
This straigthens some mistakes with the outputs of the /add endpoints.

Currently, we had exactly the same output format which:

* was not exactly the ipfs API output format but was sort of similar
* made some weird concessions to be compatible (like having a string-type "size")
* was not aligned with Cluster API conventions (lowercase keys)

This corrects all this:

* The Cluster API /add output format now uses the right types and lowercase keys.
* `Hash` is now `Cid`, because the field carries a Cid.
* We copy error handling with request trailers from IPFS, and avoid carrying the
  errors in the output objects.
* The proxy now returns exactly the types as ipfs would
* We add the X-Chunked-Output: 1 header, which is custom and redundant, but
otherwise breaks js-ipfs-api integrations with the /add endpoint.

Fixes: https://github.com/ipfs-shipyard/ipfs-companion/issues/600

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>