### PR TITLE
Init should take a list of peers

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -620,7 +620,10 @@ func (c *Cluster) Shutdown(ctx context.Context) error {
 	// Try to store peerset file for all known peers whatsoever
 	// if we got ready (otherwise, don't overwrite anything)
 	if c.readyB {
-		c.peerManager.SavePeerstoreForPeers(c.host.Peerstore().Peers())
+		err := c.peerManager.SavePeerstoreForPeers(c.host.Peerstore().Peers())
+		if err != nil {
+			logger.Warningf("could not save peers to peerstore: %s", err)
+		}
 	}
 
 	// Only attempt to leave if:

--- a/cluster.go
+++ b/cluster.go
@@ -620,10 +620,8 @@ func (c *Cluster) Shutdown(ctx context.Context) error {
 	// Try to store peerset file for all known peers whatsoever
 	// if we got ready (otherwise, don't overwrite anything)
 	if c.readyB {
-		err := c.peerManager.SavePeerstoreForPeers(c.host.Peerstore().Peers())
-		if err != nil {
-			logger.Warningf("could not save peers to peerstore: %s", err)
-		}
+		// Ignoring error since it's a best-effort
+		c.peerManager.SavePeerstoreForPeers(c.host.Peerstore().Peers())
 	}
 
 	// Only attempt to leave if:

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -310,11 +310,9 @@ remove the %s file first and clean any Raft state.
 						multiAddrs = append(multiAddrs, multiAddr)
 					}
 
-					if len(addrs) > 0 {
-						peers := ipfscluster.PeersFromMultiaddrs(multiAddrs)
-						cfgs.crdtCfg.TrustedPeers = peers
-						cfgs.raftCfg.InitPeerset = peers
-					}
+					peers := ipfscluster.PeersFromMultiaddrs(multiAddrs)
+					cfgs.crdtCfg.TrustedPeers = peers
+					cfgs.raftCfg.InitPeerset = peers
 				}
 
 				// Save

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -303,14 +303,14 @@ remove the %s file first and clean any Raft state.
 				if peersOpt != "" {
 					addrs := strings.Split(peersOpt, ",")
 
-					if len(addrs) > 0 {
-						for _, addr := range addrs {
-							addr = strings.TrimSpace(addr)
-							multiAddr, err := ma.NewMultiaddr(addr)
-							checkErr("parsing peer multiaddress: "+addr, err)
-							multiAddrs = append(multiAddrs, multiAddr)
-						}
+					for _, addr := range addrs {
+						addr = strings.TrimSpace(addr)
+						multiAddr, err := ma.NewMultiaddr(addr)
+						checkErr("parsing peer multiaddress: "+addr, err)
+						multiAddrs = append(multiAddrs, multiAddr)
+					}
 
+					if len(addrs) > 0 {
 						peers := ipfscluster.PeersFromMultiaddrs(multiAddrs)
 						cfgs.crdtCfg.TrustedPeers = peers
 						cfgs.raftCfg.InitPeerset = peers

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -343,7 +343,8 @@ multiaddresses.
 				peerManager := pstoremgr.New(context.Background(), nil, peerstorePath)
 				addrInfos, err := peer.AddrInfosFromP2pAddrs(multiAddrs...)
 				checkErr("getting AddrInfos from peer multiaddresses", err)
-				peerManager.SavePeerstore(addrInfos)
+				err = peerManager.SavePeerstore(addrInfos)
+				checkErr("saving peers to peerstore", err)
 				out("peerstore written to %s with %d entries\n", peerstorePath, len(multiAddrs))
 
 				return nil

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -231,6 +231,12 @@ environment variable.
 Note that the --force first-level-flag allows to overwrite an existing
 configuration with default values. To generate a new identity, please
 remove the %s file first and clean any Raft state.
+
+By default, an empty peerstore file will be created too. Initial contents can
+be provided with the -peers flag. In this case, the "trusted_peers" list in
+the "crdt" configuration section and the "init_peerset" list in the "raft"
+configuration section will be prefilled to the peer IDs in the given
+multiaddresses.
 `,
 				DefaultConfigFile,
 				DefaultIdentityFile,

--- a/consensus/crdt/config.go
+++ b/consensus/crdt/config.go
@@ -103,8 +103,7 @@ func (cfg *Config) LoadJSON(raw []byte) error {
 }
 
 func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
-	cfg.ClusterName = jcfg.ClusterName
-
+	config.SetIfNotDefault(jcfg.ClusterName, &cfg.ClusterName)
 	for _, p := range jcfg.TrustedPeers {
 		if p == "*" {
 			cfg.TrustAll = true

--- a/pstoremgr/pstoremgr_test.go
+++ b/pstoremgr/pstoremgr_test.go
@@ -111,7 +111,10 @@ func TestPeerstore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pm.SavePeerstoreForPeers([]peer.ID{test.PeerID1})
+	err = pm.SavePeerstoreForPeers([]peer.ID{test.PeerID1})
+	if err != nil {
+		t.Error(err)
+	}
 
 	pm2 := makeMgr(t)
 	defer clean(pm2)
@@ -172,7 +175,10 @@ func TestPriority(t *testing.T) {
 		t.Fatal("PeerID1 should be last in the list")
 	}
 
-	pm.SavePeerstoreForPeers([]peer.ID{test.PeerID4, test.PeerID2, test.PeerID3, test.PeerID1})
+	err = pm.SavePeerstoreForPeers([]peer.ID{test.PeerID4, test.PeerID2, test.PeerID3, test.PeerID1})
+	if err != nil {
+		t.Error(err)
+	}
 
 	pm2 := makeMgr(t)
 	defer clean(pm2)

--- a/sharness/t0021-service-init.sh
+++ b/sharness/t0021-service-init.sh
@@ -3,30 +3,24 @@
 test_description="Test init functionality"
 
 . lib/test-lib.sh
-test_ipfs_init
-
-test_expect_success "prerequisites" '
-    test_have_prereq IPFS
-'
-
-PEERS=/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWRN8KRjpyg9rsW2w7StbBRGper65psTZm68cjud9KAkaW,/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWPwrYNj7VficHw5qYidepMGA85756kYgMdNmRM9A1ZHjN
 
 test_expect_success "cluster-service init with --peers succeeds and fills peerstore" '
-    ipfs-cluster-service --config "test-config" init --peers $PEERS
-    [ -f "test-config/peerstore" ]
-    IFS=','
-    read -ra P <<< $PEERS
-    grep -q ${P[0]} "test-config/peerstore"
-    grep -q ${P[1]} "test-config/peerstore"
+    PEER1=/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWRN8KRjpyg9rsW2w7StbBRGper65psTZm68cjud9KAkaW
+    PEER2=/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWPwrYNj7VficHw5qYidepMGA85756kYgMdNmRM9A1ZHjN
+    echo $PEER1 >> testPeerstore
+    echo $PEER2 >> testPeerstore
+    ipfs-cluster-service --config "test-config" init --peers $PEER1,$PEER2 &&
+    [ -f "test-config/peerstore" ] &&
+    test_cmp testPeerstore test-config/peerstore &&
+    rm testPeerstore
 '
 
 test_expect_success "cluster-service init without --peers succeeds and creates empty peerstore" '
-    ipfs-cluster-service -f --config "test-config" init
-    [ -f "test-config/peerstore" ]
+    ipfs-cluster-service -f --config "test-config" init &&
+    [ -f "test-config/peerstore" ] &&
     [ -z `cat "test-config/peerstore"` ]
 '
 
-test_clean_ipfs
 test_clean_cluster
 
 test_done

--- a/sharness/t0021-service-init.sh
+++ b/sharness/t0021-service-init.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+test_description="Test init functionality"
+
+. lib/test-lib.sh
+test_ipfs_init
+
+test_expect_success "prerequisites" '
+    test_have_prereq IPFS
+'
+
+PEERS=/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWRN8KRjpyg9rsW2w7StbBRGper65psTZm68cjud9KAkaW,/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWPwrYNj7VficHw5qYidepMGA85756kYgMdNmRM9A1ZHjN
+
+test_expect_success "cluster-service init with --peers succeeds and fills peerstore" '
+    ipfs-cluster-service --config "test-config" init --peers $PEERS
+    [ -f "test-config/peerstore" ]
+    IFS=','
+    read -ra P <<< $PEERS
+    grep -q ${P[0]} "test-config/peerstore"
+    grep -q ${P[1]} "test-config/peerstore"
+'
+
+test_expect_success "cluster-service init without --peers succeeds and creates empty peerstore" '
+    ipfs-cluster-service -f --config "test-config" init
+    [ -f "test-config/peerstore" ]
+    [ -z `cat "test-config/peerstore"` ]
+'
+
+test_clean_ipfs
+test_clean_cluster
+
+test_done

--- a/sharness/t0021-service-init.sh
+++ b/sharness/t0021-service-init.sh
@@ -10,15 +10,13 @@ test_expect_success "cluster-service init with --peers succeeds and fills peerst
     echo $PEER1 >> testPeerstore
     echo $PEER2 >> testPeerstore
     ipfs-cluster-service --config "test-config" init --peers $PEER1,$PEER2 &&
-    [ -f "test-config/peerstore" ] &&
-    test_cmp testPeerstore test-config/peerstore &&
-    rm testPeerstore
+    test_cmp testPeerstore test-config/peerstore
 '
 
 test_expect_success "cluster-service init without --peers succeeds and creates empty peerstore" '
     ipfs-cluster-service -f --config "test-config" init &&
     [ -f "test-config/peerstore" ] &&
-    [ -z `cat "test-config/peerstore"` ]
+    [ ! -s "test-config/peerstore" ]
 '
 
 test_clean_cluster


### PR DESCRIPTION
This commit adds `--peers` option to `ipfs-cluster-service init`

`ipfs-cluster-service init --peers <multiaddress,multiaddress>`

- Adds and writes the given peers to the peerstore file
- For raft config section, adds the peer IDs to the `init_peerset`
- For crdt config section, add the peer IDs to the `trusted_peers`
