### PR TITLE
When a peer is removed, clear it from peerstore 

### DIFF
--- a/consensus/raft/raft.go
+++ b/consensus/raft/raft.go
@@ -698,7 +698,7 @@ func (rw *raftWrapper) observePeers() {
 	obsCh := make(chan hraft.Observation, 1)
 	defer close(obsCh)
 
-	observer := hraft.NewObserver(obsCh, false, func(o *hraft.Observation) bool {
+	observer := hraft.NewObserver(obsCh, true, func(o *hraft.Observation) bool {
 		po, ok := o.Data.(hraft.PeerObservation)
 		return ok && po.Removed
 	})

--- a/pstoremgr/pstoremgr.go
+++ b/pstoremgr/pstoremgr.go
@@ -312,14 +312,14 @@ func (pm *Manager) Bootstrap(count int) []peer.ID {
 			continue
 		}
 
-		logger.Debugf("connecting to %s", pinfo.ID)
+		logger.Infof("connecting to %s", pinfo.ID)
 		err := pm.host.Connect(ctx, pinfo)
 		if err != nil {
-			logger.Debug(err)
+			logger.Warning(err)
 			pm.SetPriority(pinfo.ID, 9999)
 			continue
 		}
-		logger.Debugf("connected to %s", pinfo.ID)
+		logger.Infof("connected to %s", pinfo.ID)
 		totalConns++
 		connectedPeers = append(connectedPeers, pinfo.ID)
 	}

--- a/pstoremgr/pstoremgr.go
+++ b/pstoremgr/pstoremgr.go
@@ -312,14 +312,14 @@ func (pm *Manager) Bootstrap(count int) []peer.ID {
 			continue
 		}
 
-		logger.Infof("connecting to %s", pinfo.ID)
+		logger.Debugf("connecting to %s", pinfo.ID)
 		err := pm.host.Connect(ctx, pinfo)
 		if err != nil {
-			logger.Warning(err)
+			logger.Debug(err)
 			pm.SetPriority(pinfo.ID, 9999)
 			continue
 		}
-		logger.Infof("connected to %s", pinfo.ID)
+		logger.Debugf("connected to %s", pinfo.ID)
 		totalConns++
 		connectedPeers = append(connectedPeers, pinfo.ID)
 	}


### PR DESCRIPTION
With this PR, cluster peer will observe on events of peer removal
from cluster. On occurence of the event, the cluster peer will clear
the removed peer from its peerstore.

Fixes #840 