### PR TITLE
make tracing service name unique

### DIFF
--- a/cmd/ipfs-cluster-service/configs.go
+++ b/cmd/ipfs-cluster-service/configs.go
@@ -95,6 +95,8 @@ func propagateTracingConfig(cfgs *cfgs, tracingFlag bool) *cfgs {
 		tracingValue = cfgs.tracingCfg.EnableTracing
 	}
 	// propagate to any other interested configuration
+	cfgs.tracingCfg.ClusterID = cfgs.clusterCfg.ID.Pretty()
+	cfgs.tracingCfg.ClusterPeername = cfgs.clusterCfg.Peername
 	cfgs.tracingCfg.EnableTracing = tracingValue
 	cfgs.clusterCfg.Tracing = tracingValue
 	cfgs.consensusCfg.Tracing = tracingValue

--- a/observations/config.go
+++ b/observations/config.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 
-	"github.com/ipfs/ipfs-cluster/config"
 	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/ipfs/ipfs-cluster/config"
 )
 
 const metricsConfigKey = "metrics"
@@ -151,6 +152,8 @@ type TracingConfig struct {
 	JaegerAgentEndpoint ma.Multiaddr
 	SamplingProb        float64
 	ServiceName         string
+	ClusterID           string
+	ClusterPeername     string
 }
 
 type jsonTracingConfig struct {

--- a/observations/setup.go
+++ b/observations/setup.go
@@ -142,7 +142,10 @@ func setupTracing(cfg *TracingConfig) (*jaeger.Exporter, error) {
 	je, err := jaeger.NewExporter(jaeger.Options{
 		AgentEndpoint: agentAddr,
 		Process: jaeger.Process{
-			ServiceName: cfg.ServiceName,
+			ServiceName: cfg.ServiceName + "-" + cfg.ClusterPeername,
+			Tags: []jaeger.Tag{
+				jaeger.StringTag("cluster_id", cfg.ClusterID),
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This commit uses the Cluster.Peername to make the Jaeger
service name unique. This allows for inter-cluster traces
to show the relationship between the different peers in the
cluster. This commit also adds the Cluster.ID as a process
(global) tag on all spans produced by a peer. This is so
that a peer is uniquely identifiable, even when a more
human-friendly name has been used for the Cluster.Peername.

License: MIT
Signed-off-by: Adrian Lanzafame <adrianlanzafame92@gmail.com>