### PR TITLE
Hide `extract_headers_path`, `extract_headers_ttl`

### DIFF
--- a/api/ipfsproxy/config.go
+++ b/api/ipfsproxy/config.go
@@ -258,8 +258,12 @@ func (cfg *Config) toJSONConfig() (jcfg *jsonConfig, err error) {
 	jcfg.NodeHTTPS = cfg.NodeHTTPS
 
 	jcfg.ExtractHeadersExtra = cfg.ExtractHeadersExtra
-	jcfg.ExtractHeadersPath = cfg.ExtractHeadersPath
-	jcfg.ExtractHeadersTTL = cfg.ExtractHeadersTTL.String()
+	if cfg.ExtractHeadersPath != DefaultExtractHeadersPath {
+		jcfg.ExtractHeadersPath = cfg.ExtractHeadersPath
+	}
+	if ttl := cfg.ExtractHeadersTTL; ttl != DefaultExtractHeadersTTL {
+		jcfg.ExtractHeadersTTL = ttl.String()
+	}
 
 	return
 }


### PR DESCRIPTION
proxy: "extract_headers_path" and "extract_headers_ttl" should be
hidden options in the config

Fixes #698 