### PR TITLE
RPC Authorization

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -158,11 +158,13 @@ func NewCluster(
 
 func (c *Cluster) setupRPC() error {
 	var rpcServer *rpc.Server
+
+	authorize := c.authorizeWithPolicy()
 	if c.config.Tracing {
 		sh := &ocgorpc.ServerHandler{}
-		rpcServer = rpc.NewServer(c.host, version.RPCProtocol, rpc.WithServerStatsHandler(sh))
+		rpcServer = rpc.NewServer(c.host, version.RPCProtocol, rpc.WithServerStatsHandler(sh), rpc.WithAuthorizeFunc(authorize))
 	} else {
-		rpcServer = rpc.NewServer(c.host, version.RPCProtocol)
+		rpcServer = rpc.NewServer(c.host, version.RPCProtocol, rpc.WithAuthorizeFunc(authorize))
 	}
 	err := rpcServer.RegisterName("Cluster", &RPCAPI{c})
 	if err != nil {

--- a/cluster.go
+++ b/cluster.go
@@ -159,7 +159,7 @@ func NewCluster(
 func (c *Cluster) setupRPC() error {
 	var rpcServer *rpc.Server
 
-	authr, err := newAuthorizer(raft, nil)
+	authr, err := newAuthorizer(raftPolicy, nil)
 	if err != nil {
 		return err
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -159,14 +159,18 @@ func NewCluster(
 func (c *Cluster) setupRPC() error {
 	var rpcServer *rpc.Server
 
-	authorize := c.authorizeWithPolicy()
+	authr, err := newAuthorizer(raft, nil)
+	if err != nil {
+		return err
+	}
+	authorize := authr.authorizeFunc()
 	if c.config.Tracing {
 		sh := &ocgorpc.ServerHandler{}
 		rpcServer = rpc.NewServer(c.host, version.RPCProtocol, rpc.WithServerStatsHandler(sh), rpc.WithAuthorizeFunc(authorize))
 	} else {
 		rpcServer = rpc.NewServer(c.host, version.RPCProtocol, rpc.WithAuthorizeFunc(authorize))
 	}
-	err := rpcServer.RegisterName("Cluster", &RPCAPI{c})
+	err = rpcServer.RegisterName("Cluster", &RPCAPI{c})
 	if err != nil {
 		return err
 	}

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmRJP3v36DnzJuXwk8U4PfXjEbqt3CidgntwtEuxoDcoSp",
+      "hash": "QmcJCApoEsCJJap2iS1os9GFX5EuRrfuPeZdjCopz2SyPm",
       "name": "go-libp2p-gorpc",
-      "version": "1.1.5"
+      "version": "1.1.4"
     },
     {
       "author": "libp2p",
@@ -158,7 +158,7 @@
     },
     {
       "author": "lanzafame",
-      "hash": "QmVXkJzSYFZcEwhucM3vwxvKZDpYVtNhDvX9ssUTmuQ4Xr",
+      "hash": "QmYe4hq5UmoR4LNYHtxNuhHtTYzjgU1FdFoKL8fWj1uMf4",
       "name": "go-libp2p-ocgorpc",
       "version": "0.1.8"
     },

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmcJCApoEsCJJap2iS1os9GFX5EuRrfuPeZdjCopz2SyPm",
+      "hash": "QmRJP3v36DnzJuXwk8U4PfXjEbqt3CidgntwtEuxoDcoSp",
       "name": "go-libp2p-gorpc",
-      "version": "1.1.4"
+      "version": "1.1.5"
     },
     {
       "author": "libp2p",
@@ -158,7 +158,7 @@
     },
     {
       "author": "lanzafame",
-      "hash": "QmYe4hq5UmoR4LNYHtxNuhHtTYzjgU1FdFoKL8fWj1uMf4",
+      "hash": "QmVXkJzSYFZcEwhucM3vwxvKZDpYVtNhDvX9ssUTmuQ4Xr",
       "name": "go-libp2p-ocgorpc",
       "version": "0.1.8"
     },

--- a/rpc_permissions.go
+++ b/rpc_permissions.go
@@ -1,0 +1,56 @@
+package ipfscluster
+
+import (
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type peerKind int
+
+const (
+	all peerKind = iota
+	trusted
+)
+
+type permissionPolicy map[peerKind]map[string]bool
+
+func (c *Cluster) authorizeWithPolicy() func(pid peer.ID, svc string, method string) bool {
+	policyName := c.config.PermissionPolicy
+	policy := getPermissionPolicy(policyName)
+	return func(pid peer.ID, svc string, method string) bool {
+		if policy == nil || policyName != DefaultPermissionPolicy {
+			return false
+		}
+
+		return policy[all][svc+"."+method]
+	}
+}
+
+func getPermissionMap() map[string]permissionPolicy {
+	return map[string]permissionPolicy{
+		"raft": permissionPolicy{
+			all: {
+				"Cluster.ID":      true,
+				"Cluster.PeerAdd": true,
+				"Cluster.Peers":   true,
+
+				"Cluster.TrackerStatusAll": true,
+				"Cluster.TrackerStatus":    true,
+				"Cluster.TrackerRecover":   true,
+
+				"Cluster.SyncAllLocal": true,
+				"Cluster.SyncLocal":    true,
+
+				"Cluster.IPFSConnectSwarms": true,
+				"Cluster.IPFSBlockPut":      true,
+				"Cluster.IPFSSwarmPeers":    true,
+
+				"Cluster.ConsensusAddPeer": true,
+				"Cluster.ConsensusRmPeer":  true,
+			},
+		},
+	}
+}
+
+func getPermissionPolicy(name string) permissionPolicy {
+	return getPermissionMap()[name]
+}

--- a/rpc_permissions.go
+++ b/rpc_permissions.go
@@ -14,7 +14,7 @@ const (
 )
 
 const (
-	raft       string = "raft"
+	raftPolicy string = "raft"
 	crdtStrict string = "crdt_strict"
 	crdtSoft   string = "crdt_soft"
 )
@@ -44,7 +44,7 @@ func (a *authorizer) authorizeFunc() func(pid peer.ID, svc string, method string
 	policy := a.policy
 
 	return func(pid peer.ID, svc string, method string) bool {
-		if policyName == raft {
+		if policyName == raftPolicy {
 			return policy[all][svc+"."+method]
 		}
 
@@ -64,7 +64,7 @@ func (a *authorizer) addPeers(peers []peer.ID) {
 
 func getPermissionPolicy(name string) (permissionPolicy, error) {
 	switch name {
-	case raft:
+	case raftPolicy:
 		return permissionPolicy{
 			all: {
 				"Cluster.ID":      true,

--- a/rpc_permissions.go
+++ b/rpc_permissions.go
@@ -44,8 +44,10 @@ func getPermissionMap() map[string]permissionPolicy {
 				"Cluster.IPFSBlockPut":      true,
 				"Cluster.IPFSSwarmPeers":    true,
 
-				"Cluster.ConsensusAddPeer": true,
-				"Cluster.ConsensusRmPeer":  true,
+				"Cluster.ConsensusAddPeer":  true,
+				"Cluster.ConsensusRmPeer":   true,
+				"Cluster.ConsensusLogPin":   true,
+				"Cluster.ConsensusLogUnpin": true,
 			},
 		},
 	}

--- a/rpc_permissions.go
+++ b/rpc_permissions.go
@@ -2,6 +2,7 @@ package ipfscluster
 
 import (
 	"errors"
+
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
@@ -22,10 +23,10 @@ type permissionPolicy map[peerKind]map[string]bool
 type authorizer struct {
 	policyName string
 	policy     permissionPolicy
-	trusted    []peer.ID
+	trusted    map[peer.ID]bool
 }
 
-func newAuthorizer(policyName string, trusted []peer.ID) (*authorizer, error) {
+func newAuthorizer(policyName string, trusted map[peer.ID]bool) (*authorizer, error) {
 	policy, err := getPermissionPolicy(policyName)
 	if err != nil {
 		return nil, err
@@ -51,8 +52,14 @@ func (a *authorizer) authorizeFunc() func(pid peer.ID, svc string, method string
 	}
 }
 
-func (a *authorizer) addPeers(peer peer.ID) {
-	a.trusted = append(a.trusted, peer)
+func (a *authorizer) addPeers(peers []peer.ID) {
+	if a.trusted == nil {
+		a.trusted = make(map[peer.ID]bool)
+	}
+
+	for _, p := range peers {
+		a.trusted[p] = true
+	}
 }
 
 func getPermissionPolicy(name string) (permissionPolicy, error) {


### PR DESCRIPTION
This PR adds permission policy for raft consensus and adds
permission policy to config(but hides it from user).
    
It proposes minimum set of RPC methods which we have to allow peers in
order for all cluster features to work as expected. It restricts peers
from accessing methods that are not part of the proposed RPC method set.
    
Proposed authorization would work only for raft consensus.
`authorizeWithPolicy` would need to be edited in order to support
 upcoming consensus mechanisms.

#666 