### PR TITLE
Remove `proxy_` and `Proxy` from proxy config

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -50,6 +50,8 @@ USER root
 RUN mkdir -p $IPFS_CLUSTER_PATH && \
     chown 1000:100 $IPFS_CLUSTER_PATH
 
+USER ipfs
+
 VOLUME $IPFS_CLUSTER_PATH
 ENTRYPOINT ["/usr/local/bin/start-daemons.sh"]
 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -45,7 +45,7 @@ COPY --from=builder /tmp/jq-linux64 /usr/local/bin/jq
 COPY --from=builder /bin/bash /bin/bash
 COPY --from=builder /lib/x86_64-linux-gnu/libtinfo.so.5 /lib64/libtinfo.so.5
 
-
+USER root
 
 RUN mkdir -p $IPFS_CLUSTER_PATH && \
     chown 1000:100 $IPFS_CLUSTER_PATH

--- a/api/ipfsproxy/config_test.go
+++ b/api/ipfsproxy/config_test.go
@@ -78,31 +78,31 @@ func TestDefault(t *testing.T) {
 	}
 
 	cfg.Default()
-	cfg.ProxyAddr = nil
+	cfg.ListenAddr = nil
 	if cfg.Validate() == nil {
 		t.Fatal("expected error validating")
 	}
 
 	cfg.Default()
-	cfg.ProxyReadTimeout = -1
+	cfg.ReadTimeout = -1
 	if cfg.Validate() == nil {
 		t.Fatal("expected error validating")
 	}
 
 	cfg.Default()
-	cfg.ProxyReadHeaderTimeout = -2
+	cfg.ReadHeaderTimeout = -2
 	if cfg.Validate() == nil {
 		t.Fatal("expected error validating")
 	}
 
 	cfg.Default()
-	cfg.ProxyIdleTimeout = -1
+	cfg.IdleTimeout = -1
 	if cfg.Validate() == nil {
 		t.Fatal("expected error validating")
 	}
 
 	cfg.Default()
-	cfg.ProxyWriteTimeout = -3
+	cfg.WriteTimeout = -3
 	if cfg.Validate() == nil {
 		t.Fatal("expected error validating")
 	}

--- a/api/ipfsproxy/ipfsproxy.go
+++ b/api/ipfsproxy/ipfsproxy.go
@@ -102,7 +102,7 @@ func New(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 
-	proxyNet, proxyAddr, err := manet.DialArgs(cfg.ProxyAddr)
+	proxyNet, proxyAddr, err := manet.DialArgs(cfg.ListenAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -122,10 +122,10 @@ func New(cfg *Config) (*Server, error) {
 
 	smux := http.NewServeMux()
 	s := &http.Server{
-		ReadTimeout:       cfg.ProxyReadTimeout,
-		WriteTimeout:      cfg.ProxyWriteTimeout,
-		ReadHeaderTimeout: cfg.ProxyReadHeaderTimeout,
-		IdleTimeout:       cfg.ProxyIdleTimeout,
+		ReadTimeout:       cfg.ReadTimeout,
+		WriteTimeout:      cfg.WriteTimeout,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+		IdleTimeout:       cfg.IdleTimeout,
 		Handler:           smux,
 	}
 
@@ -204,7 +204,7 @@ func (proxy *Server) run() {
 		defer proxy.wg.Done()
 		logger.Infof(
 			"IPFS Proxy: %s -> %s",
-			proxy.config.ProxyAddr,
+			proxy.config.ListenAddr,
 			proxy.config.NodeAddr,
 		)
 		err := proxy.server.Serve(proxy.listener) // hangs here

--- a/api/ipfsproxy/ipfsproxy_test.go
+++ b/api/ipfsproxy/ipfsproxy_test.go
@@ -28,7 +28,7 @@ func testIPFSProxy(t *testing.T) (*Server, *test.IpfsMock) {
 	cfg := &Config{}
 	cfg.Default()
 	cfg.NodeAddr = nodeMAddr
-	cfg.ProxyAddr = proxyMAddr
+	cfg.ListenAddr = proxyMAddr
 
 	proxy, err := New(cfg)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -318,13 +318,15 @@ func (cfg *Manager) LoadJSON(bs []byte) error {
 	loadSectionJSON(sections[API], jcfg.API)
 	// Should we change hardcoded "ipfsproxy" to something else
 	if _, ok := jcfg.API["ipfsproxy"]; !ok {
-		loadCompJSON("ipfsproxy", sections[API]["ipfsproxy"], jcfg.IPFSConn)
+		loadCompJSON("ipfshttp", sections[API]["ipfsproxy"], jcfg.IPFSConn)
 		logger.Warning(`
-			The IPFS proxy functionality has been extracted as a separate component and now uses
-			its own configuration section ("ipfsproxy" in the "api" section).
+The IPFS proxy functionality has been extracted as a separate component
+and now uses its own configuration section ("ipfsproxy" in the "api" section).
 
-			To keep compatibility, since you did not define an "ipfsproxy" section, the proxy configuration is taken from the "ipfshttp" section as before, but this will be removed in future versions.
-			`)
+To keep compatibility, since you did not define an "ipfsproxy" section, the
+proxy configuration is taken from the "ipfshttp" section as before, but this
+will be removed in future versions.
+`)
 	}
 	loadSectionJSON(sections[IPFSConn], jcfg.IPFSConn)
 	loadSectionJSON(sections[State], jcfg.State)

--- a/config_test.go
+++ b/config_test.go
@@ -67,22 +67,17 @@ var testingAPICfg = []byte(`{
 }`)
 
 var testingProxyCfg = []byte(`{
-    "proxy_listen_multiaddress": "/ip4/127.0.0.1/tcp/10001",
+    "listen_multiaddress": "/ip4/127.0.0.1/tcp/10001",
     "node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
-    "proxy_read_timeout": "0",
-    "proxy_read_header_timeout": "10m0s",
-    "proxy_write_timeout": "0",
-    "proxy_idle_timeout": "1m0s"
+    "read_timeout": "0",
+    "read_header_timeout": "10m0s",
+    "write_timeout": "0",
+    "idle_timeout": "1m0s"
 }`)
 
 var testingIpfsCfg = []byte(`{
-    "proxy_listen_multiaddress": "/ip4/127.0.0.1/tcp/10001",
     "node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
     "connect_swarms_delay": "7s",
-    "proxy_read_timeout": "0",
-    "proxy_read_header_timeout": "10m0s",
-    "proxy_write_timeout": "0",
-    "proxy_idle_timeout": "1m0s",
     "pin_method": "pin",
     "pin_timeout": "30s",
     "unpin_timeout": "15s"

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -154,7 +154,7 @@ func createComponents(t *testing.T, i int, clusterSecret []byte, staging bool) (
 	checkErr(t, err)
 
 	apiCfg.HTTPListenAddr = apiAddr
-	ipfsproxyCfg.ProxyAddr = proxyAddr
+	ipfsproxyCfg.ListenAddr = proxyAddr
 	ipfsproxyCfg.NodeAddr = nodeAddr
 	ipfshttpCfg.NodeAddr = nodeAddr
 	consensusCfg.DataFolder = "./e2eTestRaft/" + pid.Pretty()


### PR DESCRIPTION
Remove proxy_ and Proxy from proxy config objects without breaking
compatibility with previous revisions

Fixes #616