### PR TITLE
Fix #853: Make a more orderly shutdown of rest api libp2p host

### DIFF
--- a/api/rest/config_test.go
+++ b/api/rest/config_test.go
@@ -177,6 +177,7 @@ func TestLibp2pConfig(t *testing.T) {
 	cfg.ID = pid
 	cfg.PrivateKey = priv
 	addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
+	cfg.HTTPListenAddr = addr
 	cfg.Libp2pListenAddr = addr
 
 	err = cfg.Validate()


### PR DESCRIPTION
Cancelling its context before closing the listeners and de-registering
protocols is ground for panics on libp2p.

#853 