### PR TITLE
service: multiple fixes around init and identities

### DIFF
--- a/cmd/ipfs-cluster-service/lock.go
+++ b/cmd/ipfs-cluster-service/lock.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path"
 
 	fslock "github.com/ipfs/go-fs-lock"
@@ -28,11 +27,8 @@ func (l *lock) lock() {
 		checkErr("", errors.New("cannot acquire lock twice"))
 	}
 
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		errMsg := "%s config hasn't been initialized. Please run '%s init'"
-		errMsg = fmt.Sprintf(errMsg, programName, programName)
-		checkErr("", errors.New(errMsg))
-	}
+	// we should have a config folder whenever we try to lock
+	makeConfigFolder()
 
 	// set the lock file within this function
 	logger.Debug("checking lock")

--- a/config/identity.go
+++ b/config/identity.go
@@ -64,7 +64,7 @@ func (ident *Identity) ConfigKey() string {
 // SaveJSON saves the JSON representation of the Identity to
 // the given path.
 func (ident *Identity) SaveJSON(path string) error {
-	logger.Info("Saving configuration")
+	logger.Info("Saving identity")
 
 	bs, err := ident.ToJSON()
 	if err != nil {


### PR DESCRIPTION
* Fix error messages (they must be in the form "doing something")
* Improve/reword some error messages
* Document the identity.json existance in the cli docs
* Fix a bunch of typos
* Fix missing folder path in the --help
* Fix cluster not locking when configuration is not there but folder is
* Fix force flag not overriding the config overwrite prompt
* Fix deletion of Raft state on re-init (not necessary if identity persists)
* Fix overwriting on identity (should not be overwritten if already exists)

Much of this paves the way to be able to run without service.json:

* Either taking default values (and using env vars) - maybe someday
* Either by getting a configuration template it from somewhere (ipfs, http)
  at runtime - sooner.