### PR TITLE
service: Make --consensus a mandatory flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ VOLUME $IPFS_CLUSTER_PATH
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
 
 # Defaults for ipfs-cluster-service go here
-CMD ["daemon", "--upgrade"]
+CMD ["daemon", "--consensus raft"]

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -47,6 +47,10 @@ func parseBootstraps(flagVal []string) (bootstraps []ma.Multiaddr) {
 
 // Runs the cluster peer
 func daemon(c *cli.Context) error {
+	if c.String("consensus") == "" {
+		checkErr("starting daemon", errors.New("--consensus flag must be set to \"raft\" or \"crdt\""))
+	}
+
 	logger.Info("Initializing. For verbose output run with \"-l debug\". Please wait...")
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -28,7 +28,6 @@ const programName = `ipfs-cluster-service`
 
 // flag defaults
 const (
-	defaultConsensus  = "raft"
 	defaultAllocation = "disk-freespace"
 	defaultPinTracker = "map"
 	defaultLogLevel   = "info"
@@ -369,7 +368,6 @@ multiaddresses.
 				},
 				cli.StringFlag{
 					Name:  "consensus",
-					Value: defaultConsensus,
 					Usage: "shared state management provider [raft,crdt]",
 				},
 				cli.StringFlag{
@@ -414,13 +412,16 @@ By default, the state will be printed to stdout.
 						},
 						cli.StringFlag{
 							Name:  "consensus",
-							Value: "raft",
 							Usage: "consensus component to export data from [raft, crdt]",
 						},
 					},
 					Action: func(c *cli.Context) error {
 						locker.lock()
 						defer locker.tryUnlock()
+
+						cfgMgr, ident, cfgs := makeAndLoadConfigs()
+						defer cfgMgr.Shutdown()
+						mgr := newStateManager(c.String("consensus"), ident, cfgs)
 
 						var w io.WriteCloser
 						var err error
@@ -435,9 +436,6 @@ By default, the state will be printed to stdout.
 						}
 						defer w.Close()
 
-						cfgMgr, ident, cfgs := makeAndLoadConfigs()
-						defer cfgMgr.Shutdown()
-						mgr := newStateManager(c.String("consensus"), ident, cfgs)
 						checkErr("exporting state", mgr.ExportState(w))
 						logger.Info("state successfully exported")
 						return nil
@@ -461,7 +459,6 @@ to import. If no argument is provided, stdin will be used.
 						},
 						cli.StringFlag{
 							Name:  "consensus",
-							Value: "raft",
 							Usage: "consensus component to export data from [raft, crdt]",
 						},
 					},
@@ -474,6 +471,10 @@ to import. If no argument is provided, stdin will be used.
 						if !c.Bool("force") && !yesNoPrompt(confirm) {
 							return nil
 						}
+
+						cfgMgr, ident, cfgs := makeAndLoadConfigs()
+						defer cfgMgr.Shutdown()
+						mgr := newStateManager(c.String("consensus"), ident, cfgs)
 
 						// Get the importing file path
 						importFile := c.Args().First()
@@ -488,9 +489,6 @@ to import. If no argument is provided, stdin will be used.
 						}
 						defer r.Close()
 
-						cfgMgr, ident, cfgs := makeAndLoadConfigs()
-						defer cfgMgr.Shutdown()
-						mgr := newStateManager(c.String("consensus"), ident, cfgs)
 						checkErr("importing state", mgr.ImportState(r))
 						logger.Info("state successfully imported.  Make sure all peers have consistent states")
 						return nil
@@ -511,7 +509,6 @@ to all effects. Peers may need to bootstrap and sync from scratch after this.
 						},
 						cli.StringFlag{
 							Name:  "consensus",
-							Value: "raft",
 							Usage: "consensus component to export data from [raft, crdt]",
 						},
 					},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,14 +82,14 @@ services:
     # to it.
     command: >-
       sh -c '
-        cmd="daemon --upgrade"
+        cmd="daemon --consensus raft"
         if [ ! -d /data/ipfs-cluster/raft ]; then
           while ! ipfs-cluster-ctl --host /dns4/cluster0/tcp/9094 id; do
             sleep 1
           done
           pid=`ipfs-cluster-ctl --host /dns4/cluster0/tcp/9094 id | grep -o -E "^(\w+)"`
           sleep 10
-          cmd="daemon --bootstrap /dns4/cluster0/tcp/9096/ipfs/$$pid"
+          cmd="daemon --consensus raft --bootstrap /dns4/cluster0/tcp/9096/ipfs/$$pid"
         fi
         exec /usr/local/bin/entrypoint.sh $$cmd
       '

