### PR TITLE
Fix: api: replace two regexes with strings.HasPrefix()

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -191,14 +190,13 @@ type IPFSPinStatus int
 // IPFSPinStatusFromString parses a string and returns the matching
 // IPFSPinStatus.
 func IPFSPinStatusFromString(t string) IPFSPinStatus {
-	// Since indirect statuses are of the form "indirect through <cid>",
-	// use a regexp to match
-	var ind, _ = regexp.MatchString("^indirect", t)
-	var rec, _ = regexp.MatchString("^recursive", t)
+	// Since indirect statuses are of the form "indirect through <cid>"
+	// use a prefix match
+
 	switch {
-	case ind:
+	case strings.HasPrefix(t, "indirect"):
 		return IPFSPinStatusIndirect
-	case rec:
+	case strings.HasPrefix(t, "recursive"):
 		// FIXME: Maxdepth?
 		return IPFSPinStatusRecursive
 	case t == "direct":


### PR DESCRIPTION
Those regexes were compiled with each call to the function. As it's
called by PinLs, this resulted in a significant amount of memory used,
500MB in my case after a single call.

License: MIT
Signed-off-by: Michael Muré <batolettre@gmail.com>