### PR TITLE
Default allocations filter should be all

### DIFF
--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -743,6 +743,12 @@ func (api *API) allocationsHandler(w http.ResponseWriter, r *http.Request) {
 	for _, f := range strings.Split(filterStr, ",") {
 		filter |= types.PinTypeFromString(f)
 	}
+
+	if filter == types.BadType {
+		api.sendResponse(w, http.StatusBadRequest, errors.New("invalid filter value"), nil)
+		return
+	}
+
 	var pins []*types.Pin
 	err := api.rpcClient.CallContext(
 		r.Context(),
@@ -814,7 +820,7 @@ func (api *API) statusAllHandler(w http.ResponseWriter, r *http.Request) {
 	filterStr := queryValues.Get("filter")
 	filter := types.TrackerStatusFromString(filterStr)
 	if filter == types.TrackerStatusUndefined && filterStr != "" {
-		api.sendResponse(w, autoStatus, errors.New("invalid filter value"), nil)
+		api.sendResponse(w, http.StatusBadRequest, errors.New("invalid filter value"), nil)
 		return
 	}
 

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -748,6 +748,19 @@ func TestAPIAllocationsEndpoint(t *testing.T) {
 			!resp[2].Cid.Equals(test.Cid3) {
 			t.Error("unexpected pin list: ", resp)
 		}
+
+		makeGet(t, rest, url(rest)+"/allocations", &resp)
+		if len(resp) != 3 ||
+			!resp[0].Cid.Equals(test.Cid1) || !resp[1].Cid.Equals(test.Cid2) ||
+			!resp[2].Cid.Equals(test.Cid3) {
+			t.Error("unexpected pin list: ", resp)
+		}
+
+		errResp := api.Error{}
+		makeGet(t, rest, url(rest)+"/allocations?filter=invalid", &errResp)
+		if errResp.Code != http.StatusBadRequest {
+			t.Error("an invalid filter value should 400")
+		}
 	}
 
 	testBothEndpoints(t, tf)
@@ -850,6 +863,12 @@ func TestAPIStatusAllEndpoint(t *testing.T) {
 		makeGet(t, rest, url(rest)+"/pins?filter=error,pinned", &resp7)
 		if len(resp7) != 2 {
 			t.Errorf("unexpected statusAll+filter=error,pinned resp:\n %+v", resp7)
+		}
+
+		var errorResp api.Error
+		makeGet(t, rest, url(rest)+"/pins?filter=invalid", &errorResp)
+		if errorResp.Code != http.StatusBadRequest {
+			t.Error("an invalid filter value should 400")
 		}
 	}
 

--- a/api/types.go
+++ b/api/types.go
@@ -417,6 +417,8 @@ func PinTypeFromString(str string) PinType {
 		return ShardType
 	case "all":
 		return AllType
+	case "":
+		return AllType
 	default:
 		return BadType
 	}


### PR DESCRIPTION
Currently `curl -X GET http://localhost:9094/allocations` results in an
empty array, because no filter is provided. Solution to this would be
either 1) to consider filter as all if no filter is provided by the user
or 2) to make the `filter` parameter mandatory and reply with BadRequest
if no filter is provided

This commit makes the default filter as all