### PR TITLE
Types: make AddedOutput carry a cid.Cid

### DIFF
--- a/adder/ipfsadd/add.go
+++ b/adder/ipfsadd/add.go
@@ -393,7 +393,7 @@ func outputDagnode(out chan *api.AddedOutput, name string, dn ipld.Node) error {
 	}
 
 	out <- &api.AddedOutput{
-		Cid:  dn.Cid().String(),
+		Cid:  dn.Cid(),
 		Name: name,
 		Size: s,
 	}

--- a/adder/sharding/dag_service.go
+++ b/adder/sharding/dag_service.go
@@ -111,7 +111,7 @@ func (dgs *DAGService) Finalize(ctx context.Context, dataRoot cid.Cid) (cid.Cid,
 
 	dgs.sendOutput(&api.AddedOutput{
 		Name: fmt.Sprintf("%s-clusterDAG", dgs.pinOpts.Name),
-		Cid:  clusterDAG.String(),
+		Cid:  clusterDAG,
 		Size: dgs.totalSize,
 	})
 
@@ -265,7 +265,7 @@ func (dgs *DAGService) flushCurrentShard(ctx context.Context) (cid.Cid, error) {
 	dgs.currentShard = nil
 	dgs.sendOutput(&api.AddedOutput{
 		Name: fmt.Sprintf("shard-%d", lens),
-		Cid:  shardCid.String(),
+		Cid:  shardCid,
 		Size: shard.Size(),
 	})
 

--- a/api/add.go
+++ b/api/add.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+
+	cid "github.com/ipfs/go-cid"
 )
 
 // DefaultShardSize is the shard size for params objects created with DefaultParams().
@@ -13,10 +15,10 @@ var DefaultShardSize = uint64(100 * 1024 * 1024) // 100 MB
 // AddedOutput carries information for displaying the standard ipfs output
 // indicating a node of a file has been added.
 type AddedOutput struct {
-	Name  string `json:"name"`
-	Cid   string `json:"cid,omitempty"`
-	Bytes uint64 `json:"bytes,omitempty"`
-	Size  uint64 `json:"size,omitempty"`
+	Name  string  `json:"name" codec:"n,omitempty"`
+	Cid   cid.Cid `json:"cid,omitempty" codec:"c"`
+	Bytes uint64  `json:"bytes,omitempty" codec:"b,omitempty"`
+	Size  uint64  `json:"size,omitempty" codec:"s,omitempty"`
 }
 
 // AddParams contains all of the configurable parameters needed to specify the

--- a/api/add.go
+++ b/api/add.go
@@ -16,7 +16,7 @@ var DefaultShardSize = uint64(100 * 1024 * 1024) // 100 MB
 // indicating a node of a file has been added.
 type AddedOutput struct {
 	Name  string  `json:"name" codec:"n,omitempty"`
-	Cid   cid.Cid `json:"cid,omitempty" codec:"c"`
+	Cid   cid.Cid `json:"cid" codec:"c"`
 	Bytes uint64  `json:"bytes,omitempty" codec:"b,omitempty"`
 	Size  uint64  `json:"size,omitempty" codec:"s,omitempty"`
 }

--- a/api/ipfsproxy/ipfsproxy.go
+++ b/api/ipfsproxy/ipfsproxy.go
@@ -419,7 +419,7 @@ func (proxy *Server) addHandler(w http.ResponseWriter, r *http.Request) {
 	outputTransform := func(in *api.AddedOutput) interface{} {
 		r := &ipfsAddResp{
 			Name:  in.Name,
-			Hash:  in.Cid,
+			Hash:  in.Cid.String(),
 			Bytes: int64(in.Bytes),
 		}
 		if in.Size != 0 {

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -447,7 +447,7 @@ func TestAPIAddFileEndpointLocal(t *testing.T) {
 		makeStreamingPost(t, rest, localURL, body, mpContentType, &resp)
 
 		// resp will contain the last object from the streaming
-		if resp.Cid != test.ShardingDirBalancedRootCID {
+		if resp.Cid.String() != test.ShardingDirBalancedRootCID {
 			t.Error("Bad Cid after adding: ", resp.Cid)
 		}
 	}
@@ -512,7 +512,7 @@ func TestAPIAddFileEndpoint_StreamChannelsFalse(t *testing.T) {
 
 		makePostWithContentType(t, rest, shardURL, fullBody, mpContentType, &resp)
 		lastHash := resp[len(resp)-1]
-		if lastHash.Cid != test.ShardingDirBalancedRootCID {
+		if lastHash.Cid.String() != test.ShardingDirBalancedRootCID {
 			t.Error("Bad Cid after adding: ", lastHash.Cid)
 		}
 	}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -162,6 +162,9 @@ func TestDupTags(t *testing.T) {
 
 	typ = reflect.TypeOf(IPFSRepoStat{})
 	checkDupTags(t, "codec", typ, nil)
+
+	typ = reflect.TypeOf(AddedOutput{})
+	checkDupTags(t, "codec", typ, nil)
 }
 
 func TestPinOptionsQuery(t *testing.T) {


### PR DESCRIPTION
This was a leftover. For consisency, all CIDs coming out of the API
should have the canonical cid form ( { "/": "cid" } ), otherwise
we are inconsistent.