--- a/docker/cluster-restart.sh
+++ b/docker/cluster-restart.sh
@@ -4,6 +4,6 @@
 sleep 4
 while true; do
   export CLUSTER_SECRET=""
-  pgrep ipfs-cluster-service || echo "CLUSTER RESTARTING"; ipfs-cluster-service --debug &
+  pgrep ipfs-cluster-service || echo "CLUSTER RESTARTING"; ipfs-cluster-service daemon --consensus raft --debug &
   sleep 10
 done

--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -121,7 +121,7 @@ cluster_kill(){
 }
 
 cluster_start(){
-    ipfs-cluster-service --config "test-config" daemon >"$IPFS_OUTPUT" 2>&1 &
+    ipfs-cluster-service --config "test-config" daemon --consensus crdt >"$IPFS_OUTPUT" 2>&1 &
     export CLUSTER_D_PID=$!
     while ! curl -s 'localhost:9095/api/v0/version' >/dev/null; do
         sleep 0.2

--- a/sharness/t0052-service-state-export.sh
+++ b/sharness/t0052-service-state-export.sh
@@ -12,7 +12,7 @@ test_expect_success IPFS,CLUSTER,JQ "state export saves the correct state to exp
     ipfs-cluster-ctl pin add "$cid" &&
     sleep 5 &&
     cluster_kill && sleep 5 &&
-    ipfs-cluster-service --debug --config "test-config" state export -f export.json &&
+    ipfs-cluster-service --debug --config "test-config" state export --consensus crdt -f export.json &&
     [ -f export.json ] &&
     jq -r ".cid | .[\"/\"]" export.json | grep -q "$cid"
 '

--- a/sharness/t0053-service-state-import.sh
+++ b/sharness/t0053-service-state-import.sh
@@ -14,13 +14,13 @@ cluster_kill
 test_expect_success IPFS,CLUSTER "state import fails on incorrect format" '
     sleep 5 &&
     echo "not exactly json" > badImportFile &&
-    test_expect_code 1 ipfs-cluster-service --config "test-config" state import -f badImportFile
+    test_expect_code 1 ipfs-cluster-service --config "test-config" state import --consensus crdt -f badImportFile
 '
 
 test_expect_success IPFS,CLUSTER,IMPORTSTATE "state import succeeds on correct format" '
     sleep 5
     cid=`docker exec ipfs sh -c "echo test_53 | ipfs add -q"` &&
-    ipfs-cluster-service --debug --config "test-config" state import -f importState &&
+    ipfs-cluster-service --debug --config "test-config" state import --consensus crdt -f importState &&
     cluster_start &&
     sleep 5 &&
     ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&

--- a/sharness/t0054-service-state-clean.sh
+++ b/sharness/t0054-service-state-clean.sh
@@ -14,7 +14,7 @@ test_expect_success IPFS,CLUSTER "state cleanup refreshes state on restart" '
      ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED" &&
      [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ] &&
      cluster_kill && sleep 5 &&
-     ipfs-cluster-service --debug --config "test-config" state cleanup -f &&
+     ipfs-cluster-service --debug --config "test-config" state cleanup --consensus crdt -f &&
      cluster_start && sleep 5 &&
      [ 0 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ]
 '
@@ -24,9 +24,9 @@ test_expect_success IPFS,CLUSTER "export + cleanup + import == noop" '
     ipfs-cluster-ctl pin add "$cid" && sleep 5 &&		   
     [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ] &&
     cluster_kill && sleep 5 &&
-    ipfs-cluster-service --debug --config "test-config" state export -f import.json &&
-    ipfs-cluster-service --debug --config "test-config" state cleanup -f &&
-    ipfs-cluster-service --debug --config "test-config" state import -f import.json &&
+    ipfs-cluster-service --debug --config "test-config" state export --consensus crdt -f import.json &&
+    ipfs-cluster-service --debug --config "test-config" state cleanup --consensus crdt -f &&
+    ipfs-cluster-service --debug --config "test-config" state import --consensus crdt -f import.json &&
     cluster_start && sleep 5 &&
     ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED" &&


### PR DESCRIPTION
It has a few implications to launch a raft peer when you wanted to do crdt and vice-versa.

Same when exporting and exporting states.

Users starting cluster peers should be explicit about their consensus choice.

Also, if we ever want to make `crdt` the default, we can't do that before
making `raft` non-default first. I don't like to break things but otherwise
the experience for new users wanting to try crdts might be aweful.