### PR TITLE
RPC: Give each component a different RPC Service

### DIFF
--- a/adder/local/dag_service.go
+++ b/adder/local/dag_service.go
@@ -33,7 +33,7 @@ type DAGService struct {
 }
 
 // New returns a new Adder with the given rpc Client. The client is used
-// to perform calls to IPFSBlockPut and Pin content on Cluster.
+// to perform calls to IPFS.BlockPut and Pin content on Cluster.
 func New(rpc *rpc.Client, opts api.PinOptions) *DAGService {
 	return &DAGService{
 		rpcClient: rpc,

--- a/adder/sharding/dag.go
+++ b/adder/sharding/dag.go
@@ -140,8 +140,8 @@ func putDAG(ctx context.Context, rpcC *rpc.Client, nodes []ipld.Node, dests []pe
 		errs := rpcC.MultiCall(
 			ctxs,
 			dests,
-			"Cluster",
-			"IPFSBlockPut",
+			"IPFSConnector",
+			"BlockPut",
 			b,
 			rpcutil.RPCDiscardReplies(len(dests)),
 		)

--- a/adder/sharding/dag_service_test.go
+++ b/adder/sharding/dag_service_test.go
@@ -27,7 +27,7 @@ type testRPC struct {
 	pins   sync.Map
 }
 
-func (rpcs *testRPC) IPFSBlockPut(ctx context.Context, in *api.NodeWithMeta, out *struct{}) error {
+func (rpcs *testRPC) BlockPut(ctx context.Context, in *api.NodeWithMeta, out *struct{}) error {
 	rpcs.blocks.Store(in.Cid.String(), in.Data)
 	return nil
 }
@@ -67,6 +67,10 @@ func makeAdder(t *testing.T, params *api.AddParams) (*adder.Adder, *testRPC) {
 	rpcObj := &testRPC{}
 	server := rpc.NewServer(nil, "mock")
 	err := server.RegisterName("Cluster", rpcObj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = server.RegisterName("IPFSConnector", rpcObj)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/adder/util.go
+++ b/adder/util.go
@@ -33,8 +33,8 @@ func PutBlock(ctx context.Context, rpc *rpc.Client, n *api.NodeWithMeta, dests [
 	errs := rpc.MultiCall(
 		ctxs,
 		dests,
-		"Cluster",
-		"IPFSBlockPut",
+		"IPFSConnector",
+		"BlockPut",
 		n,
 		rpcutil.RPCDiscardReplies(len(dests)),
 	)

--- a/api/ipfsproxy/ipfsproxy.go
+++ b/api/ipfsproxy/ipfsproxy.go
@@ -435,8 +435,8 @@ func (proxy *Server) pinUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	err = proxy.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"IPFSResolve",
+		"IPFSConnector",
+		"Resolve",
 		pFrom.String(),
 		&fromCid,
 	)
@@ -591,8 +591,8 @@ func (proxy *Server) repoStatHandler(w http.ResponseWriter, r *http.Request) {
 	peers := make([]peer.ID, 0)
 	err := proxy.rpcClient.Call(
 		"",
-		"Cluster",
-		"ConsensusPeers",
+		"Consensus",
+		"Peers",
 		struct{}{},
 		&peers,
 	)
@@ -614,8 +614,8 @@ func (proxy *Server) repoStatHandler(w http.ResponseWriter, r *http.Request) {
 	errs := proxy.rpcClient.MultiCall(
 		ctxs,
 		peers,
-		"Cluster",
-		"IPFSRepoStat",
+		"IPFSConnector",
+		"RepoStat",
 		struct{}{},
 		repoStatsIfaces,
 	)

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -574,8 +574,8 @@ func (api *API) metricsHandler(w http.ResponseWriter, r *http.Request) {
 	err := api.rpcClient.CallContext(
 		r.Context(),
 		"",
-		"Cluster",
-		"PeerMonitorLatestMetrics",
+		"PeerMonitor",
+		"LatestMetrics",
 		name,
 		&metrics,
 	)

--- a/connect_graph.go
+++ b/connect_graph.go
@@ -97,8 +97,8 @@ func (c *Cluster) recordIPFSLinks(cg *api.ConnectGraph, pID *api.ID) {
 	var swarmPeers []peer.ID
 	err := c.rpcClient.Call(
 		pID.ID,
-		"Cluster",
-		"IPFSSwarmPeers",
+		"IPFSConnector",
+		"SwarmPeers",
 		struct{}{},
 		&swarmPeers,
 	)

--- a/consensus/crdt/consensus.go
+++ b/consensus/crdt/consensus.go
@@ -174,7 +174,7 @@ func (css *Consensus) setup() {
 		err = css.rpcClient.CallContext(
 			css.ctx,
 			"",
-			"Cluster",
+			"PinTracker",
 			"Track",
 			pin,
 			&struct{}{},
@@ -194,7 +194,7 @@ func (css *Consensus) setup() {
 		err = css.rpcClient.CallContext(
 			css.ctx,
 			"",
-			"Cluster",
+			"PinTracker",
 			"Untrack",
 			pin,
 			&struct{}{},
@@ -295,8 +295,8 @@ func (css *Consensus) Peers(ctx context.Context) ([]peer.ID, error) {
 	err := css.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"PeerMonitorLatestMetrics",
+		"PeerMonitor",
+		"LatestMetrics",
 		css.config.PeersetMetric,
 		&metrics,
 	)

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -280,7 +280,7 @@ func (cc *Consensus) redirectToLeader(method string, arg interface{}) (bool, err
 		finalErr = cc.rpcClient.CallContext(
 			ctx,
 			leader,
-			"Cluster",
+			"Consensus",
 			method,
 			arg,
 			&struct{}{},
@@ -360,7 +360,7 @@ func (cc *Consensus) LogPin(ctx context.Context, pin *api.Pin) error {
 	defer span.End()
 
 	op := cc.op(ctx, pin, LogOpPin)
-	err := cc.commit(ctx, op, "ConsensusLogPin", pin)
+	err := cc.commit(ctx, op, "LogPin", pin)
 	if err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func (cc *Consensus) LogUnpin(ctx context.Context, pin *api.Pin) error {
 	defer span.End()
 
 	op := cc.op(ctx, pin, LogOpUnpin)
-	err := cc.commit(ctx, op, "ConsensusLogUnpin", pin)
+	err := cc.commit(ctx, op, "LogUnpin", pin)
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (cc *Consensus) AddPeer(ctx context.Context, pid peer.ID) error {
 		if finalErr != nil {
 			logger.Errorf("retrying to add peer. Attempt #%d failed: %s", i, finalErr)
 		}
-		ok, err := cc.redirectToLeader("ConsensusAddPeer", pid)
+		ok, err := cc.redirectToLeader("AddPeer", pid)
 		if err != nil || ok {
 			return err
 		}
@@ -423,7 +423,7 @@ func (cc *Consensus) RmPeer(ctx context.Context, pid peer.ID) error {
 		if finalErr != nil {
 			logger.Errorf("retrying to remove peer. Attempt #%d failed: %s", i, finalErr)
 		}
-		ok, err := cc.redirectToLeader("ConsensusRmPeer", pid)
+		ok, err := cc.redirectToLeader("RmPeer", pid)
 		if err != nil || ok {
 			return err
 		}

--- a/consensus/raft/log_op.go
+++ b/consensus/raft/log_op.go
@@ -73,7 +73,7 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 		op.consensus.rpcClient.GoContext(
 			ctx,
 			"",
-			"Cluster",
+			"PinTracker",
 			"Track",
 			pin,
 			&struct{}{},
@@ -89,7 +89,7 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 		op.consensus.rpcClient.GoContext(
 			ctx,
 			"",
-			"Cluster",
+			"PinTracker",
 			"Untrack",
 			pin,
 			&struct{}{},

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -86,8 +86,8 @@ func (disk *Informer) GetMetric(ctx context.Context) *api.Metric {
 	err := disk.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"IPFSRepoStat",
+		"IPFSConnector",
+		"RepoStat",
 		struct{}{},
 		&repoStat,
 	)

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -17,14 +17,14 @@ type badRPCService struct {
 func badRPCClient(t *testing.T) *rpc.Client {
 	s := rpc.NewServer(nil, "mock")
 	c := rpc.NewClientWithServer(nil, "mock", s)
-	err := s.RegisterName("Cluster", &badRPCService{})
+	err := s.RegisterName("IPFSConnector", &badRPCService{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	return c
 }
 
-func (mock *badRPCService) IPFSRepoStat(ctx context.Context, in struct{}, out *api.IPFSRepoStat) error {
+func (mock *badRPCService) RepoStat(ctx context.Context, in struct{}, out *api.IPFSRepoStat) error {
 	return errors.New("fake error")
 }
 

--- a/informer/numpin/numpin.go
+++ b/informer/numpin/numpin.go
@@ -74,11 +74,11 @@ func (npi *Informer) GetMetric(ctx context.Context) *api.Metric {
 	// about the number of pins in IPFS. See RPCAPI docs.
 	err := npi.rpcClient.CallContext(
 		ctx,
-		"",          // Local call
-		"Cluster",   // Service name
-		"IPFSPinLs", // Method name
-		"recursive", // in arg
-		&pinMap,     // out arg
+		"",              // Local call
+		"IPFSConnector", // Service name
+		"PinLs",         // Method name
+		"recursive",     // in arg
+		&pinMap,         // out arg
 	)
 
 	valid := err == nil

--- a/informer/numpin/numpin_test.go
+++ b/informer/numpin/numpin_test.go
@@ -14,14 +14,14 @@ type mockService struct{}
 func mockRPCClient(t *testing.T) *rpc.Client {
 	s := rpc.NewServer(nil, "mock")
 	c := rpc.NewClientWithServer(nil, "mock", s)
-	err := s.RegisterName("Cluster", &mockService{})
+	err := s.RegisterName("IPFSConnector", &mockService{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	return c
 }
 
-func (mock *mockService) IPFSPinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
+func (mock *mockService) PinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
 	*out = map[string]api.IPFSPinStatus{
 		"QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa": api.IPFSPinStatusRecursive,
 		"QmUZ13osndQ5uL4tPWHXe3iBgBgq9gfewcBMSCAuMBsDJ6": api.IPFSPinStatusRecursive,

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -1,11 +1,9 @@
 // Package ipfscluster implements a wrapper for the IPFS deamon which
 // allows to orchestrate pinning operations among several IPFS nodes.
 //
-// IPFS Cluster uses a go-libp2p-raft to keep a shared state between
-// the different cluster peers. It also uses LibP2P to enable
-// communication between its different components, which perform different
-// tasks like managing the underlying IPFS daemons, or providing APIs for
-// external control.
+// IPFS Cluster peers form a separate libp2p swarm. A Cluster peer uses
+// multiple Cluster Componenets which perform different tasks like managing
+// the underlying IPFS daemons, or providing APIs for external control.
 package ipfscluster
 
 import (

--- a/pintracker/maptracker/maptracker.go
+++ b/pintracker/maptracker/maptracker.go
@@ -137,8 +137,8 @@ func (mpt *MapPinTracker) pin(op *optracker.Operation) error {
 	err := mpt.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"IPFSPin",
+		"IPFSConnector",
+		"Pin",
 		op.Pin(),
 		&struct{}{},
 	)
@@ -156,8 +156,8 @@ func (mpt *MapPinTracker) unpin(op *optracker.Operation) error {
 	err := mpt.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"IPFSUnpin",
+		"IPFSConnector",
+		"Unpin",
 		op.Pin(),
 		&struct{}{},
 	)
@@ -270,8 +270,8 @@ func (mpt *MapPinTracker) Sync(ctx context.Context, c cid.Cid) (*api.PinInfo, er
 	var ips api.IPFSPinStatus
 	err := mpt.rpcClient.Call(
 		"",
-		"Cluster",
-		"IPFSPinLsCid",
+		"IPFSConnector",
+		"PinLsCid",
 		c,
 		&ips,
 	)
@@ -300,8 +300,8 @@ func (mpt *MapPinTracker) SyncAll(ctx context.Context) ([]*api.PinInfo, error) {
 	var results []*api.PinInfo
 	err := mpt.rpcClient.Call(
 		"",
-		"Cluster",
-		"IPFSPinLs",
+		"IPFSConnector",
+		"PinLs",
 		"recursive",
 		&ipsMap,
 	)

--- a/pintracker/maptracker/maptracker_test.go
+++ b/pintracker/maptracker/maptracker_test.go
@@ -23,21 +23,19 @@ var (
 	ErrUnpinCancelCid = errors.New("should not have received rpc.IPFSUnpin operation")
 )
 
-type mockService struct {
-	rpcClient *rpc.Client
-}
+type mockIPFS struct{}
 
 func mockRPCClient(t *testing.T) *rpc.Client {
 	s := rpc.NewServer(nil, "mock")
 	c := rpc.NewClientWithServer(nil, "mock", s)
-	err := s.RegisterName("Cluster", &mockService{})
+	err := s.RegisterName("IPFSConnector", &mockIPFS{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	return c
 }
 
-func (mock *mockService) IPFSPin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (mock *mockIPFS) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	switch in.Cid.String() {
 	case test.SlowCid1.String():
 		time.Sleep(2 * time.Second)
@@ -47,7 +45,7 @@ func (mock *mockService) IPFSPin(ctx context.Context, in *api.Pin, out *struct{}
 	return nil
 }
 
-func (mock *mockService) IPFSUnpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (mock *mockIPFS) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	switch in.Cid.String() {
 	case test.SlowCid1.String():
 		time.Sleep(2 * time.Second)

--- a/pintracker/stateless/stateless.go
+++ b/pintracker/stateless/stateless.go
@@ -121,8 +121,8 @@ func (spt *Tracker) pin(op *optracker.Operation) error {
 	err := spt.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"IPFSPin",
+		"IPFSConnector",
+		"Pin",
 		op.Pin(),
 		&struct{}{},
 	)
@@ -140,8 +140,8 @@ func (spt *Tracker) unpin(op *optracker.Operation) error {
 	err := spt.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"IPFSUnpin",
+		"IPFSConnector",
+		"Unpin",
 		op.Pin(),
 		&struct{}{},
 	)
@@ -352,8 +352,8 @@ func (spt *Tracker) Status(ctx context.Context, c cid.Cid) *api.PinInfo {
 	var ips api.IPFSPinStatus
 	err = spt.rpcClient.Call(
 		"",
-		"Cluster",
-		"IPFSPinLsCid",
+		"IPFSConnector",
+		"PinLsCid",
 		c,
 		&ips,
 	)
@@ -462,8 +462,8 @@ func (spt *Tracker) Sync(ctx context.Context, c cid.Cid) (*api.PinInfo, error) {
 		var ips api.IPFSPinStatus
 		err := spt.rpcClient.Call(
 			"",
-			"Cluster",
-			"IPFSPinLsCid",
+			"IPFSConnector",
+			"PinLsCid",
 			c,
 			&ips,
 		)
@@ -544,8 +544,8 @@ func (spt *Tracker) ipfsStatusAll(ctx context.Context) (map[string]*api.PinInfo,
 	err := spt.rpcClient.CallContext(
 		ctx,
 		"",
-		"Cluster",
-		"IPFSPinLs",
+		"IPFSConnector",
+		"PinLs",
 		"recursive",
 		&ipsMap,
 	)

--- a/pintracker/stateless/stateless_test.go
+++ b/pintracker/stateless/stateless_test.go
@@ -25,21 +25,25 @@ var (
 	}
 )
 
-type mockService struct {
-	rpcClient *rpc.Client
-}
+type mockCluster struct{}
+
+type mockIPFS struct{}
 
 func mockRPCClient(t *testing.T) *rpc.Client {
 	s := rpc.NewServer(nil, "mock")
 	c := rpc.NewClientWithServer(nil, "mock", s)
-	err := s.RegisterName("Cluster", &mockService{})
+	err := s.RegisterName("Cluster", &mockCluster{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.RegisterName("IPFSConnector", &mockIPFS{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	return c
 }
 
-func (mock *mockService) IPFSPin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (mock *mockIPFS) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	switch in.Cid.String() {
 	case test.SlowCid1.String():
 		time.Sleep(2 * time.Second)
@@ -49,7 +53,7 @@ func (mock *mockService) IPFSPin(ctx context.Context, in *api.Pin, out *struct{}
 	return nil
 }
 
-func (mock *mockService) IPFSUnpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (mock *mockIPFS) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	switch in.Cid.String() {
 	case test.SlowCid1.String():
 		time.Sleep(2 * time.Second)
@@ -59,7 +63,7 @@ func (mock *mockService) IPFSUnpin(ctx context.Context, in *api.Pin, out *struct
 	return nil
 }
 
-func (mock *mockService) IPFSPinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
+func (mock *mockIPFS) PinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
 	m := map[string]api.IPFSPinStatus{
 		test.Cid1.String(): api.IPFSPinStatusRecursive,
 	}
@@ -67,7 +71,7 @@ func (mock *mockService) IPFSPinLs(ctx context.Context, in string, out *map[stri
 	return nil
 }
 
-func (mock *mockService) IPFSPinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
+func (mock *mockIPFS) PinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
 	switch in.String() {
 	case test.Cid1.String(), test.Cid2.String():
 		*out = api.IPFSPinStatusRecursive
@@ -77,7 +81,7 @@ func (mock *mockService) IPFSPinLsCid(ctx context.Context, in cid.Cid, out *api.
 	return nil
 }
 
-func (mock *mockService) Pins(ctx context.Context, in struct{}, out *[]*api.Pin) error {
+func (mock *mockCluster) Pins(ctx context.Context, in struct{}, out *[]*api.Pin) error {
 	*out = []*api.Pin{
 		api.PinWithOpts(test.Cid1, pinOpts),
 		api.PinWithOpts(test.Cid3, pinOpts),
@@ -85,7 +89,7 @@ func (mock *mockService) Pins(ctx context.Context, in struct{}, out *[]*api.Pin)
 	return nil
 }
 
-func (mock *mockService) PinGet(ctx context.Context, in cid.Cid, out *api.Pin) error {
+func (mock *mockCluster) PinGet(ctx context.Context, in cid.Cid, out *api.Pin) error {
 	switch in.String() {
 	case test.ErrorCid.String():
 		return errors.New("expected error when using ErrorCid")

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -3,49 +3,105 @@ package ipfscluster
 import (
 	"context"
 
-	peer "github.com/libp2p/go-libp2p-peer"
-
-	"go.opencensus.io/trace"
+	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/version"
+	ocgorpc "github.com/lanzafame/go-libp2p-ocgorpc"
 
 	cid "github.com/ipfs/go-cid"
-
-	"github.com/ipfs/ipfs-cluster/api"
+	rpc "github.com/libp2p/go-libp2p-gorpc"
+	peer "github.com/libp2p/go-libp2p-peer"
+	"go.opencensus.io/trace"
 )
 
-// RPCAPI is a go-libp2p-gorpc service which provides the internal ipfs-cluster
-// API, which enables components and cluster peers to communicate and
-// request actions from each other.
-//
-// The RPC API methods are usually redirects to the actual methods in
-// the different components of ipfs-cluster, with very little added logic.
-// Refer to documentation on those methods for details on their behaviour.
-type RPCAPI struct {
+// newRPCServer returns a new RPC Server for Cluster.
+func newRPCServer(c *Cluster) (*rpc.Server, error) {
+	var s *rpc.Server
+	if c.config.Tracing {
+		s = rpc.NewServer(
+			c.host,
+			version.RPCProtocol,
+			rpc.WithServerStatsHandler(&ocgorpc.ServerHandler{}),
+		)
+	} else {
+		s = rpc.NewServer(c.host, version.RPCProtocol)
+	}
+
+	err := s.RegisterName("Cluster", &ClusterRPCAPI{c})
+	if err != nil {
+		return nil, err
+	}
+	err = s.RegisterName("PinTracker", &PinTrackerRPCAPI{c.tracker})
+	if err != nil {
+		return nil, err
+	}
+	err = s.RegisterName("IPFSConnector", &IPFSConnectorRPCAPI{c.ipfs})
+	if err != nil {
+		return nil, err
+	}
+	err = s.RegisterName("Consensus", &ConsensusRPCAPI{c.consensus})
+	if err != nil {
+		return nil, err
+	}
+	err = s.RegisterName("PeerMonitor", &PeerMonitorRPCAPI{c.monitor})
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// ClusterRPCAPI is a go-libp2p-gorpc service which provides the internal peer
+// API for the main cluster component.
+type ClusterRPCAPI struct {
 	c *Cluster
 }
 
+// PinTrackerRPCAPI is a go-libp2p-gorpc service which provides the internal
+// peer API for the PinTracker component.
+type PinTrackerRPCAPI struct {
+	tracker PinTracker
+}
+
+// IPFSConnectorRPCAPI is a go-libp2p-gorpc service which provides the
+// internal peer API for the IPFSConnector component.
+type IPFSConnectorRPCAPI struct {
+	ipfs IPFSConnector
+}
+
+// ConsensusRPCAPI is a go-libp2p-gorpc service which provides the
+// internal peer API for the Consensus component.
+type ConsensusRPCAPI struct {
+	cons Consensus
+}
+
+// PeerMonitorRPCAPI is a go-libp2p-gorpc service which provides the
+// internal peer API for the PeerMonitor component.
+type PeerMonitorRPCAPI struct {
+	mon PeerMonitor
+}
+
 /*
-   Cluster components methods
+   Cluster component methods
 */
 
 // ID runs Cluster.ID()
-func (rpcapi *RPCAPI) ID(ctx context.Context, in struct{}, out *api.ID) error {
+func (rpcapi *ClusterRPCAPI) ID(ctx context.Context, in struct{}, out *api.ID) error {
 	id := rpcapi.c.ID(ctx)
 	*out = *id
 	return nil
 }
 
 // Pin runs Cluster.Pin().
-func (rpcapi *RPCAPI) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (rpcapi *ClusterRPCAPI) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	return rpcapi.c.Pin(ctx, in)
 }
 
 // Unpin runs Cluster.Unpin().
-func (rpcapi *RPCAPI) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (rpcapi *ClusterRPCAPI) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	return rpcapi.c.Unpin(ctx, in.Cid)
 }
 
 // PinPath resolves path into a cid and runs Cluster.Pin().
-func (rpcapi *RPCAPI) PinPath(ctx context.Context, in *api.PinPath, out *api.Pin) error {
+func (rpcapi *ClusterRPCAPI) PinPath(ctx context.Context, in *api.PinPath, out *api.Pin) error {
 	pin, err := rpcapi.c.PinPath(ctx, in)
 	if err != nil {
 		return err
@@ -55,7 +111,7 @@ func (rpcapi *RPCAPI) PinPath(ctx context.Context, in *api.PinPath, out *api.Pin
 }
 
 // UnpinPath resolves path into a cid and runs Cluster.Unpin().
-func (rpcapi *RPCAPI) UnpinPath(ctx context.Context, in *api.PinPath, out *api.Pin) error {
+func (rpcapi *ClusterRPCAPI) UnpinPath(ctx context.Context, in *api.PinPath, out *api.Pin) error {
 	pin, err := rpcapi.c.UnpinPath(ctx, in.Path)
 	if err != nil {
 		return err
@@ -65,7 +121,7 @@ func (rpcapi *RPCAPI) UnpinPath(ctx context.Context, in *api.PinPath, out *api.P
 }
 
 // Pins runs Cluster.Pins().
-func (rpcapi *RPCAPI) Pins(ctx context.Context, in struct{}, out *[]*api.Pin) error {
+func (rpcapi *ClusterRPCAPI) Pins(ctx context.Context, in struct{}, out *[]*api.Pin) error {
 	cidList, err := rpcapi.c.Pins(ctx)
 	if err != nil {
 		return err
@@ -75,7 +131,7 @@ func (rpcapi *RPCAPI) Pins(ctx context.Context, in struct{}, out *[]*api.Pin) er
 }
 
 // PinGet runs Cluster.PinGet().
-func (rpcapi *RPCAPI) PinGet(ctx context.Context, in cid.Cid, out *api.Pin) error {
+func (rpcapi *ClusterRPCAPI) PinGet(ctx context.Context, in cid.Cid, out *api.Pin) error {
 	pin, err := rpcapi.c.PinGet(ctx, in)
 	if err != nil {
 		return err
@@ -85,7 +141,7 @@ func (rpcapi *RPCAPI) PinGet(ctx context.Context, in cid.Cid, out *api.Pin) erro
 }
 
 // Version runs Cluster.Version().
-func (rpcapi *RPCAPI) Version(ctx context.Context, in struct{}, out *api.Version) error {
+func (rpcapi *ClusterRPCAPI) Version(ctx context.Context, in struct{}, out *api.Version) error {
 	*out = api.Version{
 		Version: rpcapi.c.Version(),
 	}
@@ -93,13 +149,13 @@ func (rpcapi *RPCAPI) Version(ctx context.Context, in struct{}, out *api.Version
 }
 
 // Peers runs Cluster.Peers().
-func (rpcapi *RPCAPI) Peers(ctx context.Context, in struct{}, out *[]*api.ID) error {
+func (rpcapi *ClusterRPCAPI) Peers(ctx context.Context, in struct{}, out *[]*api.ID) error {
 	*out = rpcapi.c.Peers(ctx)
 	return nil
 }
 
 // PeerAdd runs Cluster.PeerAdd().
-func (rpcapi *RPCAPI) PeerAdd(ctx context.Context, in peer.ID, out *api.ID) error {
+func (rpcapi *ClusterRPCAPI) PeerAdd(ctx context.Context, in peer.ID, out *api.ID) error {
 	id, err := rpcapi.c.PeerAdd(ctx, in)
 	if err != nil {
 		return err
@@ -109,7 +165,7 @@ func (rpcapi *RPCAPI) PeerAdd(ctx context.Context, in peer.ID, out *api.ID) erro
 }
 
 // ConnectGraph runs Cluster.GetConnectGraph().
-func (rpcapi *RPCAPI) ConnectGraph(ctx context.Context, in struct{}, out *api.ConnectGraph) error {
+func (rpcapi *ClusterRPCAPI) ConnectGraph(ctx context.Context, in struct{}, out *api.ConnectGraph) error {
 	graph, err := rpcapi.c.ConnectGraph()
 	if err != nil {
 		return err
@@ -119,17 +175,17 @@ func (rpcapi *RPCAPI) ConnectGraph(ctx context.Context, in struct{}, out *api.Co
 }
 
 // PeerRemove runs Cluster.PeerRm().
-func (rpcapi *RPCAPI) PeerRemove(ctx context.Context, in peer.ID, out *struct{}) error {
+func (rpcapi *ClusterRPCAPI) PeerRemove(ctx context.Context, in peer.ID, out *struct{}) error {
 	return rpcapi.c.PeerRemove(ctx, in)
 }
 
 // Join runs Cluster.Join().
-func (rpcapi *RPCAPI) Join(ctx context.Context, in api.Multiaddr, out *struct{}) error {
+func (rpcapi *ClusterRPCAPI) Join(ctx context.Context, in api.Multiaddr, out *struct{}) error {
 	return rpcapi.c.Join(ctx, in.Value())
 }
 
 // StatusAll runs Cluster.StatusAll().
-func (rpcapi *RPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]*api.GlobalPinInfo) error {
+func (rpcapi *ClusterRPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]*api.GlobalPinInfo) error {
 	pinfos, err := rpcapi.c.StatusAll(ctx)
 	if err != nil {
 		return err
@@ -139,14 +195,14 @@ func (rpcapi *RPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]*api.Gl
 }
 
 // StatusAllLocal runs Cluster.StatusAllLocal().
-func (rpcapi *RPCAPI) StatusAllLocal(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
+func (rpcapi *ClusterRPCAPI) StatusAllLocal(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
 	pinfos := rpcapi.c.StatusAllLocal(ctx)
 	*out = pinfos
 	return nil
 }
 
 // Status runs Cluster.Status().
-func (rpcapi *RPCAPI) Status(ctx context.Context, in cid.Cid, out *api.GlobalPinInfo) error {
+func (rpcapi *ClusterRPCAPI) Status(ctx context.Context, in cid.Cid, out *api.GlobalPinInfo) error {
 	pinfo, err := rpcapi.c.Status(ctx, in)
 	if err != nil {
 		return err
@@ -156,14 +212,14 @@ func (rpcapi *RPCAPI) Status(ctx context.Context, in cid.Cid, out *api.GlobalPin
 }
 
 // StatusLocal runs Cluster.StatusLocal().
-func (rpcapi *RPCAPI) StatusLocal(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
+func (rpcapi *ClusterRPCAPI) StatusLocal(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
 	pinfo := rpcapi.c.StatusLocal(ctx, in)
 	*out = *pinfo
 	return nil
 }
 
 // SyncAll runs Cluster.SyncAll().
-func (rpcapi *RPCAPI) SyncAll(ctx context.Context, in struct{}, out *[]*api.GlobalPinInfo) error {
+func (rpcapi *ClusterRPCAPI) SyncAll(ctx context.Context, in struct{}, out *[]*api.GlobalPinInfo) error {
 	pinfos, err := rpcapi.c.SyncAll(ctx)
 	if err != nil {
 		return err
@@ -173,7 +229,7 @@ func (rpcapi *RPCAPI) SyncAll(ctx context.Context, in struct{}, out *[]*api.Glob
 }
 
 // SyncAllLocal runs Cluster.SyncAllLocal().
-func (rpcapi *RPCAPI) SyncAllLocal(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
+func (rpcapi *ClusterRPCAPI) SyncAllLocal(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
 	pinfos, err := rpcapi.c.SyncAllLocal(ctx)
 	if err != nil {
 		return err
@@ -183,7 +239,7 @@ func (rpcapi *RPCAPI) SyncAllLocal(ctx context.Context, in struct{}, out *[]*api
 }
 
 // Sync runs Cluster.Sync().
-func (rpcapi *RPCAPI) Sync(ctx context.Context, in cid.Cid, out *api.GlobalPinInfo) error {
+func (rpcapi *ClusterRPCAPI) Sync(ctx context.Context, in cid.Cid, out *api.GlobalPinInfo) error {
 	pinfo, err := rpcapi.c.Sync(ctx, in)
 	if err != nil {
 		return err
@@ -193,7 +249,7 @@ func (rpcapi *RPCAPI) Sync(ctx context.Context, in cid.Cid, out *api.GlobalPinIn
 }
 
 // SyncLocal runs Cluster.SyncLocal().
-func (rpcapi *RPCAPI) SyncLocal(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
+func (rpcapi *ClusterRPCAPI) SyncLocal(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
 	pinfo, err := rpcapi.c.SyncLocal(ctx, in)
 	if err != nil {
 		return err
@@ -203,7 +259,7 @@ func (rpcapi *RPCAPI) SyncLocal(ctx context.Context, in cid.Cid, out *api.PinInf
 }
 
 // RecoverAllLocal runs Cluster.RecoverAllLocal().
-func (rpcapi *RPCAPI) RecoverAllLocal(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
+func (rpcapi *ClusterRPCAPI) RecoverAllLocal(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
 	pinfos, err := rpcapi.c.RecoverAllLocal(ctx)
 	if err != nil {
 		return err
@@ -213,7 +269,7 @@ func (rpcapi *RPCAPI) RecoverAllLocal(ctx context.Context, in struct{}, out *[]*
 }
 
 // Recover runs Cluster.Recover().
-func (rpcapi *RPCAPI) Recover(ctx context.Context, in cid.Cid, out *api.GlobalPinInfo) error {
+func (rpcapi *ClusterRPCAPI) Recover(ctx context.Context, in cid.Cid, out *api.GlobalPinInfo) error {
 	pinfo, err := rpcapi.c.Recover(ctx, in)
 	if err != nil {
 		return err
@@ -223,7 +279,7 @@ func (rpcapi *RPCAPI) Recover(ctx context.Context, in cid.Cid, out *api.GlobalPi
 }
 
 // RecoverLocal runs Cluster.RecoverLocal().
-func (rpcapi *RPCAPI) RecoverLocal(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
+func (rpcapi *ClusterRPCAPI) RecoverLocal(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
 	pinfo, err := rpcapi.c.RecoverLocal(ctx, in)
 	if err != nil {
 		return err
@@ -234,7 +290,7 @@ func (rpcapi *RPCAPI) RecoverLocal(ctx context.Context, in cid.Cid, out *api.Pin
 
 // BlockAllocate returns allocations for blocks. This is used in the adders.
 // It's different from pin allocations when ReplicationFactor < 0.
-func (rpcapi *RPCAPI) BlockAllocate(ctx context.Context, in *api.Pin, out *[]peer.ID) error {
+func (rpcapi *ClusterRPCAPI) BlockAllocate(ctx context.Context, in *api.Pin, out *[]peer.ID) error {
 	err := rpcapi.c.setupPin(ctx, in)
 	if err != nil {
 		return err
@@ -272,7 +328,7 @@ func (rpcapi *RPCAPI) BlockAllocate(ctx context.Context, in *api.Pin, out *[]pee
 }
 
 // SendInformerMetric runs Cluster.sendInformerMetric().
-func (rpcapi *RPCAPI) SendInformerMetric(ctx context.Context, in struct{}, out *api.Metric) error {
+func (rpcapi *ClusterRPCAPI) SendInformerMetric(ctx context.Context, in struct{}, out *api.Metric) error {
 	m, err := rpcapi.c.sendInformerMetric(ctx)
 	if err != nil {
 		return err
@@ -286,41 +342,41 @@ func (rpcapi *RPCAPI) SendInformerMetric(ctx context.Context, in struct{}, out *
 */
 
 // Track runs PinTracker.Track().
-func (rpcapi *RPCAPI) Track(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (rpcapi *PinTrackerRPCAPI) Track(ctx context.Context, in *api.Pin, out *struct{}) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/tracker/Track")
 	defer span.End()
-	return rpcapi.c.tracker.Track(ctx, in)
+	return rpcapi.tracker.Track(ctx, in)
 }
 
 // Untrack runs PinTracker.Untrack().
-func (rpcapi *RPCAPI) Untrack(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (rpcapi *PinTrackerRPCAPI) Untrack(ctx context.Context, in *api.Pin, out *struct{}) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/tracker/Untrack")
 	defer span.End()
-	return rpcapi.c.tracker.Untrack(ctx, in.Cid)
+	return rpcapi.tracker.Untrack(ctx, in.Cid)
 }
 
-// TrackerStatusAll runs PinTracker.StatusAll().
-func (rpcapi *RPCAPI) TrackerStatusAll(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
+// StatusAll runs PinTracker.StatusAll().
+func (rpcapi *PinTrackerRPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/tracker/StatusAll")
 	defer span.End()
-	*out = rpcapi.c.tracker.StatusAll(ctx)
+	*out = rpcapi.tracker.StatusAll(ctx)
 	return nil
 }
 
-// TrackerStatus runs PinTracker.Status().
-func (rpcapi *RPCAPI) TrackerStatus(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
+// Status runs PinTracker.Status().
+func (rpcapi *PinTrackerRPCAPI) Status(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/tracker/Status")
 	defer span.End()
-	pinfo := rpcapi.c.tracker.Status(ctx, in)
+	pinfo := rpcapi.tracker.Status(ctx, in)
 	*out = *pinfo
 	return nil
 }
 
-// TrackerRecoverAll runs PinTracker.RecoverAll().f
-func (rpcapi *RPCAPI) TrackerRecoverAll(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
+// RecoverAll runs PinTracker.RecoverAll().f
+func (rpcapi *PinTrackerRPCAPI) RecoverAll(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/tracker/RecoverAll")
 	defer span.End()
-	pinfos, err := rpcapi.c.tracker.RecoverAll(ctx)
+	pinfos, err := rpcapi.tracker.RecoverAll(ctx)
 	if err != nil {
 		return err
 	}
@@ -328,11 +384,11 @@ func (rpcapi *RPCAPI) TrackerRecoverAll(ctx context.Context, in struct{}, out *[
 	return nil
 }
 
-// TrackerRecover runs PinTracker.Recover().
-func (rpcapi *RPCAPI) TrackerRecover(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
+// Recover runs PinTracker.Recover().
+func (rpcapi *PinTrackerRPCAPI) Recover(ctx context.Context, in cid.Cid, out *api.PinInfo) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/tracker/Recover")
 	defer span.End()
-	pinfo, err := rpcapi.c.tracker.Recover(ctx, in)
+	pinfo, err := rpcapi.tracker.Recover(ctx, in)
 	*out = *pinfo
 	return err
 }
@@ -341,21 +397,21 @@ func (rpcapi *RPCAPI) TrackerRecover(ctx context.Context, in cid.Cid, out *api.P
    IPFS Connector component methods
 */
 
-// IPFSPin runs IPFSConnector.Pin().
-func (rpcapi *RPCAPI) IPFSPin(ctx context.Context, in *api.Pin, out *struct{}) error {
+// Pin runs IPFSConnector.Pin().
+func (rpcapi *IPFSConnectorRPCAPI) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/ipfsconn/IPFSPin")
 	defer span.End()
-	return rpcapi.c.ipfs.Pin(ctx, in.Cid, in.MaxDepth)
+	return rpcapi.ipfs.Pin(ctx, in.Cid, in.MaxDepth)
 }
 
-// IPFSUnpin runs IPFSConnector.Unpin().
-func (rpcapi *RPCAPI) IPFSUnpin(ctx context.Context, in *api.Pin, out *struct{}) error {
-	return rpcapi.c.ipfs.Unpin(ctx, in.Cid)
+// Unpin runs IPFSConnector.Unpin().
+func (rpcapi *IPFSConnectorRPCAPI) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+	return rpcapi.ipfs.Unpin(ctx, in.Cid)
 }
 
-// IPFSPinLsCid runs IPFSConnector.PinLsCid().
-func (rpcapi *RPCAPI) IPFSPinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
-	b, err := rpcapi.c.ipfs.PinLsCid(ctx, in)
+// PinLsCid runs IPFSConnector.PinLsCid().
+func (rpcapi *IPFSConnectorRPCAPI) PinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
+	b, err := rpcapi.ipfs.PinLsCid(ctx, in)
 	if err != nil {
 		return err
 	}
@@ -363,9 +419,9 @@ func (rpcapi *RPCAPI) IPFSPinLsCid(ctx context.Context, in cid.Cid, out *api.IPF
 	return nil
 }
 
-// IPFSPinLs runs IPFSConnector.PinLs().
-func (rpcapi *RPCAPI) IPFSPinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
-	m, err := rpcapi.c.ipfs.PinLs(ctx, in)
+// PinLs runs IPFSConnector.PinLs().
+func (rpcapi *IPFSConnectorRPCAPI) PinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
+	m, err := rpcapi.ipfs.PinLs(ctx, in)
 	if err != nil {
 		return err
 	}
@@ -373,15 +429,15 @@ func (rpcapi *RPCAPI) IPFSPinLs(ctx context.Context, in string, out *map[string]
 	return nil
 }
 
-// IPFSConnectSwarms runs IPFSConnector.ConnectSwarms().
-func (rpcapi *RPCAPI) IPFSConnectSwarms(ctx context.Context, in struct{}, out *struct{}) error {
-	err := rpcapi.c.ipfs.ConnectSwarms(ctx)
+// ConnectSwarms runs IPFSConnector.ConnectSwarms().
+func (rpcapi *IPFSConnectorRPCAPI) ConnectSwarms(ctx context.Context, in struct{}, out *struct{}) error {
+	err := rpcapi.ipfs.ConnectSwarms(ctx)
 	return err
 }
 
-// IPFSConfigKey runs IPFSConnector.ConfigKey().
-func (rpcapi *RPCAPI) IPFSConfigKey(ctx context.Context, in string, out *interface{}) error {
-	res, err := rpcapi.c.ipfs.ConfigKey(in)
+// ConfigKey runs IPFSConnector.ConfigKey().
+func (rpcapi *IPFSConnectorRPCAPI) ConfigKey(ctx context.Context, in string, out *interface{}) error {
+	res, err := rpcapi.ipfs.ConfigKey(in)
 	if err != nil {
 		return err
 	}
@@ -389,9 +445,9 @@ func (rpcapi *RPCAPI) IPFSConfigKey(ctx context.Context, in string, out *interfa
 	return nil
 }
 
-// IPFSRepoStat runs IPFSConnector.RepoStat().
-func (rpcapi *RPCAPI) IPFSRepoStat(ctx context.Context, in struct{}, out *api.IPFSRepoStat) error {
-	res, err := rpcapi.c.ipfs.RepoStat(ctx)
+// RepoStat runs IPFSConnector.RepoStat().
+func (rpcapi *IPFSConnectorRPCAPI) RepoStat(ctx context.Context, in struct{}, out *api.IPFSRepoStat) error {
+	res, err := rpcapi.ipfs.RepoStat(ctx)
 	if err != nil {
 		return err
 	}
@@ -399,9 +455,9 @@ func (rpcapi *RPCAPI) IPFSRepoStat(ctx context.Context, in struct{}, out *api.IP
 	return err
 }
 
-// IPFSSwarmPeers runs IPFSConnector.SwarmPeers().
-func (rpcapi *RPCAPI) IPFSSwarmPeers(ctx context.Context, in struct{}, out *[]peer.ID) error {
-	res, err := rpcapi.c.ipfs.SwarmPeers(ctx)
+// SwarmPeers runs IPFSConnector.SwarmPeers().
+func (rpcapi *IPFSConnectorRPCAPI) SwarmPeers(ctx context.Context, in struct{}, out *[]peer.ID) error {
+	res, err := rpcapi.ipfs.SwarmPeers(ctx)
 	if err != nil {
 		return err
 	}
@@ -409,14 +465,14 @@ func (rpcapi *RPCAPI) IPFSSwarmPeers(ctx context.Context, in struct{}, out *[]pe
 	return nil
 }
 
-// IPFSBlockPut runs IPFSConnector.BlockPut().
-func (rpcapi *RPCAPI) IPFSBlockPut(ctx context.Context, in *api.NodeWithMeta, out *struct{}) error {
-	return rpcapi.c.ipfs.BlockPut(ctx, in)
+// BlockPut runs IPFSConnector.BlockPut().
+func (rpcapi *IPFSConnectorRPCAPI) BlockPut(ctx context.Context, in *api.NodeWithMeta, out *struct{}) error {
+	return rpcapi.ipfs.BlockPut(ctx, in)
 }
 
-// IPFSBlockGet runs IPFSConnector.BlockGet().
-func (rpcapi *RPCAPI) IPFSBlockGet(ctx context.Context, in cid.Cid, out *[]byte) error {
-	res, err := rpcapi.c.ipfs.BlockGet(ctx, in)
+// BlockGet runs IPFSConnector.BlockGet().
+func (rpcapi *IPFSConnectorRPCAPI) BlockGet(ctx context.Context, in cid.Cid, out *[]byte) error {
+	res, err := rpcapi.ipfs.BlockGet(ctx, in)
 	if err != nil {
 		return err
 	}
@@ -424,9 +480,9 @@ func (rpcapi *RPCAPI) IPFSBlockGet(ctx context.Context, in cid.Cid, out *[]byte)
 	return nil
 }
 
-// IPFSResolve runs IPFSConnector.Resolve().
-func (rpcapi *RPCAPI) IPFSResolve(ctx context.Context, in string, out *cid.Cid) error {
-	c, err := rpcapi.c.ipfs.Resolve(ctx, in)
+// Resolve runs IPFSConnector.Resolve().
+func (rpcapi *IPFSConnectorRPCAPI) Resolve(ctx context.Context, in string, out *cid.Cid) error {
+	c, err := rpcapi.ipfs.Resolve(ctx, in)
 	if err != nil {
 		return err
 	}
@@ -438,37 +494,37 @@ func (rpcapi *RPCAPI) IPFSResolve(ctx context.Context, in string, out *cid.Cid) 
    Consensus component methods
 */
 
-// ConsensusLogPin runs Consensus.LogPin().
-func (rpcapi *RPCAPI) ConsensusLogPin(ctx context.Context, in *api.Pin, out *struct{}) error {
+// LogPin runs Consensus.LogPin().
+func (rpcapi *ConsensusRPCAPI) LogPin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/consensus/LogPin")
 	defer span.End()
-	return rpcapi.c.consensus.LogPin(ctx, in)
+	return rpcapi.cons.LogPin(ctx, in)
 }
 
-// ConsensusLogUnpin runs Consensus.LogUnpin().
-func (rpcapi *RPCAPI) ConsensusLogUnpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+// LogUnpin runs Consensus.LogUnpin().
+func (rpcapi *ConsensusRPCAPI) LogUnpin(ctx context.Context, in *api.Pin, out *struct{}) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/consensus/LogUnpin")
 	defer span.End()
-	return rpcapi.c.consensus.LogUnpin(ctx, in)
+	return rpcapi.cons.LogUnpin(ctx, in)
 }
 
-// ConsensusAddPeer runs Consensus.AddPeer().
-func (rpcapi *RPCAPI) ConsensusAddPeer(ctx context.Context, in peer.ID, out *struct{}) error {
+// AddPeer runs Consensus.AddPeer().
+func (rpcapi *ConsensusRPCAPI) AddPeer(ctx context.Context, in peer.ID, out *struct{}) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/consensus/AddPeer")
 	defer span.End()
-	return rpcapi.c.consensus.AddPeer(ctx, in)
+	return rpcapi.cons.AddPeer(ctx, in)
 }
 
-// ConsensusRmPeer runs Consensus.RmPeer().
-func (rpcapi *RPCAPI) ConsensusRmPeer(ctx context.Context, in peer.ID, out *struct{}) error {
+// RmPeer runs Consensus.RmPeer().
+func (rpcapi *ConsensusRPCAPI) RmPeer(ctx context.Context, in peer.ID, out *struct{}) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/consensus/RmPeer")
 	defer span.End()
-	return rpcapi.c.consensus.RmPeer(ctx, in)
+	return rpcapi.cons.RmPeer(ctx, in)
 }
 
-// ConsensusPeers runs Consensus.Peers().
-func (rpcapi *RPCAPI) ConsensusPeers(ctx context.Context, in struct{}, out *[]peer.ID) error {
-	peers, err := rpcapi.c.consensus.Peers(ctx)
+// Peers runs Consensus.Peers().
+func (rpcapi *ConsensusRPCAPI) Peers(ctx context.Context, in struct{}, out *[]peer.ID) error {
+	peers, err := rpcapi.cons.Peers(ctx)
 	if err != nil {
 		return err
 	}
@@ -480,13 +536,13 @@ func (rpcapi *RPCAPI) ConsensusPeers(ctx context.Context, in struct{}, out *[]pe
    PeerMonitor
 */
 
-// PeerMonitorLogMetric runs PeerMonitor.LogMetric().
-func (rpcapi *RPCAPI) PeerMonitorLogMetric(ctx context.Context, in *api.Metric, out *struct{}) error {
-	return rpcapi.c.monitor.LogMetric(ctx, in)
+// LogMetric runs PeerMonitor.LogMetric().
+func (rpcapi *PeerMonitorRPCAPI) LogMetric(ctx context.Context, in *api.Metric, out *struct{}) error {
+	return rpcapi.mon.LogMetric(ctx, in)
 }
 
-// PeerMonitorLatestMetrics runs PeerMonitor.LatestMetrics().
-func (rpcapi *RPCAPI) PeerMonitorLatestMetrics(ctx context.Context, in string, out *[]*api.Metric) error {
-	*out = rpcapi.c.monitor.LatestMetrics(ctx, in)
+// LatestMetrics runs PeerMonitor.LatestMetrics().
+func (rpcapi *PeerMonitorRPCAPI) LatestMetrics(ctx context.Context, in string, out *[]*api.Metric) error {
+	*out = rpcapi.mon.LatestMetrics(ctx, in)
 	return nil
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -14,49 +14,77 @@ func TestIpfsMock(t *testing.T) {
 
 // Test that our RPC mock resembles the original
 func TestRPCMockValid(t *testing.T) {
-	mock := &mockService{}
-	real := &ipfscluster.RPCAPI{}
-	mockT := reflect.TypeOf(mock)
-	realT := reflect.TypeOf(real)
-
-	// Make sure all the methods we have match the original
-	for i := 0; i < mockT.NumMethod(); i++ {
-		method := mockT.Method(i)
-		name := method.Name
-		origMethod, ok := realT.MethodByName(name)
-		if !ok {
-			t.Fatalf("%s method not found in real RPC", name)
-		}
-
-		mType := method.Type
-		oType := origMethod.Type
-
-		if nout := mType.NumOut(); nout != 1 || nout != oType.NumOut() {
-			t.Errorf("%s: more than 1 out parameter", name)
-		}
-
-		if mType.Out(0).Name() != "error" {
-			t.Errorf("%s out param should be an error", name)
-		}
-
-		if nin := mType.NumIn(); nin != oType.NumIn() || nin != 4 {
-			t.Fatalf("%s: num in parameter mismatch: %d vs. %d", name, nin, oType.NumIn())
-		}
-
-		for j := 1; j < 4; j++ {
-			mn := mType.In(j).String()
-			on := oType.In(j).String()
-			if mn != on {
-				t.Errorf("%s: name mismatch: %s vs %s", name, mn, on)
-			}
-		}
+	type tc struct {
+		mock reflect.Type
+		real reflect.Type
 	}
 
-	for i := 0; i < realT.NumMethod(); i++ {
-		name := realT.Method(i).Name
-		_, ok := mockT.MethodByName(name)
-		if !ok {
-			t.Logf("Warning: %s: unimplemented in mock rpc", name)
+	tcs := []tc{
+		{
+			real: reflect.TypeOf(&ipfscluster.ClusterRPCAPI{}),
+			mock: reflect.TypeOf(&mockCluster{}),
+		},
+		{
+			real: reflect.TypeOf(&ipfscluster.PinTrackerRPCAPI{}),
+			mock: reflect.TypeOf(&mockPinTracker{}),
+		},
+		{
+			real: reflect.TypeOf(&ipfscluster.IPFSConnectorRPCAPI{}),
+			mock: reflect.TypeOf(&mockIPFSConnector{}),
+		},
+		{
+			real: reflect.TypeOf(&ipfscluster.ConsensusRPCAPI{}),
+			mock: reflect.TypeOf(&mockConsensus{}),
+		},
+		{
+			real: reflect.TypeOf(&ipfscluster.PeerMonitorRPCAPI{}),
+			mock: reflect.TypeOf(&mockPeerMonitor{}),
+		},
+	}
+
+	for _, tc := range tcs {
+		realT := tc.real
+		mockT := tc.mock
+
+		// Make sure all the methods we have match the original
+		for i := 0; i < mockT.NumMethod(); i++ {
+			method := mockT.Method(i)
+			name := method.Name
+			origMethod, ok := realT.MethodByName(name)
+			if !ok {
+				t.Fatalf("%s method not found in real RPC", name)
+			}
+
+			mType := method.Type
+			oType := origMethod.Type
+
+			if nout := mType.NumOut(); nout != 1 || nout != oType.NumOut() {
+				t.Errorf("%s: more than 1 out parameter", name)
+			}
+
+			if mType.Out(0).Name() != "error" {
+				t.Errorf("%s out param should be an error", name)
+			}
+
+			if nin := mType.NumIn(); nin != oType.NumIn() || nin != 4 {
+				t.Fatalf("%s: num in parameter mismatch: %d vs. %d", name, nin, oType.NumIn())
+			}
+
+			for j := 1; j < 4; j++ {
+				mn := mType.In(j).String()
+				on := oType.In(j).String()
+				if mn != on {
+					t.Errorf("%s: name mismatch: %s vs %s", name, mn, on)
+				}
+			}
+		}
+
+		for i := 0; i < realT.NumMethod(); i++ {
+			name := realT.Method(i).Name
+			_, ok := mockT.MethodByName(name)
+			if !ok {
+				t.Logf("Warning: %s: unimplemented in mock rpc", name)
+			}
 		}
 	}
 }


### PR DESCRIPTION
I had thought of this for a very long time but there were no compelling
reasons to do it. Specifying RPC endpoint permissions becomes however
significantly nicer if each Component is a different RPC Service. This also
fixes some naming issues like having to prefix methods with the component name
to separate them from methods named in the same way in some other component
(Pin and IPFSPin).

Main changes here: in `rpc_api.go`. The rest is just renamings and adapting the tests.