### PR TITLE
Fix #793: Allow to fully disable unpinning

### DIFF
--- a/ipfsconn/ipfshttp/config.go
+++ b/ipfsconn/ipfshttp/config.go
@@ -24,6 +24,7 @@ const (
 	DefaultIPFSRequestTimeout = 5 * time.Minute
 	DefaultPinTimeout         = 24 * time.Hour
 	DefaultUnpinTimeout       = 3 * time.Hour
+	DefaultUnpinDisable       = false
 )
 
 // Config is used to initialize a Connector and allows to customize
@@ -53,6 +54,9 @@ type Config struct {
 	// Unpin Operation timeout
 	UnpinTimeout time.Duration
 
+	// Disables the unpin operation and returns an error.
+	UnpinDisable bool
+
 	// Tracing flag used to skip tracing specific paths when not enabled.
 	Tracing bool
 }
@@ -64,6 +68,7 @@ type jsonConfig struct {
 	IPFSRequestTimeout string `json:"ipfs_request_timeout"`
 	PinTimeout         string `json:"pin_timeout"`
 	UnpinTimeout       string `json:"unpin_timeout"`
+	UnpinDisable       bool   `json:"unpin_disable,omitempty"`
 }
 
 // ConfigKey provides a human-friendly identifier for this type of Config.
@@ -80,6 +85,7 @@ func (cfg *Config) Default() error {
 	cfg.IPFSRequestTimeout = DefaultIPFSRequestTimeout
 	cfg.PinTimeout = DefaultPinTimeout
 	cfg.UnpinTimeout = DefaultUnpinTimeout
+	cfg.UnpinDisable = DefaultUnpinDisable
 
 	return nil
 }
@@ -154,6 +160,7 @@ func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
 	}
 
 	cfg.NodeAddr = nodeAddr
+	cfg.UnpinDisable = jcfg.UnpinDisable
 
 	err = config.ParseDurations(
 		"ipfshttp",
@@ -199,6 +206,7 @@ func (cfg *Config) toJSONConfig() (jcfg *jsonConfig, err error) {
 	jcfg.IPFSRequestTimeout = cfg.IPFSRequestTimeout.String()
 	jcfg.PinTimeout = cfg.PinTimeout.String()
 	jcfg.UnpinTimeout = cfg.UnpinTimeout.String()
+	jcfg.UnpinDisable = cfg.UnpinDisable
 
 	return
 }

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -488,6 +488,10 @@ func (ipfs *Connector) Unpin(ctx context.Context, hash cid.Cid) error {
 	ctx, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/Unpin")
 	defer span.End()
 
+	if ipfs.config.UnpinDisable {
+		return errors.New("ipfs unpinning is disallowed by configuration on this peer")
+	}
+
 	pinStatus, err := ipfs.PinLsCid(ctx, hash)
 	if err != nil {
 		return err

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -136,6 +136,23 @@ func TestIPFSUnpin(t *testing.T) {
 	}
 }
 
+func TestIPFSUnpinDisabled(t *testing.T) {
+	ctx := context.Background()
+	ipfs, mock := testIPFSConnector(t)
+	defer mock.Close()
+	defer ipfs.Shutdown(ctx)
+	ipfs.config.UnpinDisable = true
+	err := ipfs.Pin(ctx, test.Cid1, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ipfs.Unpin(ctx, test.Cid1)
+	if err == nil {
+		t.Fatal("pin should be disabled")
+	}
+}
+
 func TestIPFSPinLsCid(t *testing.T) {
 	ctx := context.Background()
 	ipfs, mock := testIPFSConnector(t)


### PR DESCRIPTION
As raised in #793, sometimes the user wants to simply disallow unpinning
altogether in a Cluster peer so that no content can be removed from IPFS
through cluster, even when crendentials are compromised (including access to
RPC endpoint).

This introduces a disable_unpinning parameter for the ipfshttp
connector. There is no way that a cluster will effecitvely unpin something if
the connector refuses to ask ipfs.