### PR TITLE
JSON Config object key should match JSON tags

### DIFF
--- a/api/rest/config.go
+++ b/api/rest/config.go
@@ -104,9 +104,9 @@ type Config struct {
 	ID         peer.ID
 	PrivateKey crypto.PrivKey
 
-	// BasicAuthCreds is a map of username-password pairs
+	// BasicAuthCredentials is a map of username-password pairs
 	// which are authorized to use Basic Authentication
-	BasicAuthCreds map[string]string
+	BasicAuthCredentials map[string]string
 
 	// Headers provides customization for the headers returned
 	// by the API on existing routes.
@@ -138,8 +138,8 @@ type jsonConfig struct {
 	ID                       string `json:"id,omitempty"`
 	PrivateKey               string `json:"private_key,omitempty"`
 
-	BasicAuthCreds map[string]string   `json:"basic_auth_credentials"`
-	Headers        map[string][]string `json:"headers"`
+	BasicAuthCredentials map[string]string   `json:"basic_auth_credentials"`
+	Headers              map[string][]string `json:"headers"`
 
 	CORSAllowedOrigins   []string `json:"cors_allowed_origins"`
 	CORSAllowedMethods   []string `json:"cors_allowed_methods"`
@@ -174,7 +174,7 @@ func (cfg *Config) Default() error {
 	cfg.Libp2pListenAddr = nil
 
 	// Auth
-	cfg.BasicAuthCreds = nil
+	cfg.BasicAuthCredentials = nil
 
 	// Headers
 	cfg.Headers = DefaultHeaders
@@ -219,7 +219,7 @@ func (cfg *Config) Validate() error {
 		return errors.New("restapi.idle_timeout invalid")
 	case cfg.MaxHeaderBytes < minMaxHeaderBytes:
 		return fmt.Errorf("restapi.max_header_bytes must be not less then %d", minMaxHeaderBytes)
-	case cfg.BasicAuthCreds != nil && len(cfg.BasicAuthCreds) == 0:
+	case cfg.BasicAuthCredentials != nil && len(cfg.BasicAuthCredentials) == 0:
 		return errors.New("restapi.basic_auth_creds should be null or have at least one entry")
 	case (cfg.pathSSLCertFile != "" || cfg.pathSSLKeyFile != "") && cfg.TLS == nil:
 		return errors.New("restapi: missing TLS configuration")
@@ -270,7 +270,7 @@ func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
 	}
 
 	// Other options
-	cfg.BasicAuthCreds = jcfg.BasicAuthCreds
+	cfg.BasicAuthCredentials = jcfg.BasicAuthCredentials
 	cfg.Headers = jcfg.Headers
 
 	return cfg.Validate()
@@ -408,7 +408,7 @@ func (cfg *Config) toJSONConfig() (jcfg *jsonConfig, err error) {
 		WriteTimeout:           cfg.WriteTimeout.String(),
 		IdleTimeout:            cfg.IdleTimeout.String(),
 		MaxHeaderBytes:         cfg.MaxHeaderBytes,
-		BasicAuthCreds:         cfg.BasicAuthCreds,
+		BasicAuthCredentials:   cfg.BasicAuthCredentials,
 		Headers:                cfg.Headers,
 		CORSAllowedOrigins:     cfg.CORSAllowedOrigins,
 		CORSAllowedMethods:     cfg.CORSAllowedMethods,

--- a/api/rest/config_test.go
+++ b/api/rest/config_test.go
@@ -75,7 +75,7 @@ func TestLoadJSON(t *testing.T) {
 
 	j = &jsonConfig{}
 	json.Unmarshal(cfgJSON, j)
-	j.BasicAuthCreds = make(map[string]string)
+	j.BasicAuthCredentials = make(map[string]string)
 	tst, _ = json.Marshal(j)
 	err = cfg.LoadJSON(tst)
 	if err == nil {
@@ -133,7 +133,7 @@ func TestApplyEnvVars(t *testing.T) {
 	password := "thisaintmypassword"
 	user1 := "user1"
 	user1pass := "user1passwd"
-	os.Setenv("CLUSTER_RESTAPI_BASICAUTHCREDS", username+":"+password+","+user1+":"+user1pass)
+	os.Setenv("CLUSTER_RESTAPI_BASICAUTHCREDENTIALS", username+":"+password+","+user1+":"+user1pass)
 	cfg := &Config{}
 	cfg.Default()
 	err := cfg.ApplyEnvVars()
@@ -141,19 +141,19 @@ func TestApplyEnvVars(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, ok := cfg.BasicAuthCreds[username]; !ok {
-		t.Fatalf("username '%s' not set in BasicAuthCreds map: %v", username, cfg.BasicAuthCreds)
+	if _, ok := cfg.BasicAuthCredentials[username]; !ok {
+		t.Fatalf("username '%s' not set in BasicAuthCreds map: %v", username, cfg.BasicAuthCredentials)
 	}
 
-	if _, ok := cfg.BasicAuthCreds[user1]; !ok {
-		t.Fatalf("username '%s' not set in BasicAuthCreds map: %v", user1, cfg.BasicAuthCreds)
+	if _, ok := cfg.BasicAuthCredentials[user1]; !ok {
+		t.Fatalf("username '%s' not set in BasicAuthCreds map: %v", user1, cfg.BasicAuthCredentials)
 	}
 
-	if gotpasswd := cfg.BasicAuthCreds[username]; gotpasswd != password {
+	if gotpasswd := cfg.BasicAuthCredentials[username]; gotpasswd != password {
 		t.Errorf("password not what was set in env var, got: %s, want: %s", gotpasswd, password)
 	}
 
-	if gotpasswd := cfg.BasicAuthCreds[user1]; gotpasswd != user1pass {
+	if gotpasswd := cfg.BasicAuthCredentials[user1]; gotpasswd != user1pass {
 		t.Errorf("password not what was set in env var, got: %s, want: %s", gotpasswd, user1pass)
 	}
 }

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -118,7 +118,7 @@ func NewAPIWithHost(ctx context.Context, cfg *Config, h host.Host) (*API, error)
 	// wrapped with the basic auth handler.
 	router := mux.NewRouter().StrictSlash(true)
 	handler := basicAuthHandler(
-		cfg.BasicAuthCreds,
+		cfg.BasicAuthCredentials,
 		cors.New(*cfg.corsOptions()).Handler(router),
 	)
 	if cfg.Tracing {

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -89,7 +89,7 @@ func testHTTPSAPI(t *testing.T) *API {
 func testAPIwithBasicAuth(t *testing.T) *API {
 	cfg := &Config{}
 	cfg.Default()
-	cfg.BasicAuthCreds = map[string]string{
+	cfg.BasicAuthCredentials = map[string]string{
 		validUserName: validUserPassword,
 		adminUserName: adminUserPassword,
 	}

--- a/informer/disk/config.go
+++ b/informer/disk/config.go
@@ -34,13 +34,13 @@ func (t MetricType) String() string {
 type Config struct {
 	config.Saver
 
-	MetricTTL time.Duration
-	Type      MetricType
+	MetricTTL  time.Duration
+	MetricType MetricType
 }
 
 type jsonConfig struct {
-	MetricTTL string `json:"metric_ttl"`
-	Type      string `json:"metric_type"`
+	MetricTTL  string `json:"metric_ttl"`
+	MetricType string `json:"metric_type"`
 }
 
 // ConfigKey returns a human-friendly identifier for this type of Metric.
@@ -51,7 +51,7 @@ func (cfg *Config) ConfigKey() string {
 // Default initializes this Config with sensible values.
 func (cfg *Config) Default() error {
 	cfg.MetricTTL = DefaultMetricTTL
-	cfg.Type = DefaultMetricType
+	cfg.MetricType = DefaultMetricType
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (cfg *Config) Validate() error {
 		return errors.New("disk.metric_ttl is invalid")
 	}
 
-	if cfg.Type.String() == "" {
+	if cfg.MetricType.String() == "" {
 		return errors.New("disk.metric_type is invalid")
 	}
 	return nil
@@ -100,11 +100,11 @@ func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
 	t, _ := time.ParseDuration(jcfg.MetricTTL)
 	cfg.MetricTTL = t
 
-	switch jcfg.Type {
+	switch jcfg.MetricType {
 	case "reposize":
-		cfg.Type = MetricRepoSize
+		cfg.MetricType = MetricRepoSize
 	case "freespace":
-		cfg.Type = MetricFreeSpace
+		cfg.MetricType = MetricFreeSpace
 	default:
 		return errors.New("disk.metric_type is invalid")
 	}
@@ -123,7 +123,7 @@ func (cfg *Config) ToJSON() (raw []byte, err error) {
 
 func (cfg *Config) toJSONConfig() *jsonConfig {
 	return &jsonConfig{
-		MetricTTL: cfg.MetricTTL.String(),
-		Type:      cfg.Type.String(),
+		MetricTTL:  cfg.MetricTTL.String(),
+		MetricType: cfg.MetricType.String(),
 	}
 }

--- a/informer/disk/config_test.go
+++ b/informer/disk/config_test.go
@@ -33,7 +33,7 @@ func TestLoadJSON(t *testing.T) {
 
 	j = &jsonConfig{}
 	json.Unmarshal(cfgJSON, j)
-	j.Type = "abc"
+	j.MetricType = "abc"
 	tst, _ = json.Marshal(j)
 	err = cfg.LoadJSON(tst)
 	if err == nil {
@@ -42,7 +42,7 @@ func TestLoadJSON(t *testing.T) {
 
 	j = &jsonConfig{}
 	json.Unmarshal(cfgJSON, j)
-	j.Type = "reposize"
+	j.MetricType = "reposize"
 	tst, _ = json.Marshal(j)
 	err = cfg.LoadJSON(tst)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestDefault(t *testing.T) {
 	}
 
 	cfg.Default()
-	cfg.Type = MetricRepoSize
+	cfg.MetricType = MetricRepoSize
 	if cfg.Validate() != nil {
 		t.Fatal("MetricRepoSize is a valid type")
 	}

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -47,7 +47,7 @@ func NewInformer(cfg *Config) (*Informer, error) {
 
 // Name returns the user-facing name of this informer.
 func (disk *Informer) Name() string {
-	return disk.config.Type.String()
+	return disk.config.MetricType.String()
 }
 
 // SetClient provides us with an rpc.Client which allows
@@ -96,7 +96,7 @@ func (disk *Informer) GetMetric(ctx context.Context) *api.Metric {
 		logger.Error(err)
 		valid = false
 	} else {
-		switch disk.config.Type {
+		switch disk.config.MetricType {
 		case MetricFreeSpace:
 			metric = repoStat.StorageMax - repoStat.RepoSize
 		case MetricRepoSize:

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -52,7 +52,7 @@ func TestFreeSpace(t *testing.T) {
 	ctx := context.Background()
 	cfg := &Config{}
 	cfg.Default()
-	cfg.Type = MetricFreeSpace
+	cfg.MetricType = MetricFreeSpace
 
 	inf, err := NewInformer(cfg)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestRepoSize(t *testing.T) {
 	ctx := context.Background()
 	cfg := &Config{}
 	cfg.Default()
-	cfg.Type = MetricRepoSize
+	cfg.MetricType = MetricRepoSize
 
 	inf, err := NewInformer(cfg)
 	if err != nil {


### PR DESCRIPTION
Went through all the `config.go` files. There was only one extra inconsistency that what was mentioned in the issue.

Fixes #778 