### PR TITLE
Fix #743: Use lowercase "version" in json version object

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -260,7 +260,7 @@ type PinInfo struct {
 
 // Version holds version information
 type Version struct {
-	Version string `json:"Version" codec:"v"`
+	Version string `json:"version" codec:"v"`
 }
 
 // ConnectGraph holds information about the connectivity of the cluster To


### PR DESCRIPTION
Fix #743 