### PR TITLE
add envcfg to rest api

### DIFF
--- a/api/rest/config.go
+++ b/api/rest/config.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/config"
 
+	"github.com/kelseyhightower/envconfig"
+
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
 const configKey = "restapi"
+const envConfigKey = "cluster_restapi"
 
 // These are the default values for Config
 const (
@@ -182,6 +185,12 @@ func (cfg *Config) LoadJSON(raw []byte) error {
 	}
 
 	cfg.Default()
+
+	// override json config with env var
+	err = envconfig.Process(envConfigKey, jcfg)
+	if err != nil {
+		return err
+	}
 
 	err = cfg.loadHTTPOptions(jcfg)
 	if err != nil {

--- a/api/rest/config_test.go
+++ b/api/rest/config_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 	"time"
 
@@ -99,6 +100,35 @@ func TestLoadJSON(t *testing.T) {
 	err = cfg.LoadJSON(tst)
 	if err == nil {
 		t.Error("expected error with private key")
+	}
+}
+
+func TestLoadJSONEnvConfig(t *testing.T) {
+	username := "admin"
+	password := "thisaintmypassword"
+	user1 := "user1"
+	user1pass := "user1passwd"
+	os.Setenv("CLUSTER_RESTAPI_BASICAUTHCREDS", username+":"+password+","+user1+":"+user1pass)
+	cfg := &Config{}
+	err := cfg.LoadJSON(cfgJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := cfg.BasicAuthCreds[username]; !ok {
+		t.Fatalf("username '%s' not set in BasicAuthCreds map: %v", username, cfg.BasicAuthCreds)
+	}
+
+	if _, ok := cfg.BasicAuthCreds[user1]; !ok {
+		t.Fatalf("username '%s' not set in BasicAuthCreds map: %v", user1, cfg.BasicAuthCreds)
+	}
+
+	if gotpasswd := cfg.BasicAuthCreds[username]; gotpasswd != password {
+		t.Errorf("password not what was set in env var, got: %s, want: %s", gotpasswd, password)
+	}
+
+	if gotpasswd := cfg.BasicAuthCreds[user1]; gotpasswd != user1pass {
+		t.Errorf("password not what was set in env var, got: %s, want: %s", gotpasswd, user1pass)
 	}
 }
 


### PR DESCRIPTION
@hsanjuan Can we get this one through as soon as possible? There is no good way to do this without installing `jq` on to a container and editing the `service.json` after `ipfs-cluster` has been initialised.