### PR TITLE
Fix publishing snaps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,17 +61,16 @@ jobs:
       if: (NOT type IN (pull_request)) AND (fork = false) AND (tag =~ ^v\d+\.\d+\.\d+$)
       script:
         - openssl aes-256-cbc -K $encrypted_5a1cb914c6c9_key -iv $encrypted_5a1cb914c6c9_iv -in .snapcraft/travis_snapcraft.cfg -out .snapcraft/snapcraft.cfg -d
-        - docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "apt update -qq && cd $(pwd) && ./snap/snap-multiarch.sh stable"
+        - docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "apt update -qq && cd $(pwd) && ./snap/snap-multiarch.sh edge" # should be stable
     - stage: "Snapcraft deployment stage (Candidate)"
       name: "Deploy Snapcraft"
       if: (NOT type IN (pull_request)) AND (fork = false) AND (tag =~ ^v\d+\.\d+\.\d+-rc\d+$)
       script:
         - openssl aes-256-cbc -K $encrypted_5a1cb914c6c9_key -iv $encrypted_5a1cb914c6c9_iv -in .snapcraft/travis_snapcraft.cfg -out .snapcraft/snapcraft.cfg -d
-        - docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "apt update -qq && cd $(pwd) && ./snap/snap-multiarch.sh candidate"
+        - docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "apt update -qq && cd $(pwd) && ./snap/snap-multiarch.sh edge" # should be candidate
     - stage: "Snapcraft deployment stage (Edge)"
       name: "Deploy Snapcraft"
       if: (NOT type IN (pull_request)) AND (branch = master) AND (fork = false) AND (tag IS NOT present)
       script:
         - openssl aes-256-cbc -K $encrypted_5a1cb914c6c9_key -iv $encrypted_5a1cb914c6c9_iv -in .snapcraft/travis_snapcraft.cfg -out .snapcraft/snapcraft.cfg -d
         - docker run -v $(pwd):$(pwd) -t snapcore/snapcraft sh -c "apt update -qq && cd $(pwd) && ./snap/snap-multiarch.sh edge"
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Collective pinning and composition for IPFS
 description: |
   ipfs-cluster allows to replicate content (by pinning) in multiple IPFS nodes.
 
-confinement: classic
+confinement: strict
 
 apps:
   service:


### PR DESCRIPTION
Snaps won't publish with classic confimement or non-edge.
For the moment this works around that so that, at least,
there is releases on 'edge'  with strict confinement.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>

fyi @brianmcmichael . Will potentially re-enable `classic` if ever we're whitelisted.