### PR TITLE
Make metrics human

### DIFF
--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -205,9 +206,12 @@ func (c *defaultClient) GetConnectGraph() (api.ConnectGraphSerial, error) {
 	return graphS, err
 }
 
-// Metrics returns a map with the latest metrics of matching name
+// Metrics returns a map with the latest valid metrics of the given name
 // for the current cluster peers.
 func (c *defaultClient) Metrics(name string) ([]api.Metric, error) {
+	if name == "" {
+		return nil, errors.New("bad metric name")
+	}
 	var metrics []api.Metric
 	err := c.do("GET", fmt.Sprintf("/monitor/metrics/%s", name), nil, nil, &metrics)
 	return metrics, err

--- a/api/rest/client/request.go
+++ b/api/rest/client/request.go
@@ -92,9 +92,10 @@ func (c *defaultClient) handleResponse(resp *http.Response, obj interface{}) err
 			var apiErr api.Error
 			err = json.Unmarshal(body, &apiErr)
 			if err != nil {
+				// not json. 404s etc.
 				return &api.Error{
 					Code:    resp.StatusCode,
-					Message: err.Error(),
+					Message: string(body),
 				}
 			}
 			return &apiErr

--- a/cluster.go
+++ b/cluster.go
@@ -275,7 +275,10 @@ func (c *Cluster) alertsHandler() {
 			// only the leader handles alerts
 			leader, err := c.consensus.Leader()
 			if err == nil && leader == c.id {
-				logger.Warningf("Peer %s received alert for %s in %s", c.id, alrt.MetricName, alrt.Peer.Pretty())
+				logger.Warningf(
+					"Peer %s received alert for %s in %s",
+					c.id, alrt.MetricName, alrt.Peer,
+				)
 				switch alrt.MetricName {
 				case pingMetricName:
 					c.repinFromPeer(alrt.Peer)

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/ipfs/ipfs-cluster/api"
+	peer "github.com/libp2p/go-libp2p-peer"
 )
 
 func jsonFormatObject(resp interface{}) {
@@ -216,7 +218,8 @@ func textFormatPrintAddedOutput(obj *api.AddedOutput) {
 }
 
 func textFormatPrintMetric(obj *api.Metric) {
-	fmt.Printf("%s: %s | Expire : %d\n", obj.Peer.Pretty(), obj.Value, obj.Expire)
+	date := time.Unix(0, obj.Expire).UTC().Format(time.RFC3339)
+	fmt.Printf("%s: %s | Expire: %s\n", peer.IDB58Encode(obj.Peer), obj.Value, date)
 }
 
 func textFormatPrintError(obj *api.Error) {

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -768,10 +768,21 @@ graph of the connections.  Output is a dot file encoding the cluster's connectio
 					Description: `
 This commands displays the latest valid metrics of the given type logged
 by this peer for all current cluster peers.
+
+Currently supported metrics depend on the informer component used,
+but usually are:
+
+- freespace
+- ping
 `,
-					ArgsUsage: "Metric name",
+					ArgsUsage: "<metric name>",
 					Action: func(c *cli.Context) error {
-						resp, cerr := globalClient.Metrics(c.Args().First())
+						metric := c.Args().First()
+						if metric == "" {
+							checkErr("", errors.New("provide a metric name"))
+						}
+
+						resp, cerr := globalClient.Metrics(metric)
 						formatResponse(c, resp, cerr)
 						return nil
 					},

--- a/monitor/metrics/store.go
+++ b/monitor/metrics/store.go
@@ -71,14 +71,14 @@ func (mtrs *Store) Latest(name string) []api.Metric {
 
 // PeerMetrics returns the latest metrics for a given peer ID for
 // all known metrics types. It may return expired metrics.
-func (mtrs *Store) PeerMetrics(peer peer.ID) []api.Metric {
+func (mtrs *Store) PeerMetrics(pid peer.ID) []api.Metric {
 	mtrs.mux.RLock()
 	defer mtrs.mux.RUnlock()
 
 	result := make([]api.Metric, 0)
 
 	for _, byPeer := range mtrs.byName {
-		window, ok := byPeer[peer]
+		window, ok := byPeer[pid]
 		if !ok {
 			continue
 		}

--- a/monitor/metrics/util.go
+++ b/monitor/metrics/util.go
@@ -10,8 +10,8 @@ import (
 // peerset
 func PeersetFilter(metrics []api.Metric, peerset []peer.ID) []api.Metric {
 	peerMap := make(map[peer.ID]struct{})
-	for _, peer := range peerset {
-		peerMap[peer] = struct{}{}
+	for _, pid := range peerset {
+		peerMap[pid] = struct{}{}
 	}
 
 	filtered := make([]api.Metric, 0, len(metrics))

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -205,12 +205,12 @@ func (rpcapi *RPCAPI) BlockAllocate(ctx context.Context, in api.PinSerial, out *
 		// Returned metrics are Valid and belong to current
 		// Cluster peers.
 		metrics := rpcapi.c.monitor.LatestMetrics(pingMetricName)
-		peers := make([]peer.ID, len(metrics), len(metrics))
+		peers := make([]string, len(metrics), len(metrics))
 		for i, m := range metrics {
-			peers[i] = m.Peer
+			peers[i] = peer.IDB58Encode(m.Peer)
 		}
 
-		*out = api.PeersToStrings(peers)
+		*out = peers
 		return nil
 	}
 


### PR DESCRIPTION
Issue #572 exposes metrics but they carry the peer ID in binary.

This was ok with our internal codecs but it doesn't seem to work
very well with json, and makes the output format unusable.

This makes the Metric.Peer field a string.

Additionally, fixes calling the command without arguments and displaying
the date in the right format.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>