### PR TITLE
config: Fix confusing errors

### DIFF
--- a/config/util.go
+++ b/config/util.go
@@ -97,7 +97,8 @@ type DurationOpt struct {
 func ParseDurations(component string, args ...*DurationOpt) error {
 	for _, arg := range args {
 		if arg.Duration == "" {
-			*arg.Dst = 0
+			// don't do anything. Let the destination field
+			// stay at its default.
 			continue
 		}
 		t, err := time.ParseDuration(arg.Duration)

--- a/config/util.go
+++ b/config/util.go
@@ -96,6 +96,10 @@ type DurationOpt struct {
 // ParseDurations takes a time.Duration src and saves it to the given dst.
 func ParseDurations(component string, args ...*DurationOpt) error {
 	for _, arg := range args {
+		if arg.Duration == "" {
+			*arg.Dst = 0
+			continue
+		}
 		t, err := time.ParseDuration(arg.Duration)
 		if err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
The JSON parsing of the config could error, but we skipped error checking and
use Validate() at the end. This caused that maybe some JSON parsing errors
where logged but the final error when validating the configuration came from
somewhere different, creating very confusing error messages for the user.

This changes this, along with removing hardcoded section lists. This also
removes a Sharder component section because, AFAIK, it was a left over
from the sharding branch and in the end there is no separate sharding
component that needs a config.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>