### PR TITLE
Fix: default base32 in IPFS breaks cluster pin-ls

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -128,13 +128,35 @@ func TestIPFSPinLsCid(t *testing.T) {
 
 	ipfs.Pin(ctx, c, -1)
 	ips, err := ipfs.PinLsCid(ctx, c)
-	if err != nil || !ips.IsPinned(-1) {
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !ips.IsPinned(-1) {
 		t.Error("c should appear pinned")
 	}
 
 	ips, err = ipfs.PinLsCid(ctx, c2)
 	if err != nil || ips != api.IPFSPinStatusUnpinned {
 		t.Error("c2 should appear unpinned")
+	}
+}
+
+func TestIPFSPinLsCid_DifferentEncoding(t *testing.T) {
+	ctx := context.Background()
+	ipfs, mock := testIPFSConnector(t)
+	defer mock.Close()
+	defer ipfs.Shutdown(ctx)
+	c := test.Cid4 // ipfs mock treats this specially
+
+	ipfs.Pin(ctx, c, -1)
+	ips, err := ipfs.PinLsCid(ctx, c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !ips.IsPinned(-1) {
+		t.Error("c should appear pinned")
 	}
 }
 

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -206,11 +206,17 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			goto ERROR
 		}
+
 		ok, err = m.pinMap.Has(ctx, c)
 		if err != nil {
 			goto ERROR
 		}
 		if ok {
+			if c.Equals(Cid4) { // this a v1 cid. Do not return default-base32
+				w.Write([]byte(`{ "Keys": { "zb2rhiKhUepkTMw7oFfBUnChAN7ABAvg2hXUwmTBtZ6yxuc57": { "Type": "recursive" }}}`))
+				return
+			}
+
 			rMap := make(map[string]mockPinType)
 			rMap[cidStr] = mockPinType{"recursive"}
 			j, _ := json.Marshal(mockPinLsResp{rMap})


### PR DESCRIPTION
The switch to base32 as default output format for cidv1 keys in IPFS pin/ls
responses causes an error in PinLsCid as the base32 string does not correspond
to the base58 string expected by cluster when using an old peer.

This affects old Cluster peers running with new IPFS versions and new cluster
peers running with old IPFS versions for v1 CIDs.

Since Current master uses an updated cid dependency which also uses base32 by
default, master would already work with the latest IPFS daemon, so this is
just allowing to use cluster peers with older ipfs daemons, and preventing a
similar breakage in the future.