### PR TITLE
Fix/update json config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -178,26 +178,26 @@ type jsonConfig struct {
 	Observations jsonSection      `json:"observations,omitempty"`
 }
 
-func (jcfg *jsonConfig) getSection(i SectionType) jsonSection {
+func (jcfg *jsonConfig) getSection(i SectionType) *jsonSection {
 	switch i {
 	case Consensus:
-		return jcfg.Consensus
+		return &jcfg.Consensus
 	case API:
-		return jcfg.API
+		return &jcfg.API
 	case IPFSConn:
-		return jcfg.IPFSConn
+		return &jcfg.IPFSConn
 	case State:
-		return jcfg.State
+		return &jcfg.State
 	case PinTracker:
-		return jcfg.PinTracker
+		return &jcfg.PinTracker
 	case Monitor:
-		return jcfg.Monitor
+		return &jcfg.Monitor
 	case Allocator:
-		return jcfg.Allocator
+		return &jcfg.Allocator
 	case Informer:
-		return jcfg.Informer
+		return &jcfg.Informer
 	case Observations:
-		return jcfg.Observations
+		return &jcfg.Observations
 	default:
 		return nil
 	}
@@ -356,7 +356,7 @@ func (cfg *Manager) LoadJSON(bs []byte) error {
 		if t == Cluster {
 			continue
 		}
-		err := loadSectionJSON(sections[t], jcfg.getSection(t))
+		err := loadSectionJSON(sections[t], *jcfg.getSection(t))
 		if err != nil {
 			return err
 		}
@@ -445,7 +445,7 @@ func (cfg *Manager) ToJSON() ([]byte, error) {
 			continue
 		}
 		jsection := jcfg.getSection(t)
-		err := updateJSONConfigs(cfg.sections[t], &jsection)
+		err := updateJSONConfigs(cfg.sections[t], jsection)
 		if err != nil {
 			return nil, err
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,18 +38,9 @@ func setupConfigManager() *config.Manager {
 	cfg := config.NewManager()
 	mockCfg := &mockCfg{}
 	cfg.RegisterComponent(config.Cluster, mockCfg)
-	cfg.RegisterComponent(config.API, mockCfg)
-	cfg.RegisterComponent(config.API, mockCfg)
-	cfg.RegisterComponent(config.IPFSConn, mockCfg)
-	cfg.RegisterComponent(config.Consensus, mockCfg)
-	cfg.RegisterComponent(config.PinTracker, mockCfg)
-	cfg.RegisterComponent(config.PinTracker, mockCfg)
-	cfg.RegisterComponent(config.Monitor, mockCfg)
-	cfg.RegisterComponent(config.Monitor, mockCfg)
-	cfg.RegisterComponent(config.Informer, mockCfg)
-	cfg.RegisterComponent(config.Informer, mockCfg)
-	cfg.RegisterComponent(config.Observations, mockCfg)
-	cfg.RegisterComponent(config.Observations, mockCfg)
+	for _, sect := range config.SectionTypes() {
+		cfg.RegisterComponent(sect, mockCfg)
+	}
 	return cfg
 }
 
@@ -73,12 +64,22 @@ func TestManager_ToJSON(t *testing.T) {
       "a": "b"
     }
   },
+  "state": {
+    "mock": {
+      "a": "b"
+    }
+  },
   "pin_tracker": {
     "mock": {
       "a": "b"
     }
   },
   "monitor": {
+    "mock": {
+      "a": "b"
+    }
+  },
+  "allocator": {
     "mock": {
       "a": "b"
     }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,137 +5,106 @@ package config_test
 
 import (
 	"bytes"
-	"encoding/json"
-	"reflect"
 	"testing"
 
-	ipfscluster "github.com/ipfs/ipfs-cluster"
-	"github.com/ipfs/ipfs-cluster/api/ipfsproxy"
-	"github.com/ipfs/ipfs-cluster/api/rest"
 	"github.com/ipfs/ipfs-cluster/config"
-	"github.com/ipfs/ipfs-cluster/pintracker/maptracker"
 )
+
+type mockCfg struct {
+	config.Saver
+}
+
+func (m *mockCfg) ConfigKey() string {
+	return "mock"
+}
+
+func (m *mockCfg) LoadJSON([]byte) error {
+	return nil
+}
+
+func (m *mockCfg) ToJSON() ([]byte, error) {
+	return []byte(`{"a":"b"}`), nil
+}
+
+func (m *mockCfg) Default() error {
+	return nil
+}
+
+func (m *mockCfg) Validate() error {
+	return nil
+}
 
 func setupConfigManager() *config.Manager {
 	cfg := config.NewManager()
-	clusterCfg := &ipfscluster.Config{}
-	apiCfg := &rest.Config{}
-	ipfsproxyCfg := &ipfsproxy.Config{}
-	maptrackerCfg := &maptracker.Config{}
-	cfg.RegisterComponent(config.Cluster, clusterCfg)
-	cfg.RegisterComponent(config.API, apiCfg)
-	cfg.RegisterComponent(config.API, ipfsproxyCfg)
-	cfg.RegisterComponent(config.PinTracker, maptrackerCfg)
+	mockCfg := &mockCfg{}
+	cfg.RegisterComponent(config.Cluster, mockCfg)
+	cfg.RegisterComponent(config.API, mockCfg)
+	cfg.RegisterComponent(config.API, mockCfg)
+	cfg.RegisterComponent(config.IPFSConn, mockCfg)
+	cfg.RegisterComponent(config.Consensus, mockCfg)
+	cfg.RegisterComponent(config.PinTracker, mockCfg)
+	cfg.RegisterComponent(config.PinTracker, mockCfg)
+	cfg.RegisterComponent(config.Monitor, mockCfg)
+	cfg.RegisterComponent(config.Monitor, mockCfg)
+	cfg.RegisterComponent(config.Informer, mockCfg)
+	cfg.RegisterComponent(config.Informer, mockCfg)
+	cfg.RegisterComponent(config.Observations, mockCfg)
+	cfg.RegisterComponent(config.Observations, mockCfg)
 	return cfg
 }
 
 func TestManager_ToJSON(t *testing.T) {
-	var want1 bytes.Buffer
-	json.Compact(&want1, []byte(`{
-"api": {
-"ipfsproxy": {
-"listen_multiaddress": "/ip4/127.0.0.1/tcp/9095",
-"node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
-"read_timeout": "0s",
-"read_header_timeout": "5s",
-"write_timeout": "0s",
-"idle_timeout": "1m0s",
-"extract_headers_path": "/api/v0/version",
-"extract_headers_ttl": "5m0s"
-},
-"restapi": {
-"http_listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
-"read_timeout": "0s",
-"read_header_timeout": "5s",
-"write_timeout": "0s",
-"idle_timeout": "2m0s",
-"basic_auth_credentials": null,
-"headers": {},
-"cors_allowed_origins": [
-"*"
-],
-"cors_allowed_methods": [
-"GET"
-],
-"cors_allowed_headers": [],
-"cors_exposed_headers": [
-"Content-Type",
-"X-Stream-Output",
-"X-Chunked-Output",
-"X-Content-Length"
-],
-"cors_allow_credentials": true,
-"cors_max_age": "0s"
-}
-},
-"pin_tracker": {
-"maptracker": {
-"max_pin_queue_size": 50000,
-"concurrent_pins": 10
-}
-}
-}`))
-	tests := []struct {
-		name    string
-		want    []byte
-		wantErr bool
-	}{
-		{
-			"basic default config",
-			want1.Bytes(),
-			false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfgMgr := setupConfigManager()
-			err := cfgMgr.Default()
-			if err != nil {
-				t.Fatal(err)
-			}
-			got, err := cfgMgr.ToJSON()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Manager.ToJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			// Extract non-cluster config sections as cluster section just with each run.
-
-			// api section
-			gotapi, err := extractJsonSection("api", got)
-			if err != nil {
-				t.Fatal(err)
-			}
-			wantapi, err := extractJsonSection("api", tt.want)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(gotapi, wantapi) {
-				t.Errorf("api section not the same: got: %s want: %s", gotapi, wantapi)
-			}
-
-			// pintracker section
-			gotpintracker, err := extractJsonSection("pin_tracker", got)
-			if err != nil {
-				t.Fatal(err)
-			}
-			wantpintracker, err := extractJsonSection("pin_tracker", tt.want)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(gotpintracker, wantpintracker) {
-				t.Errorf("api section not the same: got: %s want: %s", gotpintracker, wantpintracker)
-			}
-		})
-	}
-}
-
-func extractJsonSection(name string, rawSection []byte) ([]byte, error) {
-	var section map[string]interface{}
-	json.Unmarshal(rawSection, &section)
-	jsection, err := json.Marshal(section[name].(map[string]interface{}))
+	want := []byte(`{
+  "cluster": {
+    "a": "b"
+  },
+  "consensus": {
+    "mock": {
+      "a": "b"
+    }
+  },
+  "api": {
+    "mock": {
+      "a": "b"
+    }
+  },
+  "ipfs_connector": {
+    "mock": {
+      "a": "b"
+    }
+  },
+  "pin_tracker": {
+    "mock": {
+      "a": "b"
+    }
+  },
+  "monitor": {
+    "mock": {
+      "a": "b"
+    }
+  },
+  "informer": {
+    "mock": {
+      "a": "b"
+    }
+  },
+  "observations": {
+    "mock": {
+      "a": "b"
+    }
+  }
+}`)
+	cfgMgr := setupConfigManager()
+	err := cfgMgr.Default()
 	if err != nil {
-		return nil, err
+		t.Fatal(err)
 	}
-	return jsection, nil
+	got, err := cfgMgr.ToJSON()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("mismatch between got: %s and want: %s", got, want)
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,141 @@
+// Package config provides interfaces and utilities for different Cluster
+// components to register, read, write and validate configuration sections
+// stored in a central configuration file.
+package config_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	ipfscluster "github.com/ipfs/ipfs-cluster"
+	"github.com/ipfs/ipfs-cluster/api/ipfsproxy"
+	"github.com/ipfs/ipfs-cluster/api/rest"
+	"github.com/ipfs/ipfs-cluster/config"
+	"github.com/ipfs/ipfs-cluster/pintracker/maptracker"
+)
+
+func setupConfigManager() *config.Manager {
+	cfg := config.NewManager()
+	clusterCfg := &ipfscluster.Config{}
+	apiCfg := &rest.Config{}
+	ipfsproxyCfg := &ipfsproxy.Config{}
+	maptrackerCfg := &maptracker.Config{}
+	cfg.RegisterComponent(config.Cluster, clusterCfg)
+	cfg.RegisterComponent(config.API, apiCfg)
+	cfg.RegisterComponent(config.API, ipfsproxyCfg)
+	cfg.RegisterComponent(config.PinTracker, maptrackerCfg)
+	return cfg
+}
+
+func TestManager_ToJSON(t *testing.T) {
+	var want1 bytes.Buffer
+	json.Compact(&want1, []byte(`{
+"api": {
+"ipfsproxy": {
+"listen_multiaddress": "/ip4/127.0.0.1/tcp/9095",
+"node_multiaddress": "/ip4/127.0.0.1/tcp/5001",
+"read_timeout": "0s",
+"read_header_timeout": "5s",
+"write_timeout": "0s",
+"idle_timeout": "1m0s",
+"extract_headers_path": "/api/v0/version",
+"extract_headers_ttl": "5m0s"
+},
+"restapi": {
+"http_listen_multiaddress": "/ip4/127.0.0.1/tcp/9094",
+"read_timeout": "0s",
+"read_header_timeout": "5s",
+"write_timeout": "0s",
+"idle_timeout": "2m0s",
+"basic_auth_credentials": null,
+"headers": {},
+"cors_allowed_origins": [
+"*"
+],
+"cors_allowed_methods": [
+"GET"
+],
+"cors_allowed_headers": [],
+"cors_exposed_headers": [
+"Content-Type",
+"X-Stream-Output",
+"X-Chunked-Output",
+"X-Content-Length"
+],
+"cors_allow_credentials": true,
+"cors_max_age": "0s"
+}
+},
+"pin_tracker": {
+"maptracker": {
+"max_pin_queue_size": 50000,
+"concurrent_pins": 10
+}
+}
+}`))
+	tests := []struct {
+		name    string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"basic default config",
+			want1.Bytes(),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgMgr := setupConfigManager()
+			err := cfgMgr.Default()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := cfgMgr.ToJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Manager.ToJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Extract non-cluster config sections as cluster section just with each run.
+
+			// api section
+			gotapi, err := extractJsonSection("api", got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantapi, err := extractJsonSection("api", tt.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(gotapi, wantapi) {
+				t.Errorf("api section not the same: got: %s want: %s", gotapi, wantapi)
+			}
+
+			// pintracker section
+			gotpintracker, err := extractJsonSection("pin_tracker", got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantpintracker, err := extractJsonSection("pin_tracker", tt.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(gotpintracker, wantpintracker) {
+				t.Errorf("api section not the same: got: %s want: %s", gotpintracker, wantpintracker)
+			}
+		})
+	}
+}
+
+func extractJsonSection(name string, rawSection []byte) ([]byte, error) {
+	var section map[string]interface{}
+	json.Unmarshal(rawSection, &section)
+	jsection, err := json.Marshal(section[name].(map[string]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	return jsection, nil
+}


### PR DESCRIPTION
Resolves #658.

jsonConfigs.getSection() returned a value when it needed to
return a pointer to the jsonSection fields inside the struct.

Even though the jsonSection type is a map, therefore on the heap,
returning it as a value (non-pointer) resulted in it being
disassociated with the jsonConfigs overarching struct.

License: MIT
Signed-off-by: Adrian Lanzafame <adrianlanzafame92@gmail.com>