### PR TITLE
Fix context cancelled too early.

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -683,8 +683,9 @@ func (ipfs *Connector) shouldUpdateMetric() bool {
 
 // Trigger a broadcast of the local informer metrics.
 func (ipfs *Connector) updateInformerMetric(ctx context.Context) error {
-	ctx, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/updateInformerMetric")
+	_, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/updateInformerMetric")
 	defer span.End()
+	ctx = trace.NewContext(ipfs.ctx, span)
 
 	if !ipfs.shouldUpdateMetric() {
 		return nil
@@ -693,7 +694,7 @@ func (ipfs *Connector) updateInformerMetric(ctx context.Context) error {
 	var metric api.Metric
 
 	err := ipfs.rpcClient.GoContext(
-		ipfs.ctx,
+		ctx,
 		"",
 		"Cluster",
 		"SendInformerMetric",

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -693,7 +693,7 @@ func (ipfs *Connector) updateInformerMetric(ctx context.Context) error {
 	var metric api.Metric
 
 	err := ipfs.rpcClient.GoContext(
-		ctx,
+		ipfs.ctx,
 		"",
 		"Cluster",
 		"SendInformerMetric",


### PR DESCRIPTION
Every 10th pin the ipfs connector calls repo stat.

Because the call is async, the context was cancelled immediately and failed.

@lanzafame for 0.9.0