### PR TITLE
alerting for peers stops after one alert

### DIFF
--- a/consensus/raft/logging.go
+++ b/consensus/raft/logging.go
@@ -65,6 +65,7 @@ func (log *hcLogToLogger) Info(msg string, args ...interface{}) {
 }
 
 func (log *hcLogToLogger) Warn(msg string, args ...interface{}) {
+	fmt.Println(msg)
 	raftLogger.Warning(log.format(msg, args))
 }
 

--- a/monitor/metrics/checker.go
+++ b/monitor/metrics/checker.go
@@ -19,7 +19,7 @@ var AlertChannelCap = 256
 
 // MaxAlertThreshold specifies how many alerts will occur per a peer is
 // removed the list of monitored peers.
-var MaxAlertThreshold = 5
+var MaxAlertThreshold = 1
 
 // ErrAlertChannelFull is returned if the alert channel is full.
 var ErrAlertChannelFull = errors.New("alert channel is full")

--- a/monitor/metrics/checker_test.go
+++ b/monitor/metrics/checker_test.go
@@ -112,6 +112,48 @@ func TestChecker_Failed(t *testing.T) {
 	})
 }
 
+func TestChecker_alert(t *testing.T) {
+	t.Run("remove peer from store after alert", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		metrics := NewStore()
+		checker := NewChecker(ctx, metrics, 2.0)
+
+		metr := &api.Metric{
+			Name:  "test",
+			Peer:  test.PeerID1,
+			Value: "1",
+			Valid: true,
+		}
+		metr.SetTTL(100 * time.Millisecond)
+		metrics.Add(metr)
+
+		peersF := func(context.Context) ([]peer.ID, error) {
+			return []peer.ID{test.PeerID1}, nil
+		}
+
+		go checker.Watch(ctx, peersF, 200*time.Millisecond)
+
+		var alertCount int
+		for {
+			select {
+			case a := <-checker.Alerts():
+				t.Log("received alert:", a)
+				alertCount++
+				if alertCount > 1 {
+					t.Fatal("there should no more than one alert")
+				}
+			case <-ctx.Done():
+				if alertCount < 1 {
+					t.Fatal("should have received an alert")
+				}
+				return
+			}
+		}
+	})
+}
+
 //////////////////
 // HELPER TESTS //
 //////////////////

--- a/monitor/metrics/checker_test.go
+++ b/monitor/metrics/checker_test.go
@@ -141,8 +141,8 @@ func TestChecker_alert(t *testing.T) {
 			case a := <-checker.Alerts():
 				t.Log("received alert:", a)
 				alertCount++
-				if alertCount > 1 {
-					t.Fatal("there should no more than one alert")
+				if alertCount > MaxAlertThreshold {
+					t.Fatalf("there should no more than %d alert", MaxAlertThreshold)
 				}
 			case <-ctx.Done():
 				if alertCount < 1 {

--- a/monitor/metrics/store.go
+++ b/monitor/metrics/store.go
@@ -47,6 +47,15 @@ func (mtrs *Store) Add(m *api.Metric) {
 	window.Add(m)
 }
 
+// RemovePeer removes all metrics related to a peer from the Store.
+func (mtrs *Store) RemovePeer(pid peer.ID) {
+	mtrs.mux.Lock()
+	for _, mtrs := range mtrs.byName {
+		delete(mtrs, pid)
+	}
+	mtrs.mux.Unlock()
+}
+
 // LatestValid returns all the last known valid metrics of a given type. A metric
 // is valid if it has not expired.
 func (mtrs *Store) LatestValid(name string) []*api.Metric {

--- a/monitor/metrics/store.go
+++ b/monitor/metrics/store.go
@@ -50,9 +50,17 @@ func (mtrs *Store) Add(m *api.Metric) {
 // RemovePeer removes all metrics related to a peer from the Store.
 func (mtrs *Store) RemovePeer(pid peer.ID) {
 	mtrs.mux.Lock()
-	for _, mtrs := range mtrs.byName {
-		delete(mtrs, pid)
+	for _, metrics := range mtrs.byName {
+		delete(metrics, pid)
 	}
+	mtrs.mux.Unlock()
+}
+
+// RemovePeerMetrics removes all metrics of a given name for a given peer ID.
+func (mtrs *Store) RemovePeerMetrics(pid peer.ID, name string) {
+	mtrs.mux.Lock()
+	metrics := mtrs.byName[name]
+	delete(metrics, pid)
 	mtrs.mux.Unlock()
 }
 

--- a/monitor/metrics/store_test.go
+++ b/monitor/metrics/store_test.go
@@ -32,3 +32,24 @@ func TestStoreLatest(t *testing.T) {
 		t.Error("expected no metrics")
 	}
 }
+
+func TestRemovePeer(t *testing.T) {
+	store := NewStore()
+
+	metr := &api.Metric{
+		Name:  "test",
+		Peer:  test.PeerID1,
+		Value: "1",
+		Valid: true,
+	}
+	metr.SetTTL(200 * time.Millisecond)
+	store.Add(metr)
+
+	if pmtrs := store.PeerMetrics(test.PeerID1); len(pmtrs) <= 0 {
+		t.Errorf("there should be one peer metric; got: %v", pmtrs)
+	}
+	store.RemovePeer(test.PeerID1)
+	if pmtrs := store.PeerMetrics(test.PeerID1); len(pmtrs) > 0 {
+		t.Errorf("there should be no peer metrics; got: %v", pmtrs)
+	}
+}


### PR DESCRIPTION
Resolves #812.

This PR still requires clarification of whether the alerting for a peer should stop after one alert or several.