### PR TITLE
Issue #449 API endpoint for Peer Monitor metrics

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -104,9 +104,9 @@ type Client interface {
 	// serialized version, strings instead of pids, is returned
 	GetConnectGraph() (api.ConnectGraphSerial, error)
 
-	// PeerMonitorLatestMetrics returns a map with the latest metrics of matching name
+	// Metrics returns a map with the latest metrics of matching name
 	// for the current cluster peers.
-	PeerMonitorLatestMetrics(name string) ([]api.Metric, error)
+	Metrics(name string) ([]api.Metric, error)
 }
 
 // Config allows to configure the parameters to connect

--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -103,6 +103,10 @@ type Client interface {
 	// GetConnectGraph returns an ipfs-cluster connection graph.  The
 	// serialized version, strings instead of pids, is returned
 	GetConnectGraph() (api.ConnectGraphSerial, error)
+
+	// PeerMonitorLatestMetrics returns a map with the latest metrics of matching name
+	// for the current cluster peers.
+	PeerMonitorLatestMetrics(name string) ([]api.Metric, error)
 }
 
 // Config allows to configure the parameters to connect

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -204,11 +204,11 @@ func (c *defaultClient) GetConnectGraph() (api.ConnectGraphSerial, error) {
 	return graphS, err
 }
 
-// PeerMonitorLatestMetrics returns a map with the latest metrics of matching name
+// Metrics returns a map with the latest metrics of matching name
 // for the current cluster peers.
-func (c *defaultClient) PeerMonitorLatestMetrics(name string) ([]api.Metric, error) {
+func (c *defaultClient) Metrics(name string) ([]api.Metric, error) {
 	var metrics []api.Metric
-	err := c.do("GET", fmt.Sprintf("/health/metrics/%s", name), nil, nil, &metrics)
+	err := c.do("GET", fmt.Sprintf("/monitor/metrics/%s", name), nil, nil, &metrics)
 	return metrics, err
 }
 

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -204,6 +204,14 @@ func (c *defaultClient) GetConnectGraph() (api.ConnectGraphSerial, error) {
 	return graphS, err
 }
 
+// PeerMonitorLatestMetrics returns a map with the latest metrics of matching name
+// for the current cluster peers.
+func (c *defaultClient) PeerMonitorLatestMetrics(name string) ([]api.Metric, error) {
+	var metrics []api.Metric
+	err := c.do("GET", fmt.Sprintf("/health/metrics/%s", name), nil, nil, &metrics)
+	return metrics, err
+}
+
 // WaitFor is a utility function that allows for a caller to wait for a
 // paticular status for a CID (as defined by StatusFilterParams).
 // It returns the final status for that CID and an error, if there was.

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -385,6 +385,12 @@ func (api *API) routes() []route {
 			"/health/graph",
 			api.graphHandler,
 		},
+		{
+			"PeerMonitorLatestMetrics",
+			"GET",
+			"/health/metrics/{name}",
+			api.metricsHandler,
+		},
 	}
 }
 
@@ -504,6 +510,19 @@ func (api *API) graphHandler(w http.ResponseWriter, r *http.Request) {
 		struct{}{},
 		&graph)
 	api.sendResponse(w, autoStatus, err, graph)
+}
+
+func (api *API) metricsHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	name := vars["name"]
+
+	var metrics []types.Metric
+	err := api.rpcClient.Call("",
+		"Cluster",
+		"PeerMonitorLatestMetrics",
+		name,
+		&metrics)
+	sendResponse(w, err, metrics)
 }
 
 func (api *API) addHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -386,9 +386,9 @@ func (api *API) routes() []route {
 			api.graphHandler,
 		},
 		{
-			"PeerMonitorLatestMetrics",
+			"Metrics",
 			"GET",
-			"/health/metrics/{name}",
+			"/monitor/metrics/{name}",
 			api.metricsHandler,
 		},
 	}
@@ -522,7 +522,7 @@ func (api *API) metricsHandler(w http.ResponseWriter, r *http.Request) {
 		"PeerMonitorLatestMetrics",
 		name,
 		&metrics)
