### PR TITLE
Fix docker-compose testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ clean: rwundo clean_sharness
 	$(MAKE) -C cmd/ipfs-cluster-service clean
 	$(MAKE) -C cmd/ipfs-cluster-ctl clean
 	@rm -rf ./test/testingData
+	@rm -rf ./compose
 
 install: deps
 	$(MAKE) -C cmd/ipfs-cluster-service install
@@ -95,6 +96,8 @@ docker:
 
 
 docker-compose:
+	mkdir -p compose/ipfs0 compose/ipfs1 compose/cluster0 compose/cluster1
+	chmod -R 0777 compose
 	CLUSTER_SECRET=$(shell od -vN 32 -An -tx1 /dev/urandom | tr -d ' \n') docker-compose up -d
 	sleep 20
 	docker exec cluster0 ipfs-cluster-ctl peers ls | grep -o "Sees 1 other peers" | uniq -c | grep 2

--- a/sharness/t0030-ctl-pin.sh
+++ b/sharness/t0030-ctl-pin.sh
@@ -49,7 +49,7 @@ test_expect_success IPFS,CLUSTER "wait for data to unpin from cluster with ctl w
     ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
 '
 
-cid=(`docker exec ipfs sh -c "mkdir -p test1/test2 && touch test1/test2/test3.txt && ipfs add -qr test1"`)
+cid=(`docker exec ipfs sh -c "mkdir -p /tmp/test1/test2 && touch /tmp/test1/test2/test3.txt && ipfs add -qr /tmp/test1"`)
 
 test_expect_success IPFS,CLUSTER "pin data to cluster with ctl using ipfs paths" '
     ipfs-cluster-ctl pin add "/ipfs/${cid[2]}/test2/test3.txt" &&


### PR DESCRIPTION
We need to pre-create configuration folders and set write permissions
because https://github.com/ipfs/go-ipfs/pull/5048

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>