### PR TITLE
Restapi: Add configurable response headers

### DIFF
--- a/api/rest/config.go
+++ b/api/rest/config.go
@@ -27,6 +27,15 @@ const (
 	DefaultIdleTimeout       = 120 * time.Second
 )
 
+// These are the default values for Config.
+var (
+	DefaultHeaders = map[string][]string{
+		"Access-Control-Allow-Headers": []string{"X-Requested-With", "Range"},
+		"Access-Control-Allow-Methods": []string{"GET"},
+		"Access-Control-Allow-Origin":  []string{"*"},
+	}
+)
+
 // Config is used to intialize the API object and allows to
 // customize the behaviour of it. It implements the config.ComponentConfig
 // interface.
@@ -71,6 +80,10 @@ type Config struct {
 	// BasicAuthCreds is a map of username-password pairs
 	// which are authorized to use Basic Authentication
 	BasicAuthCreds map[string]string
+
+	// Headers provides customization for the headers returned
+	// by the API. By default it sets a CORS policy.
+	Headers map[string][]string
 }
 
 type jsonConfig struct {
@@ -87,7 +100,8 @@ type jsonConfig struct {
 	ID                       string `json:"id,omitempty"`
 	PrivateKey               string `json:"private_key,omitempty"`
 
-	BasicAuthCreds map[string]string `json:"basic_auth_credentials"`
+	BasicAuthCreds map[string]string   `json:"basic_auth_credentials"`
+	Headers        map[string][]string `json:"headers"`
 }
 
 // ConfigKey returns a human-friendly identifier for this type of
@@ -115,6 +129,9 @@ func (cfg *Config) Default() error {
 
 	// Auth
 	cfg.BasicAuthCreds = nil
+
+	// Headers
+	cfg.Headers = DefaultHeaders
 
 	return nil
 }
@@ -177,6 +194,7 @@ func (cfg *Config) LoadJSON(raw []byte) error {
 
 	// Other options
 	cfg.BasicAuthCreds = jcfg.BasicAuthCreds
+	cfg.Headers = jcfg.Headers
 
 	return cfg.Validate()
 }
@@ -295,6 +313,7 @@ func (cfg *Config) ToJSON() (raw []byte, err error) {
 		WriteTimeout:           cfg.WriteTimeout.String(),
 		IdleTimeout:            cfg.IdleTimeout.String(),
 		BasicAuthCreds:         cfg.BasicAuthCreds,
+		Headers:                cfg.Headers,
 	}
 
 	if cfg.ID != "" {

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -863,7 +863,7 @@ func pinInfosToGlobal(pInfos []types.PinInfoSerial) []types.GlobalPinInfoSerial 
 // sendResponse wraps all the logic for writing the response to a request:
 // * Write configured headers
 // * Write application/json content type
-// * Write status: determined automatically if given 0
+// * Write status: determined automatically if given "autoStatus"
 // * Write an error if there is or write the response if there is
 func (api *API) sendResponse(
 	w http.ResponseWriter,

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -124,6 +124,17 @@ func processStreamingResp(t *testing.T, httpResp *http.Response, err error, resp
 	}
 }
 
+func checkHeaders(t *testing.T, rest *API, url string, headers http.Header) {
+	for k, v := range rest.config.Headers {
+		if strings.Join(v, ",") != strings.Join(headers[k], ",") {
+			t.Errorf("%s does not show configured headers: %s", url, k)
+		}
+	}
+	if headers.Get("Content-Type") != "application/json" {
+		t.Errorf("%s is not application/json", url)
+	}
+}
+
 // makes a libp2p host that knows how to talk to the rest API host.
 func makeHost(t *testing.T, rest *API) host.Host {
 	h, err := libp2p.New(context.Background())
@@ -185,6 +196,7 @@ func makeGet(t *testing.T, rest *API, url string, resp interface{}) {
 	c := httpClient(t, h, isHTTPS(url))
 	httpResp, err := c.Get(url)
 	processResp(t, httpResp, err, resp)
+	checkHeaders(t, rest, url, httpResp.Header)
 }
 
 func makePost(t *testing.T, rest *API, url string, body []byte, resp interface{}) {
@@ -193,6 +205,7 @@ func makePost(t *testing.T, rest *API, url string, body []byte, resp interface{}
 	c := httpClient(t, h, isHTTPS(url))
 	httpResp, err := c.Post(url, "application/json", bytes.NewReader(body))
 	processResp(t, httpResp, err, resp)
+	checkHeaders(t, rest, url, httpResp.Header)
 }
 
 func makeDelete(t *testing.T, rest *API, url string, resp interface{}) {
@@ -202,6 +215,7 @@ func makeDelete(t *testing.T, rest *API, url string, resp interface{}) {
 	req, _ := http.NewRequest("DELETE", url, bytes.NewReader([]byte{}))
 	httpResp, err := c.Do(req)
 	processResp(t, httpResp, err, resp)
+	checkHeaders(t, rest, url, httpResp.Header)
 }
 
 func makeStreamingPost(t *testing.T, rest *API, url string, body io.Reader, contentType string, resp interface{}) {
@@ -210,6 +224,7 @@ func makeStreamingPost(t *testing.T, rest *API, url string, body io.Reader, cont
 	c := httpClient(t, h, isHTTPS(url))
 	httpResp, err := c.Post(url, contentType, body)
 	processStreamingResp(t, httpResp, err, resp)
+	checkHeaders(t, rest, url, httpResp.Header)
 }
 
 type testF func(t *testing.T, url urlF)
@@ -251,6 +266,7 @@ func TestRestAPIIDEndpoint(t *testing.T) {
 	rest := testAPI(t)
 	httpsrest := testHTTPSAPI(t)
 	defer rest.Shutdown()
+	defer httpsrest.Shutdown()
 
 	tf := func(t *testing.T, url urlF) {
 		id := api.IDSerial{}

--- a/config_test.go
+++ b/config_test.go
@@ -50,7 +50,19 @@ var testingAPICfg = []byte(`{
     "read_timeout": "0",
     "read_header_timeout": "5s",
     "write_timeout": "0",
-    "idle_timeout": "2m0s"
+    "idle_timeout": "2m0s",
+    "headers": {
+      "Access-Control-Allow-Headers": [
+        "X-Requested-With",
+        "Range"
+      ],
+      "Access-Control-Allow-Methods": [
+        "GET"
+      ],
+      "Access-Control-Allow-Origin": [
+        "*"
+      ]
+    }
 }`)
 
 var testingIpfsCfg = []byte(`{


### PR DESCRIPTION
By default, CORS headers allowing GET requests from everywhere are
set. This should facilitate the IPFS Web UI integration with the
Cluster API.

This commit refactors the sendResponse methods in the API, merging
them into one as it was difficult to follow the flows that actually
send something to the client. All tests now check the presence of
the configured headers too, to make sure no route was missed.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>