### PR TITLE
Auto-trust bootstrap peers

### DIFF
--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -62,6 +62,10 @@ func daemon(c *cli.Context) error {
 
 	defer cfgMgr.Shutdown()
 
+	if len(bootstraps) > 0 && !c.Bool("no-trust") {
+		cfgs.crdtCfg.TrustedPeers = append(cfgs.crdtCfg.TrustedPeers, ipfscluster.PeersFromMultiaddrs(bootstraps)...)
+	}
+
 	if c.Bool("stats") {
 		cfgs.metricsCfg.EnableStats = true
 	}

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -393,7 +393,7 @@ multiaddresses.
 				},
 				cli.BoolFlag{
 					Name:  "no-trust",
-					Usage: "do not trust bootstrap peers (only for \"crdt\" consensus",
+					Usage: "do not trust bootstrap peers (only for \"crdt\" consensus)",
 				},
 			},
 			Action: daemon,

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -391,6 +391,10 @@ multiaddresses.
 					Name:  "tracing",
 					Usage: "enable tracing collection",
 				},
+				cli.BoolFlag{
+					Name:  "no-trust",
+					Usage: "do not trust bootstrap peers",
+				},
 			},
 			Action: daemon,
 		},

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -393,7 +393,7 @@ multiaddresses.
 				},
 				cli.BoolFlag{
 					Name:  "no-trust",
-					Usage: "do not trust bootstrap peers",
+					Usage: "do not trust bootstrap peers (only for \"crdt\" consensus",
 				},
 			},
 			Action: daemon,


### PR DESCRIPTION
Add bootstrap peers to list of trusted peers for crdt.
Just adding them to crdt trusted_peers in config is enough.
 
Fixes #834 