### PR TITLE
Fix ipfs-cluster-ctl with HTTPs multiaddresses

### DIFF
--- a/api/rest/client/client_test.go
+++ b/api/rest/client/client_test.go
@@ -185,12 +185,12 @@ func TestDNSMultiaddress(t *testing.T) {
 		t.Fatal(err)
 	}
 	dc := c.(*defaultClient)
-	if dc.hostname != "127.0.0.1:1234" {
-		t.Error("bad resolved address")
+	if dc.hostname != "localhost:1234" {
+		t.Error("address should not be resolved")
 	}
 
-	if dc.config.ProxyAddr == nil || dc.config.ProxyAddr.String() != "/ip4/127.0.0.1/tcp/9095" {
-		t.Error("proxy address was not guessed correctly")
+	if paddr := dc.config.ProxyAddr; paddr == nil || paddr.String() != "/dns4/localhost/tcp/9095" {
+		t.Error("proxy address was not guessed correctly: ", paddr)
 	}
 }
 


### PR DESCRIPTION
Before we resolved all /dns*/ multiaddresses before we used them.

When using HTTPs, the Go HTTP Client only sees the resolved IP address
and it is unable to negotiate TLS with a cerficate because the request
is not going to the hostname the certificate is signed for, but to
the IP. This leverages a recent feature in go-multiaddr-net
and uses directly the user-provided hostname.