### PR TITLE
Fix #382: Extract headers from IPFS API requests and apply them to hijacked ones.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/pstoremgr"
 	"github.com/ipfs/ipfs-cluster/rpcutil"
 	"github.com/ipfs/ipfs-cluster/state"
+	"github.com/ipfs/ipfs-cluster/version"
 
 	cid "github.com/ipfs/go-cid"
 	rpc "github.com/libp2p/go-libp2p-gorpc"
@@ -104,7 +105,7 @@ func NewCluster(
 		listenAddrs += fmt.Sprintf("        %s/ipfs/%s\n", addr, host.ID().Pretty())
 	}
 
-	logger.Infof("IPFS Cluster v%s listening on:\n%s\n", Version, listenAddrs)
+	logger.Infof("IPFS Cluster v%s listening on:\n%s\n", version.Version, listenAddrs)
 
 	// Note, we already loaded peers from peerstore into the host
 	// in daemon.go.
@@ -162,13 +163,13 @@ func NewCluster(
 }
 
 func (c *Cluster) setupRPC() error {
-	rpcServer := rpc.NewServer(c.host, RPCProtocol)
+	rpcServer := rpc.NewServer(c.host, version.RPCProtocol)
 	err := rpcServer.RegisterName("Cluster", &RPCAPI{c})
 	if err != nil {
 		return err
 	}
 	c.rpcServer = rpcServer
-	rpcClient := rpc.NewClientWithServer(c.host, RPCProtocol, rpcServer)
+	rpcClient := rpc.NewClientWithServer(c.host, version.RPCProtocol, rpcServer)
 	c.rpcClient = rpcClient
 	return nil
 }
@@ -540,8 +541,8 @@ func (c *Cluster) ID() api.ID {
 		Addresses:             addrs,
 		ClusterPeers:          peers,
 		ClusterPeersAddresses: c.peerManager.PeersAddresses(peers),
-		Version:               Version.String(),
-		RPCProtocolVersion:    RPCProtocol,
+		Version:               version.Version.String(),
+		RPCProtocolVersion:    version.RPCProtocol,
 		IPFS:                  ipfsID,
 		Peername:              c.config.Peername,
 	}
@@ -1092,7 +1093,7 @@ func (c *Cluster) AddFile(reader *multipart.Reader, params *api.AddParams) (cid.
 
 // Version returns the current IPFS Cluster version.
 func (c *Cluster) Version() string {
-	return Version.String()
+	return version.Version.String()
 }
 
 // Peers returns the IDs of the members of this Cluster.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/state"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 	"github.com/ipfs/ipfs-cluster/test"
+	"github.com/ipfs/ipfs-cluster/version"
 
 	cid "github.com/ipfs/go-cid"
 	rpc "github.com/libp2p/go-libp2p-gorpc"
@@ -230,7 +231,7 @@ func TestClusterID(t *testing.T) {
 	if id.ID == "" {
 		t.Error("expected a cluster ID")
 	}
-	if id.Version != Version.String() {
+	if id.Version != version.Version.String() {
 		t.Error("version should match current version")
 	}
 	//if id.PublicKey == nil {
@@ -776,7 +777,7 @@ func TestVersion(t *testing.T) {
 	cl, _, _, _, _ := testingCluster(t)
 	defer cleanRaft()
 	defer cl.Shutdown()
-	if cl.Version() != Version.String() {
+	if cl.Version() != version.Version.String() {
 		t.Error("bad Version()")
 	}
 }

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -13,6 +13,7 @@ import (
 
 	ipfscluster "github.com/ipfs/ipfs-cluster"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
+	"github.com/ipfs/ipfs-cluster/version"
 
 	semver "github.com/blang/semver"
 	logging "github.com/ipfs/go-log"
@@ -117,7 +118,7 @@ var (
 func init() {
 	// Set build information.
 	if build, err := semver.NewBuildVersion(commit); err == nil {
-		ipfscluster.Version.Build = []string{"git" + build}
+		version.Version.Build = []string{"git" + build}
 	}
 
 	// We try guessing user's home from the HOME variable. This
@@ -164,7 +165,7 @@ func main() {
 	app.Usage = "IPFS Cluster node"
 	app.Description = Description
 	//app.Copyright = "© Protocol Labs, Inc."
-	app.Version = ipfscluster.Version.String()
+	app.Version = version.Version.String()
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "config, c",
@@ -446,7 +447,7 @@ the mth data folder (m currently defaults to 5)
 			Name:  "version",
 			Usage: "Print the ipfs-cluster version",
 			Action: func(c *cli.Context) error {
-				fmt.Printf("%s\n", ipfscluster.Version)
+				fmt.Printf("%s\n", version.Version)
 				return nil
 			},
 		},

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/state"
 	"github.com/ipfs/ipfs-cluster/state/mapstate"
 	"github.com/ipfs/ipfs-cluster/test"
+	"github.com/ipfs/ipfs-cluster/version"
 
 	cid "github.com/ipfs/go-cid"
 	crypto "github.com/libp2p/go-libp2p-crypto"
@@ -378,7 +379,7 @@ func TestClustersVersion(t *testing.T) {
 	defer shutdownClusters(t, clusters, mock)
 	f := func(t *testing.T, c *Cluster) {
 		v := c.Version()
-		if v != Version.String() {
+		if v != version.Version.String() {
 			t.Error("Bad version")
 		}
 	}

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ if [ -z $version ]; then
 fi
 
 make gx-clean
-sed -i "s/Version = semver\.MustParse.*$/Version = semver.MustParse(\"$version\")/" version.go
+sed -i "s/Version = semver\.MustParse.*$/Version = semver.MustParse(\"$version\")/" version/version.go
 sed -i "s/const Version.*$/const Version = \"$version\"/" cmd/ipfs-cluster-ctl/main.go
 git commit -S -a -m "Release $version"
 lastver=`git tag -l | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1`

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -107,6 +107,8 @@ func NewIpfsMock() *IpfsMock {
 // FIXME: what if IPFS API changes?
 func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 	p := r.URL.Path
+	w.Header().Set("Access-Control-Allow-Headers", "test-allow-header")
+	w.Header().Set("Server", "ipfs-mock")
 	endp := strings.TrimPrefix(p, "/api/v0/")
 	switch endp {
 	case "id":

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-package ipfscluster
+package version
 
 import (
 	"fmt"


### PR DESCRIPTION
This commit makes the proxy extract useful fixed headers (like CORS) from
the IPFS daemon API responses and then apply them to the responses
from hijacked endpoints like /add or /repo/stat.

It does this by caching a list of headers from the first IPFS API
response which has them. If we have not performed any proxied request or
managed to obtain the headers we're interested in, this will try triggering a
request to "/api/v0/version" to obtain them first.

This should fix the issues with using Cluster proxy with IPFS Companion and
Chrome.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>