### PR TITLE
Feat/improve pin serial

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -838,6 +838,16 @@ func (pins PinSerial) Clone() PinSerial {
 	return new
 }
 
+// DecodeCid retrieves just the cid from a PinSerial without
+// allocating a Pin.
+func (pins PinSerial) DecodeCid() cid.Cid {
+	c, err := cid.Decode(pins.Cid)
+	if err != nil {
+		logger.Debug(pins.Cid, err)
+	}
+	return c
+}
+
 // NodeWithMeta specifies a block of data and a set of optional metadata fields
 // carrying information about the encoded ipld node
 type NodeWithMeta struct {

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -257,3 +257,45 @@ func TestMetric(t *testing.T) {
 		t.Error("looks like a bad ttl")
 	}
 }
+
+func BenchmarkPinSerial_ToPin(b *testing.B) {
+	pin := Pin{
+		Cid:         testCid1,
+		Type:        ClusterDAGType,
+		Allocations: []peer.ID{testPeerID1},
+		Reference:   testCid2,
+		MaxDepth:    -1,
+		PinOptions: PinOptions{
+			ReplicationFactorMax: -1,
+			ReplicationFactorMin: -1,
+			Name:                 "A test pin",
+		},
+	}
+	pinS := pin.ToSerial()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pinS.ToPin()
+	}
+}
+
+func BenchmarkPinSerial_DecodeCid(b *testing.B) {
+	pin := Pin{
+		Cid:         testCid1,
+		Type:        ClusterDAGType,
+		Allocations: []peer.ID{testPeerID1},
+		Reference:   testCid2,
+		MaxDepth:    -1,
+		PinOptions: PinOptions{
+			ReplicationFactorMax: -1,
+			ReplicationFactorMin: -1,
+			Name:                 "A test pin",
+		},
+	}
+	pinS := pin.ToSerial()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pinS.DecodeCid()
+	}
+}

--- a/consensus/raft/log_op.go
+++ b/consensus/raft/log_op.go
@@ -50,24 +50,28 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 			goto ROLLBACK
 		}
 		// Async, we let the PinTracker take care of any problems
-		op.consensus.rpcClient.Go("",
+		op.consensus.rpcClient.Go(
+			"",
 			"Cluster",
 			"Track",
 			pinS,
 			&struct{}{},
-			nil)
+			nil,
+		)
 	case LogOpUnpin:
-		err = state.Rm(pin.Cid)
+		err = state.Rm(pinS.DecodeCid())
 		if err != nil {
 			goto ROLLBACK
 		}
 		// Async, we let the PinTracker take care of any problems
-		op.consensus.rpcClient.Go("",
+		op.consensus.rpcClient.Go(
+			"",
 			"Cluster",
 			"Untrack",
 			pinS,
 			&struct{}{},
-			nil)
+			nil,
+		)
 	default:
 		logger.Error("unknown LogOp type. Ignoring")
 	}

--- a/consensus/raft/log_op.go
+++ b/consensus/raft/log_op.go
@@ -43,11 +43,9 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 	// api.PinSerial, which don't get copied when passed.
 	pinS := op.Cid.Clone()
 
-	pin := pinS.ToPin()
-
 	switch op.Type {
 	case LogOpPin:
-		err = state.Add(pin)
+		err = state.Add(pinS.ToPin())
 		if err != nil {
 			goto ROLLBACK
 		}

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -37,7 +37,7 @@ func (rpcapi *RPCAPI) Pin(ctx context.Context, in api.PinSerial, out *struct{}) 
 
 // Unpin runs Cluster.Unpin().
 func (rpcapi *RPCAPI) Unpin(ctx context.Context, in api.PinSerial, out *struct{}) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	return rpcapi.c.Unpin(c)
 }
 
