### PR TITLE
Fix #787: Connectivity fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ test_problem: gx-deps
 
 $(sharness):
 	@echo "Downloading sharness"
-	@curl -L -s -o sharness/lib/sharness.tar.gz http://github.com/chriscool/sharness/archive/master.tar.gz
+	@curl -L -s -o sharness/lib/sharness.tar.gz http://github.com/chriscool/sharness/archive/8fa4b9b0465d21b7ec114ec4528fa17f5a6eb361.tar.gz
 	@cd sharness/lib; tar -zxf sharness.tar.gz; cd ../..
-	@mv sharness/lib/sharness-master sharness/lib/sharness
+	@mv sharness/lib/sharness-8fa4b9b0465d21b7ec114ec4528fa17f5a6eb361 sharness/lib/sharness
 	@rm sharness/lib/sharness.tar.gz
 
 clean_sharness:

--- a/api/ipfsproxy/config.go
+++ b/api/ipfsproxy/config.go
@@ -206,20 +206,23 @@ func (cfg *Config) LoadJSON(raw []byte) error {
 }
 
 func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
-	proxyAddr, err := ma.NewMultiaddr(jcfg.ListenMultiaddress)
-	if err != nil {
-		return fmt.Errorf("error parsing proxy listen_multiaddress: %s", err)
+	if jcfg.ListenMultiaddress != "" {
+		proxyAddr, err := ma.NewMultiaddr(jcfg.ListenMultiaddress)
+		if err != nil {
+			return fmt.Errorf("error parsing proxy listen_multiaddress: %s", err)
+		}
+		cfg.ListenAddr = proxyAddr
 	}
-	nodeAddr, err := ma.NewMultiaddr(jcfg.NodeMultiaddress)
-	if err != nil {
-		return fmt.Errorf("error parsing ipfs node_multiaddress: %s", err)
+	if jcfg.NodeMultiaddress != "" {
+		nodeAddr, err := ma.NewMultiaddr(jcfg.NodeMultiaddress)
+		if err != nil {
+			return fmt.Errorf("error parsing ipfs node_multiaddress: %s", err)
+		}
+		cfg.NodeAddr = nodeAddr
 	}
-
-	cfg.ListenAddr = proxyAddr
-	cfg.NodeAddr = nodeAddr
 	config.SetIfNotDefault(jcfg.NodeHTTPS, &cfg.NodeHTTPS)
 
-	err = config.ParseDurations(
+	err := config.ParseDurations(
 		"ipfsproxy",
 		&config.DurationOpt{Duration: jcfg.ReadTimeout, Dst: &cfg.ReadTimeout, Name: "read_timeout"},
 		&config.DurationOpt{Duration: jcfg.ReadHeaderTimeout, Dst: &cfg.ReadHeaderTimeout, Name: "read_header_timeout"},

--- a/api/rest/client/transports.go
+++ b/api/rest/client/transports.go
@@ -8,11 +8,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ipfs/ipfs-cluster/api"
-
 	p2phttp "github.com/hsanjuan/go-libp2p-http"
 	libp2p "github.com/libp2p/go-libp2p"
 	ipnet "github.com/libp2p/go-libp2p-interface-pnet"
+	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	pnet "github.com/libp2p/go-libp2p-pnet"
 	madns "github.com/multiformats/go-multiaddr-dns"
@@ -41,9 +40,13 @@ func (c *defaultClient) defaultTransport() {
 func (c *defaultClient) enableLibp2p() error {
 	c.defaultTransport()
 
-	pid, addr, err := api.Libp2pMultiaddrSplit(c.config.APIAddr)
+	pinfo, err := peerstore.InfoFromP2pAddr(c.config.APIAddr)
 	if err != nil {
 		return err
+	}
+
+	if len(pinfo.Addrs) == 0 {
+		return errors.New("APIAddr only includes a Peer ID")
 	}
 
 	var prot ipnet.Protector
@@ -67,16 +70,16 @@ func (c *defaultClient) enableLibp2p() error {
 
 	ctx, cancel := context.WithTimeout(c.ctx, ResolveTimeout)
 	defer cancel()
-	resolvedAddrs, err := madns.Resolve(ctx, addr)
+	resolvedAddrs, err := madns.Resolve(ctx, pinfo.Addrs[0])
 	if err != nil {
 		return err
 	}
 
-	h.Peerstore().AddAddrs(pid, resolvedAddrs, peerstore.PermanentAddrTTL)
+	h.Peerstore().AddAddrs(pinfo.ID, resolvedAddrs, peerstore.PermanentAddrTTL)
 	c.transport.RegisterProtocol("libp2p", p2phttp.NewTransport(h))
 	c.net = "libp2p"
 	c.p2p = h
-	c.hostname = pid.Pretty()
+	c.hostname = peer.IDB58Encode(pinfo.ID)
 	return nil
 }
 

--- a/api/util.go
+++ b/api/util.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"fmt"
-
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -30,29 +28,6 @@ func StringsToPeers(strs []string) []peer.ID {
 		peers = append(peers, pid)
 	}
 	return peers
-}
-
-// Libp2pMultiaddrSplit takes a LibP2P multiaddress (/<multiaddr>/ipfs/<peerID>)
-// and decapsulates it, parsing the peer ID. Returns an error if there is
-// any problem (for example, the provided address not being a Libp2p one).
-func Libp2pMultiaddrSplit(addr ma.Multiaddr) (peer.ID, ma.Multiaddr, error) {
-	pid, err := addr.ValueForProtocol(ma.P_IPFS)
-	if err != nil {
-		err = fmt.Errorf("invalid peer multiaddress: %s: %s", addr, err)
-		logger.Error(err)
-		return "", nil, err
-	}
-
-	ipfs, _ := ma.NewMultiaddr("/ipfs/" + pid)
-	decapAddr := addr.Decapsulate(ipfs)
-
-	peerID, err := peer.IDB58Decode(pid)
-	if err != nil {
-		err = fmt.Errorf("invalid peer ID in multiaddress: %s: %s", pid, err)
-		logger.Error(err)
-		return "", nil, err
-	}
-	return peerID, decapAddr, nil
 }
 
 // MustLibp2pMultiaddrJoin takes a LibP2P multiaddress and a peer ID and

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ipfs/ipfs-cluster/observations"
 	"github.com/ipfs/ipfs-cluster/pintracker/maptracker"
 	"github.com/ipfs/ipfs-cluster/pintracker/stateless"
-	"github.com/ipfs/ipfs-cluster/pstoremgr"
 	"go.opencensus.io/tag"
 
 	ds "github.com/ipfs/go-datastore"
@@ -112,13 +111,6 @@ func createCluster(
 
 	ctx, err := tag.New(ctx, tag.Upsert(observations.HostKey, host.ID().Pretty()))
 	checkErr("tag context with host id", err)
-
-	peerstoreMgr := pstoremgr.New(host, cfgs.clusterCfg.GetPeerstorePath())
-	// Import peers but do not connect. We cannot connect to peers until
-	// everything has been created (dht, pubsub, bitswap). Otherwise things
-	// fail.
-	// Connections will happen as needed during bootstrap, rpc etc.
-	peerstoreMgr.ImportPeersFromPeerstore(false)
 
 	api, err := rest.NewAPIWithHost(ctx, cfgs.apiCfg, host)
 	checkErr("creating REST API component", err)

--- a/cmd/ipfs-cluster-service/state.go
+++ b/cmd/ipfs-cluster-service/state.go
@@ -73,7 +73,7 @@ func (raftsm *raftStateManager) ImportState(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	pm := pstoremgr.New(nil, raftsm.cfgs.clusterCfg.GetPeerstorePath())
+	pm := pstoremgr.New(context.Background(), nil, raftsm.cfgs.clusterCfg.GetPeerstorePath())
 	raftPeers := append(
 		ipfscluster.PeersFromMultiaddrs(pm.LoadPeerstore()),
 		raftsm.ident.ID,

--- a/consensus/crdt/consensus.go
+++ b/consensus/crdt/consensus.go
@@ -102,12 +102,6 @@ func New(
 		readyCh:     make(chan struct{}, 1),
 	}
 
-	// Set up a fast-lookup trusted peers cache.
-	// Protect these peers in the ConnMgr
-	for _, p := range css.config.TrustedPeers {
-		css.Trust(ctx, p)
-	}
-
 	go css.setup()
 	return css, nil
 }
@@ -117,6 +111,12 @@ func (css *Consensus) setup() {
 	case <-css.ctx.Done():
 		return
 	case <-css.rpcReady:
+	}
+
+	// Set up a fast-lookup trusted peers cache.
+	// Protect these peers in the ConnMgr
+	for _, p := range css.config.TrustedPeers {
+		css.Trust(css.ctx, p)
 	}
 
 	// Hash the cluster name and produce the topic name from there

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -155,11 +155,11 @@ func TestClustersPeerAdd(t *testing.T) {
 		addrs := c.peerManager.LoadPeerstore()
 		peerMap := make(map[peer.ID]struct{})
 		for _, a := range addrs {
-			pid, _, err := api.Libp2pMultiaddrSplit(a)
+			pinfo, err := peerstore.InfoFromP2pAddr(a)
 			if err != nil {
 				t.Fatal(err)
 			}
-			peerMap[pid] = struct{}{}
+			peerMap[pinfo.ID] = struct{}{}
 		}
 
 		if len(peerMap) == 0 {

--- a/pstoremgr/pstoremgr.go
+++ b/pstoremgr/pstoremgr.go
@@ -256,7 +256,7 @@ func (pm *Manager) SavePeerstoreForPeers(peers []peer.ID) {
 
 // Bootstrap attempts to get as much as count connected peers by selecting
 // randomly from those in the libp2p host peerstore. It returns the number
-// if peers it sucessfully connected to.
+// of peers it successfully connected to.
 func (pm *Manager) Bootstrap(count int) int {
 	knownPeers := pm.host.Peerstore().PeersWithAddrs()
 	toSort := &peerSort{
@@ -296,6 +296,11 @@ func (pm *Manager) SetPriority(pid peer.ID, prio int) error {
 	return pm.host.Peerstore().Put(pid, PriorityTag, prio)
 }
 
+// peerSort is used to sort a slice of PinInfos given the PriorityTag in the
+// peerstore, from the lowest tag value (0 is the highest priority) to the
+// highest, Peers without a valid priority tag are considered as having a tag
+// with value 0, so they will be among the first elements in the resulting
+// slice.
 type peerSort struct {
 	pinfos []peerstore.PeerInfo
 	pstore peerstore.Peerstore

--- a/pstoremgr/pstoremgr_test.go
+++ b/pstoremgr/pstoremgr_test.go
@@ -4,21 +4,21 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
-	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/test"
 
 	libp2p "github.com/libp2p/go-libp2p"
+	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
-
-var pid = "QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabc"
 
 func makeMgr(t *testing.T) *Manager {
 	h, err := libp2p.New(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	return New(h, "peerstore")
+	return New(context.Background(), h, "peerstore")
 }
 
 func clean(pm *Manager) {
@@ -27,31 +27,45 @@ func clean(pm *Manager) {
 	}
 }
 
+func testAddr(loc string, pid peer.ID) ma.Multiaddr {
+	m, _ := ma.NewMultiaddr(loc + "/ipfs/" + peer.IDB58Encode(pid))
+	return m
+}
+
 func TestManager(t *testing.T) {
 	pm := makeMgr(t)
 	defer clean(pm)
 
-	testPeer, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1234/ipfs/" + pid)
+	loc := "/ip4/127.0.0.1/tcp/1234"
+	testAddr := testAddr(loc, test.PeerID1)
 
-	err := pm.ImportPeer(testPeer, false)
+	_, err := pm.ImportPeer(testAddr, false, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	peers := api.StringsToPeers([]string{pid, pm.host.ID().Pretty()})
-	addrs := pm.PeersAddresses(peers)
-	if len(addrs) != 1 {
-		t.Fatal("expected 1 address")
+	peers := []peer.ID{test.PeerID1, pm.host.ID()}
+	pinfos := pm.PeerInfos(peers)
+	if len(pinfos) != 1 {
+		t.Fatal("expected 1 peerinfo")
 	}
 
-	if !addrs[0].Equal(testPeer) {
+	if pinfos[0].ID != test.PeerID1 {
+		t.Error("expected same peer as added")
+	}
+
+	if len(pinfos[0].Addrs) != 1 {
+		t.Fatal("expected an address")
+	}
+
+	if pinfos[0].Addrs[0].String() != loc {
 		t.Error("expected same address as added")
 	}
 
 	pm.RmPeer(peers[0])
-	addrs = pm.PeersAddresses(peers)
-	if len(addrs) != 0 {
-		t.Fatal("expected 0 addresses")
+	pinfos = pm.PeerInfos(peers)
+	if len(pinfos) != 0 {
+		t.Fatal("expected 0 pinfos")
 	}
 }
 
@@ -59,21 +73,27 @@ func TestManagerDNS(t *testing.T) {
 	pm := makeMgr(t)
 	defer clean(pm)
 
-	testPeer, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1234/ipfs/" + pid)
-	testPeer2, _ := ma.NewMultiaddr("/dns4/localhost/tcp/1235/ipfs/" + pid)
+	loc1 := "/ip4/127.0.0.1/tcp/1234"
+	testAddr1 := testAddr(loc1, test.PeerID1)
+	loc2 := "/dns4/localhost/tcp/1235"
+	testAddr2 := testAddr(loc2, test.PeerID1)
 
-	err := pm.ImportPeers([]ma.Multiaddr{testPeer, testPeer2}, false)
+	err := pm.ImportPeers([]ma.Multiaddr{testAddr1, testAddr2}, false, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	addrs := pm.PeersAddresses(api.StringsToPeers([]string{pid}))
-	if len(addrs) != 1 {
-		t.Fatal("expected 1 address")
+	pinfos := pm.PeerInfos([]peer.ID{test.PeerID1})
+	if len(pinfos) != 1 {
+		t.Fatal("expected 1 pinfo")
 	}
 
-	if !addrs[0].Equal(testPeer2) {
-		t.Error("expected only the dns address")
+	if len(pinfos[0].Addrs) != 1 {
+		t.Error("expected a single address")
+	}
+
+	if pinfos[0].Addrs[0].String() != "/dns4/localhost/tcp/1235" {
+		t.Error("expected the dns address")
 	}
 }
 
@@ -81,25 +101,95 @@ func TestPeerstore(t *testing.T) {
 	pm := makeMgr(t)
 	defer clean(pm)
 
-	testPeer, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1234/ipfs/" + pid)
-	testPeer2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1235/ipfs/" + pid)
+	loc1 := "/ip4/127.0.0.1/tcp/1234"
+	testAddr1 := testAddr(loc1, test.PeerID1)
+	loc2 := "/ip4/127.0.0.1/tcp/1235"
+	testAddr2 := testAddr(loc2, test.PeerID1)
 
-	err := pm.ImportPeers([]ma.Multiaddr{testPeer, testPeer2}, false)
+	err := pm.ImportPeers([]ma.Multiaddr{testAddr1, testAddr2}, false, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pm.SavePeerstoreForPeers(api.StringsToPeers([]string{pid}))
+	pm.SavePeerstoreForPeers([]peer.ID{test.PeerID1})
 
 	pm2 := makeMgr(t)
 	defer clean(pm2)
 
-	err = pm2.ImportPeersFromPeerstore(false)
+	err = pm2.ImportPeersFromPeerstore(false, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(pm2.PeersAddresses(api.StringsToPeers([]string{pid}))) != 2 {
-		t.Error("expected 2 addresses from the peerstore")
+	pinfos := pm2.PeerInfos([]peer.ID{test.PeerID1})
+	if len(pinfos) != 1 {
+		t.Fatal("expected 1 peer in the peerstore")
+	}
+
+	if len(pinfos[0].Addrs) != 2 {
+		t.Error("expected 2 addresses")
+	}
+}
+
+func TestPriority(t *testing.T) {
+	pm := makeMgr(t)
+	defer clean(pm)
+
+	loc1 := "/ip4/127.0.0.1/tcp/1234"
+	testAddr1 := testAddr(loc1, test.PeerID1)
+	loc2 := "/ip4/127.0.0.2/tcp/1235"
+	testAddr2 := testAddr(loc2, test.PeerID2)
+	loc3 := "/ip4/127.0.0.3/tcp/1234"
+	testAddr3 := testAddr(loc3, test.PeerID3)
+	loc4 := "/ip4/127.0.0.4/tcp/1235"
+	testAddr4 := testAddr(loc4, test.PeerID4)
+
+	err := pm.ImportPeers([]ma.Multiaddr{testAddr1, testAddr2, testAddr3, testAddr4}, false, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pinfos := pm.PeerInfos([]peer.ID{test.PeerID4, test.PeerID2, test.PeerID3, test.PeerID1})
+	if len(pinfos) != 4 {
+		t.Fatal("expected 4 pinfos")
+	}
+
+	if pinfos[0].ID != test.PeerID1 ||
+		pinfos[1].ID != test.PeerID2 ||
+		pinfos[2].ID != test.PeerID3 ||
+		pinfos[3].ID != test.PeerID4 {
+		t.Error("wrong order of peerinfos")
+	}
+
+	pm.SetPriority(test.PeerID1, 100)
+
+	pinfos = pm.PeerInfos([]peer.ID{test.PeerID4, test.PeerID2, test.PeerID3, test.PeerID1})
+	if len(pinfos) != 4 {
+		t.Fatal("expected 4 pinfos")
+	}
+
+	if pinfos[3].ID != test.PeerID1 {
+		t.Fatal("PeerID1 should be last in the list")
+	}
+
+	pm.SavePeerstoreForPeers([]peer.ID{test.PeerID4, test.PeerID2, test.PeerID3, test.PeerID1})
+
+	pm2 := makeMgr(t)
+	defer clean(pm2)
+
+	err = pm2.ImportPeersFromPeerstore(false, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pinfos = pm2.PeerInfos([]peer.ID{test.PeerID4, test.PeerID2, test.PeerID3, test.PeerID1})
+	if len(pinfos) != 4 {
+		t.Fatal("expected 4 pinfos")
+	}
+
+	if pinfos[0].ID != test.PeerID2 ||
+		pinfos[1].ID != test.PeerID3 ||
+		pinfos[2].ID != test.PeerID4 ||
+		pinfos[3].ID != test.PeerID1 {
+		t.Error("wrong order of peerinfos")
 	}
 }

--- a/util.go
+++ b/util.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ipfs/ipfs-cluster/api"
-
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-peer"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -18,14 +17,14 @@ func PeersFromMultiaddrs(addrs []ma.Multiaddr) []peer.ID {
 	var pids []peer.ID
 	pm := make(map[peer.ID]struct{})
 	for _, addr := range addrs {
-		pid, _, err := api.Libp2pMultiaddrSplit(addr)
+		pinfo, err := peerstore.InfoFromP2pAddr(addr)
 		if err != nil {
 			continue
 		}
-		_, ok := pm[pid]
+		_, ok := pm[pinfo.ID]
 		if !ok {
-			pm[pid] = struct{}{}
-			pids = append(pids, pid)
+			pm[pinfo.ID] = struct{}{}
+			pids = append(pids, pinfo.ID)
 		}
 	}
 	return pids


### PR DESCRIPTION
Fix #787: Connectivity fixes

Currently, unless doing Join() (--bootstrap), we do not connect to any peers on startup.

We however loaded up the peerstore file and Raft would automatically connect
older peers in its peerset to figure out who is the leader, catch up etc. DHT bootstrap, after Raft
was working, did the rest. This worked more or less well for Raft.

For CRDTs we need to connect to people on a normal boot as otherwise, unless
bootstrapping, this does not happen, even if the peerstore contains known peers.

This introduces a number of changes:

* Move peerstore file management back inside the Cluster component, which was
already in charge of saving the peerstore file.
* We keep saving all "known addresses" but we load them with a non permanent
TTL, so that there will be clean up of peers we're not connected to for long.
* "Bootstrap" (connect) to a small number of peers during Cluster component creation.
* Bootstrap the DHT asap after this, so that other cluster components can
initialize with a working peer discovery mechanism.
* CRDT Trust() method will now:
  * Protect the trusted Peer ID in the conn manager
  * Give top priority in the PeerManager to that Peer (see below)
  * Mark addresses as permanent in the Peerstore

The PeerManager now attaches priorities to peers when importing them and is
able to order them according to that priority. The result is that peers with
high priority are saved first in the peerstore file. When we load the peerstore
file, the first entries in it are given the highest priority.

This means that during startup we will connect to "trusted peers" first
(because they have been tagged with priority in the previous run and saved at
the top of the list). Once connected to a small number of peers, we let the
DHT bootstrap process in the background do the rest and discover the network.

All this makes the peerstore file a "bootstrap" list for CRDTs and we will attempt
to connect to peers on that list until some of those connections succeed.