### PR TITLE
Fix importing peers using /dnsaddr/

### DIFF
--- a/consensus/raft/logging.go
+++ b/consensus/raft/logging.go
@@ -65,7 +65,6 @@ func (log *hcLogToLogger) Info(msg string, args ...interface{}) {
 }
 
 func (log *hcLogToLogger) Warn(msg string, args ...interface{}) {
-	fmt.Println(msg)
 	raftLogger.Warning(log.format(msg, args))
 }
 


### PR DESCRIPTION
In this case we need to resolve (unlike with /dns4/), since otherwise
we may not know which peer ID the /dnsaddr is about.