### PR TITLE
Pin timeouts should start from the last block

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -423,7 +423,7 @@ func (ipfs *Connector) refsProgress(ctx context.Context, hash cid.Cid, maxDepth 
 
 		// We have a Ref!
 		if errStr := ref.Err; errStr != "" {
-			return errors.New(errStr)
+			logger.Error(errStr)
 		}
 
 		select { // do not lock

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -431,7 +431,6 @@ func (ipfs *Connector) refsProgress(ctx context.Context, hash cid.Cid, maxDepth 
 		default:
 		}
 	}
-	return nil
 }
 
 // pinProgress pins an item and sends fetched node's progress on a
@@ -478,7 +477,6 @@ func (ipfs *Connector) pinProgress(ctx context.Context, hash cid.Cid, maxDepth i
 		default:
 		}
 	}
-	return nil
 }
 
 // Unpin performs an unpin request against the configured IPFS

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -91,13 +91,13 @@ type ipfsResolveResp struct {
 }
 
 type ipfsRefsResp struct {
-	Ref string `json:"Ref"`
-	Err string `json:"Err"`
+	Ref string
+	Err string
 }
 
 type ipfsPinsResp struct {
-	Pins     []string `json:"Pins"`
-	Progress int      `json:"Progress"`
+	Pins     []string
+	Progress int
 }
 
 type ipfsSwarmPeersResp struct {

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -532,10 +532,9 @@ func checkTimeout(ctx context.Context, cancel context.CancelFunc, timer *time.Ti
 			select {
 			case <-reset:
 				{
-					if !timer.Stop() {
-						<-timer.C
+					if timer.Stop() {
+						timer.Reset(timeout)
 					}
-					timer.Reset(timeout)
 				}
 			case <-timer.C:
 				{

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -504,7 +504,6 @@ func (ipfs *Connector) postCtxStreaming(ctx context.Context, path string, timeou
 					err = json.Unmarshal(line, &pins)
 					break
 				}
-				fmt.Println(err.Error())
 				return err
 			}
 

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -492,7 +492,7 @@ func handleRefsProgress(dec *json.Decoder, reset chan int) error {
 		} else if err != nil {
 			return err
 		}
-		// logger.Infof("Ref %s", ref.Ref)
+		//logger.Infof("Ref %s", ref.Ref)
 		if ref.Err != "" {
 			logger.Error(ref.Err)
 		}
@@ -515,7 +515,7 @@ func handlePinsProgress(dec *json.Decoder, reset chan int) error {
 		} else if err != nil {
 			return err
 		}
-		logger.Infof("Progress: %d", pins.Progress)
+		//logger.Infof("Progress: %d", pins.Progress)
 		if pins.Progress > progress {
 			progress = pins.Progress
 			reset <- 1
@@ -532,7 +532,9 @@ func checkTimeout(ctx context.Context, cancel context.CancelFunc, timer *time.Ti
 			select {
 			case <-reset:
 				{
-					//timer.Stop()
+					if !timer.Stop() {
+						<-timer.C
+					}
 					timer.Reset(timeout)
 				}
 			case <-timer.C:
@@ -549,7 +551,6 @@ func checkTimeout(ctx context.Context, cancel context.CancelFunc, timer *time.Ti
 			}
 
 			if done {
-				fmt.Println("breaking out of the immortal goroutine")
 				break
 			}
 		}

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -79,11 +79,11 @@ func testPin(t *testing.T, method string) {
 	c := test.Cid1
 	err := ipfs.Pin(ctx, c, -1)
 	if err != nil {
-		t.Error("expected success pinning cid")
+		t.Error("expected success pinning cid:", err)
 	}
 	pinSt, err := ipfs.PinLsCid(ctx, c)
 	if err != nil {
-		t.Fatal("expected success doing ls")
+		t.Fatal("expected success doing ls:", err)
 	}
 	if !pinSt.IsPinned(-1) {
 		t.Error("cid should have been pinned")

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -95,24 +95,23 @@ func testPin(t *testing.T, method string) {
 		t.Error("expected error pinning cid")
 	}
 
-	if method == "refs" {
+	switch method {
+	case "refs":
 		ipfs.config.PinTimeout = 1 * time.Second
 		c3 := test.SlowCid1
 		err = ipfs.Pin(ctx, c3, -1)
 		if err == nil {
 			t.Error("expected error pinning cid")
 		}
-	}
-
-	if method == "pin" {
+	case "pin":
 		ipfs.config.PinTimeout = 5 * time.Second
 		c4 := test.SlowCid1
 		err = ipfs.Pin(ctx, c4, -1)
 		if err == nil {
 			t.Error("expected error pinning cid")
 		}
+	default:
 	}
-
 }
 
 func TestIPFSPin(t *testing.T) {

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -94,6 +94,26 @@ func testPin(t *testing.T, method string) {
 	if err == nil {
 		t.Error("expected error pinning cid")
 	}
+
+	if method == "refs" {
+		ipfs.config.PinTimeout = 1 * time.Second
+		c3 := test.SlowCid1
+		err = ipfs.Pin(ctx, c3, -1)
+		if err == nil {
+			t.Error("expected error pinning cid")
+		}
+		fmt.Println("SlowCid1 " + err.Error())
+	}
+
+	if method == "pin" {
+		ipfs.config.PinTimeout = 5 * time.Second
+		c4 := test.SlowCid1
+		err = ipfs.Pin(ctx, c4, -1)
+		if err == nil {
+			t.Error("expected error pinning cid")
+		}
+	}
+
 }
 
 func TestIPFSPin(t *testing.T) {

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -102,7 +102,6 @@ func testPin(t *testing.T, method string) {
 		if err == nil {
 			t.Error("expected error pinning cid")
 		}
-		fmt.Println("SlowCid1 " + err.Error())
 	}
 
 	if method == "pin" {

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -169,7 +169,14 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 			Pins: []string{arg},
 		}
 		j, _ := json.Marshal(resp)
-		w.Write(j)
+		if c.Equals(SlowCid1) {
+			for i := 0; i <= 10; i++ {
+				time.Sleep(1 * time.Second)
+				w.Write(j)
+			}
+		} else {
+			w.Write(j)
+		}
 	case "pin/rm":
 		arg, ok := extractCid(r.URL)
 		if !ok {
@@ -339,7 +346,14 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 			Ref: arg,
 		}
 		j, _ := json.Marshal(resp)
-		w.Write(j)
+		if arg == SlowCid1.String() {
+			for i := 0; i <= 5; i++ {
+				time.Sleep(2 * time.Second)
+				w.Write(j)
+			}
+		} else {
+			w.Write(j)
+		}
 	case "version":
 		w.Write([]byte("{\"Version\":\"m.o.c.k\"}"))
 	default:

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -41,7 +41,8 @@ type IpfsMock struct {
 }
 
 type mockPinResp struct {
-	Pins []string
+	Pins     []string
+	Progress int `json:",omitempty"`
 }
 
 type mockPinType struct {
@@ -168,13 +169,16 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		resp := mockPinResp{
 			Pins: []string{arg},
 		}
-		j, _ := json.Marshal(resp)
+
 		if c.Equals(SlowCid1) {
 			for i := 0; i <= 10; i++ {
 				time.Sleep(1 * time.Second)
+				resp.Progress = i
+				j, _ := json.Marshal(resp)
 				w.Write(j)
 			}
 		} else {
+			j, _ := json.Marshal(resp)
 			w.Write(j)
 		}
 	case "pin/rm":


### PR DESCRIPTION
IPFSConnector Pin operation should not have a timeout since the start
of the operation, but a timeout since the last block was received,
thus only cancelling operations when there are no more blocks provided
in the network

Fixes #497 