### PR TITLE
Init should take a list of peers

### DIFF
--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -3,15 +3,21 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	ipfscluster "github.com/ipfs/ipfs-cluster"
 	"github.com/ipfs/ipfs-cluster/config"
+	"github.com/ipfs/ipfs-cluster/pstoremgr"
 	"github.com/ipfs/ipfs-cluster/version"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	peerstore "github.com/libp2p/go-libp2p-core/peerstore"
+	ma "github.com/multiformats/go-multiaddr"
 
 	semver "github.com/blang/semver"
 	logging "github.com/ipfs/go-log"
@@ -239,6 +245,10 @@ remove the %s file first and clean any Raft state.
 					Name:  "custom-secret, s",
 					Usage: "prompt for the cluster secret",
 				},
+				cli.StringFlag{
+					Name:  "peers, p",
+					Usage: "comma-separated list of multiaddresses to init with",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				userSecret, userSecretDefined := userProvidedSecret(c.Bool("custom-secret"))
@@ -289,6 +299,20 @@ remove the %s file first and clean any Raft state.
 					cfgs.clusterCfg.Secret = userSecret
 				}
 
+				addrs := strings.Split(c.String("peers"), ",")
+				multiAddrs := []ma.Multiaddr{}
+				var peers []peer.ID
+				if len(addrs) > 0 {
+					for _, addr := range addrs {
+						multiAddr, err := ma.NewMultiaddr(addr)
+						checkErr("parsing multiaddress", err)
+						multiAddrs = append(multiAddrs, multiAddr)
+					}
+					peers = ipfscluster.PeersFromMultiaddrs(multiAddrs)
+					cfgs.crdtCfg.TrustedPeers = peers
+					cfgs.raftCfg.InitPeerset = peers
+				}
+
 				// Save
 				saveConfig(cfgMgr)
 
@@ -304,6 +328,22 @@ remove the %s file first and clean any Raft state.
 					checkErr("saving "+DefaultIdentityFile, err)
 					out("new identity written to %s\n", identityPath)
 				}
+				if len(addrs) > 0 {
+					_, ident, cfgs := makeAndLoadConfigs()
+
+					ctx := context.Background()
+					host, _, _, err := ipfscluster.NewClusterHost(ctx, ident, cfgs.clusterCfg)
+					checkErr("creating libp2p host", err)
+
+					peerstorePath := cfgs.clusterCfg.GetPeerstorePath()
+					peerManager := pstoremgr.New(ctx, host, peerstorePath)
+
+					err = peerManager.ImportPeers(multiAddrs, false, peerstore.AddressTTL)
+					checkErr("importing peers into peerstore", err)
+					peerManager.SavePeerstoreForPeers(peers)
+					out("peerstore written to %s\n", peerstorePath)
+				}
+
 				return nil
 			},
 		},

--- a/consensus/crdt/config.go
+++ b/consensus/crdt/config.go
@@ -103,8 +103,7 @@ func (cfg *Config) LoadJSON(raw []byte) error {
 }
 
 func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
-	cfg.ClusterName = jcfg.ClusterName
-
+	config.SetIfNotDefault(jcfg.ClusterName, &cfg.ClusterName)
 	for _, p := range jcfg.TrustedPeers {
 		if p == "*" {
 			cfg.TrustAll = true


### PR DESCRIPTION
This commit adds `--peers` option to `ipfs-cluster-service init`

`ipfs-cluster-service init --peers <multiaddress,multiaddress>`

- Adds and writes the given peers to the peerstore file
- For raft config section, adds the peer IDs to the `init_peerset`
- For crdt config section, add the peer IDs to the `trusted_peers`