### PR TITLE
Fix #577: Try downloading gx and gx-go from local ipfs gateway first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ tag_annotation
 coverage.out
 cmd/ipfs-cluster-service/ipfs-cluster-service
 cmd/ipfs-cluster-ctl/ipfs-cluster-ctl
-deptools
+deptools/gx*
 sharness/lib/sharness
 sharness/test-results
 sharness/trash*

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,7 @@
-gx_version=v0.13.0
-gx-go_version=v1.8.0
-
 deptools=deptools
-
-gx=gx_$(gx_version)
-gx-go=gx-go_$(gx-go_version)
-gx_bin=$(deptools)/$(gx)
-gx-go_bin=$(deptools)/$(gx-go)
-bin_env=$(shell go env GOHOSTOS)-$(shell go env GOHOSTARCH)
 sharness = sharness/lib/sharness
+gx=$(deptools)/gx
+gx-go=$(deptools)/gx-go
 
 # For debugging
 problematic_test = TestClustersReplicationRealloc
@@ -20,9 +13,6 @@ clean: rwundo clean_sharness
 	$(MAKE) -C cmd/ipfs-cluster-service clean
 	$(MAKE) -C cmd/ipfs-cluster-ctl clean
 	@rm -rf ./test/testingData
-
-gx-clean: clean
-	@rm -f $(deptools)/*
 
 install: deps
 	$(MAKE) -C cmd/ipfs-cluster-service install
@@ -42,38 +32,22 @@ service: deps
 ctl: deps
 	$(MAKE) -C cmd/ipfs-cluster-ctl ipfs-cluster-ctl
 
-$(gx_bin):
-	@echo "Downloading gx"
-	mkdir -p ./$(deptools)
-	rm -f $(deptools)/gx
-	wget -nc -O $(gx_bin).tgz https://dist.ipfs.io/gx/$(gx_version)/$(gx)_$(bin_env).tar.gz
-	tar -zxf $(gx_bin).tgz -C $(deptools) --strip-components=1 gx/gx
-	mv $(deptools)/gx $(gx_bin)
-	ln -s $(gx) $(deptools)/gx
-	rm $(gx_bin).tgz
+gx-clean: clean
+	$(MAKE) -C $(deptools) gx-clean
 
-$(gx-go_bin):
-	@echo "Downloading gx-go"
-	mkdir -p ./$(deptools)
-	rm -f $(deptools)/gx-go
-	wget -nc -O $(gx-go_bin).tgz https://dist.ipfs.io/gx-go/$(gx-go_version)/$(gx-go)_$(bin_env).tar.gz
-	tar -zxf $(gx-go_bin).tgz -C $(deptools) --strip-components=1 gx-go/gx-go
-	mv $(deptools)/gx-go $(gx-go_bin)
-	ln -s $(gx-go) $(deptools)/gx-go
-	rm $(gx-go_bin).tgz
-
-gx: $(gx_bin) $(gx-go_bin)
+gx:
+	$(MAKE) -C $(deptools) gx
 
 deps: gx
-	$(gx_bin) install --global
-	$(gx-go_bin) rewrite
+	$(gx) install --global
+	$(gx-go) rewrite
 
 # Run this target before building the docker image 
 # and then gx won't attempt to pull all deps 
 # from the network each time
 docker_deps: gx
-	$(gx_bin) install --local
-	$(gx-go_bin) rewrite
+	$(gx) install --local
+	$(gx-go) rewrite
 
 check:
 	go vet ./...
@@ -101,11 +75,11 @@ clean_sharness:
 	@rm -rf sharness/trash\ directory*
 
 rw: gx
-	$(gx-go_bin) rewrite
+	$(gx-go) rewrite
 rwundo: gx
-	$(gx-go_bin) rewrite --undo
+	$(gx-go) rewrite --undo
 publish: rwundo
-	$(gx_bin) publish
+	$(gx) publish
 
 docker:
 	docker build -t cluster-image -f Dockerfile .

--- a/deptools/Makefile
+++ b/deptools/Makefile
@@ -1,0 +1,45 @@
+gx_version=v0.13.0
+gx-go_version=v1.8.0
+gateway=https://ipfs.io
+local_gateway=http://127.0.0.1:8080
+dist=dist.ipfs.io
+dl_cmd=wget -nc
+
+gx=gx_$(gx_version)
+gx-go=gx-go_$(gx-go_version)
+bin_env=$(shell go env GOHOSTOS)-$(shell go env GOHOSTARCH)
+
+gx_tar=$(gx)_$(bin_env).tar.gz
+gx-go_tar=$(gx-go)_$(bin_env).tar.gz
+
+gx_dist_path=/ipns/$(dist)/gx/$(gx_version)/$(gx_tar)
+gx-go_dist_path=/ipns/$(dist)/gx-go/$(gx-go_version)/$(gx-go_tar)
+
+gx_download_local=$(dl_cmd) $(local_gateway)$(gx_dist_path)
+gx_download=$(dl_cmd) $(gateway)$(gx_dist_path)
+
+gx-go_download_local=$(dl_cmd) $(local_gateway)$(gx-go_dist_path)
+gx-go_download=$(dl_cmd) $(gateway)$(gx-go_dist_path)
+
+$(gx):
+	@echo "Downloading gx"
+	rm -f gx
+	$(gx_download_local) || $(gx_download)
+	tar -zxf $(gx_tar) --strip-components=1 gx/gx
+	mv gx $(gx)
+	ln -s $(gx) gx
+	rm $(gx_tar)
+
+$(gx-go):
+	@echo "Downloading gx-go"
+	rm -f gx-go
+	$(gx-go_download_local) || $(gx-go_download)
+	tar -zxf $(gx-go_tar) --strip-components=1 gx-go/gx-go
+	mv gx-go $(gx-go)
+	ln -s $(gx-go) gx-go
+	rm $(gx-go_tar)
+
+gx: $(gx) $(gx-go)
+
+gx-clean:
+	@rm -f gx*


### PR DESCRIPTION
This modifies the Makefile so that gx and gx-go downloads are first
attempted from the local ipfs gateway (127.0.0.1:8080) and then
from the offical gateway (ipfs.io).

Make and wget doesn't work well dealing with stuff in subfolders,
so I have moved deptools-related rules to the deptools folder in its own
Makefile.

#577 

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>