### PR TITLE
Allow ipfs-cluster-ctl to access files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Collective pinning and composition for IPFS
 description: |
   ipfs-cluster allows to replicate content (by pinning) in multiple IPFS nodes.
 
-confinement: strict
+confinement: classic
 
 apps:
   service:


### PR DESCRIPTION
In the snap-installed distribution, calls like `ipfs-cluster-ctl add myfile.txt` fail with error `Error: open myfile.txt: permission denied` due to strict confinement to files in the /snap folder. Modifying confinement to `classic` will allow access to files elsewhere on the system.