### PR TITLE
Fix #632: Add --no-stream to ipfs-cluster-ctl

### DIFF
--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 )
 
+type addedOutputQuiet struct {
+	added *api.AddedOutput
+	quiet bool
+}
+
 func jsonFormatObject(resp interface{}) {
 	switch resp.(type) {
 	case nil:
@@ -25,6 +30,10 @@ func jsonFormatObject(resp interface{}) {
 		jsonFormatPrint(resp.(api.Pin).ToSerial())
 	case api.AddedOutput:
 		jsonFormatPrint(resp.(api.AddedOutput))
+	case addedOutputQuiet:
+		// print original object as in json it does
+		// not make sense quiet output.
+		jsonFormatPrint(resp.(addedOutputQuiet).added)
 	case api.Version:
 		jsonFormatPrint(resp.(api.Version))
 	case api.Metric:
@@ -57,6 +66,13 @@ func jsonFormatObject(resp interface{}) {
 	case []api.AddedOutput:
 		serials := resp.([]api.AddedOutput)
 		jsonFormatPrint(serials)
+	case []addedOutputQuiet: // print original output
+		serials := resp.([]addedOutputQuiet)
+		var actual []*api.AddedOutput
+		for _, s := range serials {
+			actual = append(actual, s.added)
+		}
+		jsonFormatPrint(actual)
 	case []api.Metric:
 		serials := resp.([]api.Metric)
 		jsonFormatPrint(serials)
@@ -87,6 +103,9 @@ func textFormatObject(resp interface{}) {
 	case api.AddedOutput:
 		serial := resp.(api.AddedOutput)
 		textFormatPrintAddedOutput(&serial)
+	case addedOutputQuiet:
+		serial := resp.(addedOutputQuiet)
+		textFormatPrintAddedOutputQuiet(&serial)
 	case api.Version:
 		serial := resp.(api.Version)
 		textFormatPrintVersion(&serial)
@@ -110,6 +129,10 @@ func textFormatObject(resp interface{}) {
 		}
 	case []api.AddedOutput:
 		for _, item := range resp.([]api.AddedOutput) {
+			textFormatObject(item)
+		}
+	case []addedOutputQuiet:
+		for _, item := range resp.([]addedOutputQuiet) {
 			textFormatObject(item)
 		}
 	case []api.Metric:
@@ -216,6 +239,14 @@ func textFormatPrintPin(obj *api.PinSerial) {
 
 func textFormatPrintAddedOutput(obj *api.AddedOutput) {
 	fmt.Printf("added %s %s\n", obj.Cid, obj.Name)
+}
+
+func textFormatPrintAddedOutputQuiet(obj *addedOutputQuiet) {
+	if obj.quiet {
+		fmt.Printf("%s\n", obj.added.Cid)
+	} else {
+		textFormatPrintAddedOutput(obj.added)
+	}
 }
 
 func textFormatPrintMetric(obj *api.Metric) {

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -31,8 +31,8 @@ func jsonFormatObject(resp interface{}) {
 	case api.AddedOutput:
 		jsonFormatPrint(resp.(api.AddedOutput))
 	case addedOutputQuiet:
-		// print original object as in json it does
-		// not make sense quiet output.
+		// print original object as in JSON it does
+		// not make sense to have a human "quiet" output.
 		jsonFormatPrint(resp.(addedOutputQuiet).added)
 	case api.Version:
 		jsonFormatPrint(resp.(api.Version))
@@ -66,7 +66,9 @@ func jsonFormatObject(resp interface{}) {
 	case []api.AddedOutput:
 		serials := resp.([]api.AddedOutput)
 		jsonFormatPrint(serials)
-	case []addedOutputQuiet: // print original output
+	case []addedOutputQuiet:
+		// print original objects as in JSON it makes
+		// no sense to have a human "quiet" output
 		serials := resp.([]addedOutputQuiet)
 		var actual []*api.AddedOutput
 		for _, s := range serials {

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -279,7 +279,7 @@ cluster "pin add".
 				},
 				cli.BoolFlag{
 					Name:  "no-stream",
-					Usage: "Buffer output locally. Produces a valid slice with --enc=json.",
+					Usage: "Buffer output locally. Produces a valid JSON array with --enc=json.",
 				},
 				cli.StringFlag{
 					Name:  "layout",
@@ -400,7 +400,7 @@ cluster "pin add".
 					var lastBuf = make([]addedOutputQuiet, 1, 1)
 					var qq = c.Bool("quieter")
 					var q = c.Bool("quiet") || qq
-					var bufferResults = !c.Bool("stream")
+					var bufferResults = c.Bool("no-stream")
 					for v := range out {
 						added := addedOutputQuiet{v, q}
 						lastBuf[0] = added


### PR DESCRIPTION
tl;dr: this solves the user's immediate need and, even if not tne strictest
solution, it is the simplest one.

I think we should not have the server buffer output when we can do it rather
easily client side and have the clients use their own memory for the task even
if `stream-channels=false` would do this.

We can always change the approach, but this is the minimal solution to
json array with all the AddedOutput things.

We might not buffer at all and hack a `[`, `,` separating elements and `]`
at the end, when json encoding is enabled, etc. But that would not be clean,
specially if we mean to support more output formats at some point.

Enabling supporting stream-channels=false in the api/rest/client means adding
new methods, with tests, modifying the interface etc etc. for what is
essentially a presentation issue in "ctl" in the end. Similarly we could
buffer inside the client, but it is so trivial that I don't see advatange.
We should also start thinking about moving to streaming API endpoints and
when that moment arrives we shall revisit this discussion.

I have removed the hacky manual output parts by declaring a custom
addedOutputQuiet type which wraps added output and is understood by
the formatters.go helpers.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>