### PR TITLE
sharness: Fix test typo causing an empty grep

### DIFF
--- a/sharness/t0032-ctl-health.sh
+++ b/sharness/t0032-ctl-health.sh
@@ -21,7 +21,7 @@ test_expect_success IPFS,CLUSTER "health metrics without metric name fails" '
 '
 
 test_expect_success IPFS,CLUSTER "list latest metrics logged by this peer" '
-    pid=`docker exec ipfs sh -c "ipfs id | jq .ID"`
+    pid=`docker exec ipfs sh -c "ipfs id"` | jq ".ID"
     ipfs-cluster-ctl health metrics freespace | grep -q "$pid: [0-9]* | Expire: .*T.*Z"
 '
 

--- a/sharness/t0032-ctl-health.sh
+++ b/sharness/t0032-ctl-health.sh
@@ -21,8 +21,8 @@ test_expect_success IPFS,CLUSTER "health metrics without metric name fails" '
 '
 
 test_expect_success IPFS,CLUSTER "list latest metrics logged by this peer" '
-    pid=`docker exec ipfs sh -c "ipfs id" | jq ".ID"`
-    ipfs-cluster-ctl health metrics freespace | grep -q "$pid: [0-9]* | Expire: .*T.*Z"
+    pid=`ipfs-cluster-ctl --enc=json id | jq -r ".id"`
+    ipfs-cluster-ctl health metrics freespace | grep -q -E "^$pid: [0-9]+ | Expire: .+T.+Z"
 '
 
 test_clean_ipfs

--- a/sharness/t0032-ctl-health.sh
+++ b/sharness/t0032-ctl-health.sh
@@ -21,7 +21,7 @@ test_expect_success IPFS,CLUSTER "health metrics without metric name fails" '
 '
 
 test_expect_success IPFS,CLUSTER "list latest metrics logged by this peer" '
-    pid=`docker exec ipfs sh -c "ipfs id"` | jq ".ID"
+    pid=`docker exec ipfs sh -c "ipfs id" | jq ".ID"`
     ipfs-cluster-ctl health metrics freespace | grep -q "$pid: [0-9]* | Expire: .*T.*Z"
 '
 


### PR DESCRIPTION
The ipfs container does not have `jq` in it. We need to run `jq` outside of it. This was logged when tests run, but the test did not fail.