@@ -124,7 +124,7 @@ func (rpcapi *RPCAPI) StatusAllLocal(ctx context.Context, in struct{}, out *[]ap
 
 // Status runs Cluster.Status().
 func (rpcapi *RPCAPI) Status(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo, err := rpcapi.c.Status(c)
 	*out = pinfo.ToSerial()
 	return err
@@ -132,7 +132,7 @@ func (rpcapi *RPCAPI) Status(ctx context.Context, in api.PinSerial, out *api.Glo
 
 // StatusLocal runs Cluster.StatusLocal().
 func (rpcapi *RPCAPI) StatusLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo := rpcapi.c.StatusLocal(c)
 	*out = pinfo.ToSerial()
 	return nil
@@ -154,7 +154,7 @@ func (rpcapi *RPCAPI) SyncAllLocal(ctx context.Context, in struct{}, out *[]api.
 
 // Sync runs Cluster.Sync().
 func (rpcapi *RPCAPI) Sync(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo, err := rpcapi.c.Sync(c)
 	*out = pinfo.ToSerial()
 	return err
@@ -162,7 +162,7 @@ func (rpcapi *RPCAPI) Sync(ctx context.Context, in api.PinSerial, out *api.Globa
 
 // SyncLocal runs Cluster.SyncLocal().
 func (rpcapi *RPCAPI) SyncLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo, err := rpcapi.c.SyncLocal(c)
 	*out = pinfo.ToSerial()
 	return err
@@ -177,7 +177,7 @@ func (rpcapi *RPCAPI) RecoverAllLocal(ctx context.Context, in struct{}, out *[]a
 
 // Recover runs Cluster.Recover().
 func (rpcapi *RPCAPI) Recover(ctx context.Context, in api.PinSerial, out *api.GlobalPinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo, err := rpcapi.c.Recover(c)
 	*out = pinfo.ToSerial()
 	return err
@@ -185,7 +185,7 @@ func (rpcapi *RPCAPI) Recover(ctx context.Context, in api.PinSerial, out *api.Gl
 
 // RecoverLocal runs Cluster.RecoverLocal().
 func (rpcapi *RPCAPI) RecoverLocal(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo, err := rpcapi.c.RecoverLocal(c)
 	*out = pinfo.ToSerial()
 	return err
@@ -248,7 +248,7 @@ func (rpcapi *RPCAPI) Track(ctx context.Context, in api.PinSerial, out *struct{}
 
 // Untrack runs PinTracker.Untrack().
 func (rpcapi *RPCAPI) Untrack(ctx context.Context, in api.PinSerial, out *struct{}) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	return rpcapi.c.tracker.Untrack(c)
 }
 
@@ -260,7 +260,7 @@ func (rpcapi *RPCAPI) TrackerStatusAll(ctx context.Context, in struct{}, out *[]
 
 // TrackerStatus runs PinTracker.Status().
 func (rpcapi *RPCAPI) TrackerStatus(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo := rpcapi.c.tracker.Status(c)
 	*out = pinfo.ToSerial()
 	return nil
@@ -275,7 +275,7 @@ func (rpcapi *RPCAPI) TrackerRecoverAll(ctx context.Context, in struct{}, out *[
 
 // TrackerRecover runs PinTracker.Recover().
 func (rpcapi *RPCAPI) TrackerRecover(ctx context.Context, in api.PinSerial, out *api.PinInfoSerial) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	pinfo, err := rpcapi.c.tracker.Recover(c)
 	*out = pinfo.ToSerial()
 	return err
@@ -287,20 +287,20 @@ func (rpcapi *RPCAPI) TrackerRecover(ctx context.Context, in api.PinSerial, out 
 
 // IPFSPin runs IPFSConnector.Pin().
 func (rpcapi *RPCAPI) IPFSPin(ctx context.Context, in api.PinSerial, out *struct{}) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	depth := in.ToPin().MaxDepth
 	return rpcapi.c.ipfs.Pin(ctx, c, depth)
 }
 
 // IPFSUnpin runs IPFSConnector.Unpin().
 func (rpcapi *RPCAPI) IPFSUnpin(ctx context.Context, in api.PinSerial, out *struct{}) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	return rpcapi.c.ipfs.Unpin(ctx, c)
 }
 
 // IPFSPinLsCid runs IPFSConnector.PinLsCid().
 func (rpcapi *RPCAPI) IPFSPinLsCid(ctx context.Context, in api.PinSerial, out *api.IPFSPinStatus) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	b, err := rpcapi.c.ipfs.PinLsCid(ctx, c)
 	*out = b
 	return err
@@ -347,7 +347,7 @@ func (rpcapi *RPCAPI) IPFSBlockPut(ctx context.Context, in api.NodeWithMeta, out
 
 // IPFSBlockGet runs IPFSConnector.BlockGet().
 func (rpcapi *RPCAPI) IPFSBlockGet(ctx context.Context, in api.PinSerial, out *[]byte) error {
-	c := in.ToPin().Cid
+	c := in.DecodeCid()
 	res, err := rpcapi.c.ipfs.BlockGet(c)
 	*out = res
 	return err


### PR DESCRIPTION
Merge #597 first. 

Benchmarks of `PinSerial.ToPin()` and `PinSerial.DecodeCid()`:
```
BenchmarkPinSerial_ToPin-8               2000000              4322 ns/op            1680 B/op         18 allocs/op
BenchmarkPinSerial_DecodeCid-8           5000000              1456 ns/op             576 B/op          6 allocs/op
```
I don't expect `ToPin()` to be efficient but we call it quite a lot just to get the decoded Cid value out, especially in the rpc functions (14 occurances of `c := pinSerial.ToPin().Cid`) which will be a win for rpc calls like `Status` which gets called a lot. 