### PR TITLE
Fix: ctl: --enc=json shows empty output on "add"

### DIFF
--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -14,7 +14,7 @@ import (
 )
 
 type addedOutputQuiet struct {
-	added *api.AddedOutput
+	*api.AddedOutput
 	quiet bool
 }
 
@@ -28,7 +28,7 @@ func jsonFormatObject(resp interface{}) {
 		serials := resp.([]*addedOutputQuiet)
 		var actual []*api.AddedOutput
 		for _, s := range serials {
-			actual = append(actual, s.added)
+			actual = append(actual, s.AddedOutput)
 		}
 		jsonFormatPrint(actual)
 	default:
@@ -197,9 +197,9 @@ func textFormatPrintAddedOutput(obj *api.AddedOutput) {
 
 func textFormatPrintAddedOutputQuiet(obj *addedOutputQuiet) {
 	if obj.quiet {
-		fmt.Printf("%s\n", obj.added.Cid)
+		fmt.Printf("%s\n", obj.AddedOutput.Cid)
 	} else {
-		textFormatPrintAddedOutput(obj.added)
+		textFormatPrintAddedOutput(obj.AddedOutput)
 	}
 }
 

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -423,7 +423,10 @@ cluster "pin add".
 					var q = c.Bool("quiet") || qq
 					var bufferResults = c.Bool("no-stream")
 					for v := range out {
-						added := &addedOutputQuiet{v, q}
+						added := &addedOutputQuiet{
+							AddedOutput: v,
+							quiet:       q,
+						}
 						lastBuf = added
 						if bufferResults {
 							buffered = append(buffered, added)
@@ -433,7 +436,7 @@ cluster "pin add".
 							formatResponse(c, added, nil)
 						}
 					}
-					if lastBuf == nil || lastBuf.added == nil {
+					if lastBuf == nil || lastBuf.AddedOutput == nil {
 						return // no elements at all
 					}
 					if bufferResults { // we buffered.


### PR DESCRIPTION
The problem is that addedOutputQuiet produced `{}` when converted to JSON.