### PR TITLE
Fix/639: Add support for handling preflight CORS requests

### DIFF
--- a/api/rest/config.go
+++ b/api/rest/config.go
@@ -52,8 +52,8 @@ var (
 		"X-Chunked-Output",
 		"X-Content-Length",
 	}
-	DefaultCORSAllowCredentials               = true
-	DefaultCORSMaxAge           time.Duration = 0
+	DefaultCORSAllowCredentials = true
+	DefaultCORSMaxAge           time.Duration // 0. Means always.
 )
 
 // Config is used to intialize the API object and allows to

--- a/api/rest/config.go
+++ b/api/rest/config.go
@@ -279,6 +279,9 @@ func (cfg *Config) loadHTTPOptions(jcfg *jsonConfig) error {
 	cfg.CORSAllowedHeaders = jcfg.CORSAllowedHeaders
 	cfg.CORSExposedHeaders = jcfg.CORSExposedHeaders
 	cfg.CORSAllowCredentials = jcfg.CORSAllowCredentials
+	if jcfg.CORSMaxAge == "" { // compatibility
+		jcfg.CORSMaxAge = "0s"
+	}
 
 	return config.ParseDurations(
 		"restapi",

--- a/api/rest/config_test.go
+++ b/api/rest/config_test.go
@@ -13,14 +13,20 @@ import (
 
 var cfgJSON = []byte(`
 {
-      "listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
+      "listen_multiaddress": "/ip4/127.0.0.1/tcp/12122",
       "ssl_cert_file": "test/server.crt",
       "ssl_key_file": "test/server.key",
       "read_timeout": "30s",
       "read_header_timeout": "5s",
       "write_timeout": "1m0s",
       "idle_timeout": "2m0s",
-      "basic_auth_credentials": null
+      "basic_auth_credentials": null,
+      "cors_allowed_origins": ["myorigin"],
+      "cors_allowed_methods": ["GET"],
+      "cors_allowed_headers": ["X-Custom"],
+      "cors_exposed_headers": ["X-Chunked-Output"],
+      "cors_allow_credentials": false,
+      "cors_max_age": "1s"
 }
 `)
 

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -21,9 +21,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/cors"
+
 	"github.com/ipfs/ipfs-cluster/adder/adderutils"
 	types "github.com/ipfs/ipfs-cluster/api"
-	"github.com/rs/cors"
 
 	mux "github.com/gorilla/mux"
 	gostream "github.com/hsanjuan/go-libp2p-gostream"
@@ -109,15 +110,20 @@ func NewAPIWithHost(cfg *Config, h host.Host) (*API, error) {
 		return nil, err
 	}
 
+	// Our handler is a gorilla router,
+	// wrapped with the cors handler,
+	// wrapped with the basic auth handler.
 	router := mux.NewRouter().StrictSlash(true)
-	c := cors.New(*cfg.corsOptions())
-	withCorsRouter := c.Handler(router)
+	handler := basicAuthHandler(
+		cfg.BasicAuthCreds,
+		cors.New(*cfg.corsOptions()).Handler(router),
+	)
 	s := &http.Server{
 		ReadTimeout:       cfg.ReadTimeout,
 		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
 		WriteTimeout:      cfg.WriteTimeout,
 		IdleTimeout:       cfg.IdleTimeout,
-		Handler:           withCorsRouter,
+		Handler:           handler,
 	}
 
 	// See: https://github.com/ipfs/go-ipfs/issues/5168
@@ -228,9 +234,6 @@ func (api *API) Host() host.Host {
 
 func (api *API) addRoutes(router *mux.Router) {
 	for _, route := range api.routes() {
-		if api.config.BasicAuthCreds != nil {
-			route.HandlerFunc = basicAuth(route.HandlerFunc, api.config.BasicAuthCreds)
-		}
 		router.
 			Methods(route.Method).
 			Path(route.Pattern).
@@ -240,8 +243,13 @@ func (api *API) addRoutes(router *mux.Router) {
 	api.router = router
 }
 
-func basicAuth(h http.HandlerFunc, credentials map[string]string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+// basicAuth wraps a given handler with basic authentication
+func basicAuthHandler(credentials map[string]string, h http.Handler) http.Handler {
+	if credentials == nil {
+		return h
+	}
+
+	wrap := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 		username, password, ok := r.BasicAuth()
 		if !ok {
@@ -271,6 +279,7 @@ func basicAuth(h http.HandlerFunc, credentials map[string]string) http.HandlerFu
 		}
 		h.ServeHTTP(w, r)
 	}
+	return http.HandlerFunc(wrap)
 }
 
 func unauthorizedResp() (string, error) {

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/adder/adderutils"
 	types "github.com/ipfs/ipfs-cluster/api"
+	"github.com/rs/cors"
 
 	mux "github.com/gorilla/mux"
 	gostream "github.com/hsanjuan/go-libp2p-gostream"
@@ -109,12 +110,14 @@ func NewAPIWithHost(cfg *Config, h host.Host) (*API, error) {
 	}
 
 	router := mux.NewRouter().StrictSlash(true)
+	c := cors.New(*cfg.corsOptions())
+	withCorsRouter := c.Handler(router)
 	s := &http.Server{
 		ReadTimeout:       cfg.ReadTimeout,
 		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
 		WriteTimeout:      cfg.WriteTimeout,
 		IdleTimeout:       cfg.IdleTimeout,
-		Handler:           router,
+		Handler:           withCorsRouter,
 	}
 
 	// See: https://github.com/ipfs/go-ipfs/issues/5168

--- a/package.json
+++ b/package.json
@@ -155,6 +155,12 @@
       "hash": "QmeP7Gybon3hs9KhoxSFvzqAHQS6xgyKYvsnjqktaXX3QN",
       "name": "go-libp2p-pubsub",
       "version": "100.11.9"
+    },
+    {
+      "author": "hsanjuan",
+      "hash": "QmNNk4iczWp8Q4R1mXQ2mrrjQvWisYqMqbW1an8qGbJZsM",
+      "name": "cors",
+      "version": "1.6.0"
     }
   ],
   "gxVersion": "0.11.0",


### PR DESCRIPTION
This adds support for handling preflight requests in the REST API
and fixes currently mostly broken CORS.

Before we just let the user add custom response headers to the
configuration "headers" key but this is not the best way because
CORs headers and requests need special handling and doing it wrong
has security implications.

Therefore, I have added specific CORS-related configuration options
which control CORS behavour. We are forced to change the "headers"
defaults and will notify the users about this in the changelog.