### PR TITLE
Proxy: hijack pin/update

### DIFF
--- a/api/ipfsproxy/ipfsproxy_test.go
+++ b/api/ipfsproxy/ipfsproxy_test.go
@@ -327,7 +327,7 @@ func TestIPFSProxyPinUpdate(t *testing.T) {
 		}
 
 		defer res.Body.Close()
-		if res.StatusCode != http.StatusInternalServerError {
+		if res.StatusCode != http.StatusBadRequest {
 			t.Error("request should not be successful with a no arguments")
 		}
 
@@ -337,7 +337,7 @@ func TestIPFSProxyPinUpdate(t *testing.T) {
 		}
 
 		defer res2.Body.Close()
-		if res2.StatusCode != http.StatusInternalServerError {
+		if res2.StatusCode != http.StatusBadRequest {
 			t.Error("request should not be successful with a single argument")
 		}
 	})
@@ -357,8 +357,8 @@ func TestIPFSProxyPinUpdate(t *testing.T) {
 			t.Fatal(err)
 		}
 		if len(resp.Pins) != 2 ||
-			resp.Pins[0] != test.PathIPFS1 ||
-			resp.Pins[1] != test.PathIPFS2 {
+			resp.Pins[0] != test.Cid2.String() ||
+			resp.Pins[1] != test.CidResolved.String() { // always resolve to the same
 			t.Errorf("bad response: %s", string(resBytes))
 		}
 	})

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -614,7 +614,6 @@ func (ipfs *Connector) Resolve(ctx context.Context, path string) (cid.Cid, error
 		logger.Error("could not parse path: " + err.Error())
 		return cid.Undef, err
 	}
-
 	if !strings.HasPrefix(path, "/ipns") && validPath.IsJustAKey() {
 		ci, _, err := gopath.SplitAbsPath(validPath)
 		return ci, err

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -424,6 +424,16 @@ func (rpcapi *RPCAPI) IPFSBlockGet(ctx context.Context, in cid.Cid, out *[]byte)
 	return nil
 }
 
+// IPFSResolve runs IPFSConnector.Resolve().
+func (rpcapi *RPCAPI) IPFSResolve(ctx context.Context, in string, out *cid.Cid) error {
+	c, err := rpcapi.c.ipfs.Resolve(ctx, in)
+	if err != nil {
+		return err
+	}
+	*out = c
+	return nil
+}
+
 /*
    Consensus component methods
 */

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -429,6 +429,16 @@ func (mock *mockService) IPFSBlockPut(ctx context.Context, in *api.NodeWithMeta,
 	return nil
 }
 
+func (mock *mockService) IPFSResolve(ctx context.Context, in string, out *cid.Cid) error {
+	switch in {
+	case ErrorCid.String(), "/ipfs/" + ErrorCid.String():
+		*out = ErrorCid
+	default:
+		*out = Cid2
+	}
+	return nil
+}
+
 func (mock *mockService) ConsensusAddPeer(ctx context.Context, in peer.ID, out *struct{}) error {
 	return errors.New("mock rpc cannot redirect")
 }


### PR DESCRIPTION
The IPFS pin/update endpoint takes two arguments and usually
unpins the first and pins the second. It is a bit more efficient
to do it in a single operation than two separate ones.

This will make the proxy endpoint hijack pin/update requests.

First, the FROM pin is fetched from the state. If present, we
set the options (replication factors, actual allocations) from
that pin to the new one. Then we pin the TO item and proceed
to unpin the FROM item when `unpin` is not false.

We need to support path resolving, just like IPFS, therefore
it was necessary to expose IPFSResolve() via RPC.

Goes on top of #767 

Fixes #732 