-	sendResponse(w, err, metrics)
+	api.sendResponse(w, autoStatus, err, metrics)
 }
 
 func (api *API) addHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -24,6 +24,9 @@ func jsonFormatObject(resp interface{}) {
 		jsonFormatPrint(resp.(api.AddedOutput))
 	case api.Version:
 		jsonFormatPrint(resp.(api.Version))
+	case api.Metric:
+		serial := resp.(api.Metric)
+		textFormatPrintMetric(&serial)
 	case api.Error:
 		jsonFormatPrint(resp.(api.Error))
 	case []api.ID:
@@ -50,6 +53,9 @@ func jsonFormatObject(resp interface{}) {
 		jsonFormatPrint(serials)
 	case []api.AddedOutput:
 		serials := resp.([]api.AddedOutput)
+		jsonFormatPrint(serials)
+	case []api.Metric:
+		serials := resp.([]api.Metric)
 		jsonFormatPrint(serials)
 	default:
 		checkErr("", errors.New("unsupported type returned"))
@@ -84,6 +90,9 @@ func textFormatObject(resp interface{}) {
 	case api.Error:
 		serial := resp.(api.Error)
 		textFormatPrintError(&serial)
+	case api.Metric:
+		serial := resp.(api.Metric)
+		textFormatPrintMetric(&serial)
 	case []api.ID:
 		for _, item := range resp.([]api.ID) {
 			textFormatObject(item)
@@ -98,6 +107,10 @@ func textFormatObject(resp interface{}) {
 		}
 	case []api.AddedOutput:
 		for _, item := range resp.([]api.AddedOutput) {
+			textFormatObject(item)
+		}
+	case []api.Metric:
+		for _, item := range resp.([]api.Metric) {
 			textFormatObject(item)
 		}
 	default:
@@ -200,6 +213,15 @@ func textFormatPrintPin(obj *api.PinSerial) {
 
 func textFormatPrintAddedOutput(obj *api.AddedOutput) {
 	fmt.Printf("added %s %s\n", obj.Cid, obj.Name)
+}
+
+func textFormatPrintMetric(obj *api.Metric) {
+	fmt.Printf("{\n")
+	fmt.Printf("	Peer:   %s\n", (obj.Peer).String())
+	fmt.Printf("	Value:  %s\n", obj.Value)
+	fmt.Printf("	Expire: %d\n", obj.Expire)
+	fmt.Printf("	Expire: %t\n", obj.Valid)
+	fmt.Printf("}\n")
 }
 
 func textFormatPrintError(obj *api.Error) {

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -216,12 +216,7 @@ func textFormatPrintAddedOutput(obj *api.AddedOutput) {
 }
 
 func textFormatPrintMetric(obj *api.Metric) {
-	fmt.Printf("{\n")
-	fmt.Printf("	Peer:   %s\n", (obj.Peer).String())
-	fmt.Printf("	Value:  %s\n", obj.Value)
-	fmt.Printf("	Expire: %d\n", obj.Expire)
-	fmt.Printf("	Expire: %t\n", obj.Valid)
-	fmt.Printf("}\n")
+	fmt.Printf("%s: %s | Expire : %d\n", obj.Peer.Pretty(), obj.Value, obj.Expire)
 }
 
 func textFormatPrintError(obj *api.Error) {

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -764,14 +764,14 @@ graph of the connections.  Output is a dot file encoding the cluster's connectio
 				},
 				{
 					Name:  "metrics",
-					Usage: "Get latest metrics of matching name for the current cluster peers.",
+					Usage: "List latest metrics logged by this peer",
 					Description: `
-This command would show the peers and the last list of metrics logged for each as
-returned by the Peer Monitor, in a friendly way.
+This commands displays the latest valid metrics of the given type logged
+by this peer for all current cluster peers.
 `,
 					ArgsUsage: "Metric name",
 					Action: func(c *cli.Context) error {
-						resp, cerr := globalClient.PeerMonitorLatestMetrics(c.Args().First())
+						resp, cerr := globalClient.Metrics(c.Args().First())
 						formatResponse(c, resp, cerr)
 						return nil
 					},

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -762,6 +762,20 @@ graph of the connections.  Output is a dot file encoding the cluster's connectio
 						return nil
 					},
 				},
+				{
+					Name:  "metrics",
+					Usage: "Get latest metrics of matching name for the current cluster peers.",
+					Description: `
+This command would show the peers and the last list of metrics logged for each as
+returned by the Peer Monitor, in a friendly way.
+`,
+					ArgsUsage: "Metric name",
+					Action: func(c *cli.Context) error {
+						resp, cerr := globalClient.PeerMonitorLatestMetrics(c.Args().First())
+						formatResponse(c, resp, cerr)
+						return nil
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
- [x] Opened new endpoint `GET /health/metrics/<name>` which would respond
with metrics of type `<name>`
- [x] Support the new endpoint in rest/api/client
- [x] Support the new method in ipfs-cluster-ctl. i.e. ipfs-cluster-ctl health metrics <name> would show the peers and the last list of metrics logged for each as returned by the Peer Monitor, in a friendly way.
- [ ] Tests

Fixes #449 