### PR TITLE
Improve error handling on `add`

### DIFF
--- a/add_test.go
+++ b/add_test.go
@@ -5,11 +5,16 @@ package ipfscluster
 import (
 	"context"
 	"mime/multipart"
+	"sync"
 	"testing"
 	"time"
 
+	cid "github.com/ipfs/go-cid"
+	files "github.com/ipfs/go-ipfs-files"
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	rpc "github.com/libp2p/go-libp2p-gorpc"
 )
 
 func TestAdd(t *testing.T) {
@@ -101,4 +106,124 @@ func TestAddPeerDown(t *testing.T) {
 
 		runF(t, clusters, f)
 	})
+}
+
+func TestAddOnePeerFails(t *testing.T) {
+	ctx := context.Background()
+	clusters, mock := createClusters(t)
+	defer shutdownClusters(t, clusters, mock)
+	sth := test.NewShardingTestHelper()
+	defer sth.Clean(t)
+
+	waitForLeaderAndMetrics(t, clusters)
+
+	t.Run("local", func(t *testing.T) {
+		params := api.DefaultAddParams()
+		params.Shard = false
+		params.Name = "testlocal"
+		lg, closer := sth.GetRandFileReader(t, 50000) // 50 MB
+		defer closer.Close()
+
+		mr := files.NewMultiFileReader(lg, true)
+
+		r := multipart.NewReader(mr, mr.Boundary())
+
+		var err error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err = clusters[0].AddFile(r, params)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		err = clusters[1].Shutdown(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wg.Wait()
+	})
+}
+
+// Kishan: Uncomment after https://github.com/ipfs/ipfs-cluster/issues/761
+// is resolved. This test would pass, but not for the reason we want it to.
+// Add fails waiting for the leader.
+func TestAddAllPeersFail(t *testing.T) {
+	ctx := context.Background()
+	clusters, mock := createClusters(t)
+	defer shutdownClusters(t, clusters, mock)
+	sth := test.NewShardingTestHelper()
+	defer sth.Clean(t)
+
+	waitForLeaderAndMetrics(t, clusters)
+
+	t.Run("local", func(t *testing.T) {
+		params := api.DefaultAddParams()
+		params.Shard = false
+		params.Name = "testlocal"
+		lg, closer := sth.GetRandFileReader(t, 50000) // 50 MB
+		defer closer.Close()
+
+		mr := files.NewMultiFileReader(lg, true)
+
+		r := multipart.NewReader(mr, mr.Boundary())
+		params.PinOptions.ReplicationFactorMax = 2
+		params.PinOptions.ReplicationFactorMin = 2
+		clusters[0].allocator = &mockPinAllocator{
+			peers: []peer.ID{clusters[1].id, clusters[2].id},
+		}
+
+		var err error
+		// var cid cid.Cid
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err = clusters[0].AddFile(r, params)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+		}()
+
+		for i := 1; i < 3; i++ {
+			err = clusters[i].Shutdown(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		wg.Wait()
+
+		// pinDelay()
+
+		// pini, err := clusters[0].Status(ctx, cid)
+		// if err != nil {
+		// 	t.Error(err)
+		// }
+		// fmt.Println(pini.String())
+
+		// pin, err := clusters[0].PinGet(ctx, cid)
+		// if err != nil {
+		// 	t.Fatal(err)
+		// }
+
+		// fmt.Println(pin.Allocations)
+	})
+}
+
+type mockPinAllocator struct {
+	peers []peer.ID
+}
+
+// SetClient does nothing in this allocator
+func (alloc mockPinAllocator) SetClient(c *rpc.Client) {}
+
+// Shutdown does nothing in this allocator
+func (alloc mockPinAllocator) Shutdown(_ context.Context) error { return nil }
+
+func (alloc mockPinAllocator) Allocate(ctx context.Context, c cid.Cid, current, candidates, priority map[peer.ID]*api.Metric) ([]peer.ID, error) {
+	return alloc.peers, nil
 }

--- a/add_test.go
+++ b/add_test.go
@@ -135,11 +135,14 @@ func TestAddOnePeerFails(t *testing.T) {
 			}
 		}()
 
-		// Shutdown 1 cluster (the last). Things should keep working.
-		// Important that we shut down the hosts, otherwise the RPC
+		// Disconnect 1 cluster (the last). Things should keep working.
+		// Important that we close the hosts, otherwise the RPC
 		// Servers keep working along with BlockPuts.
 		time.Sleep(100 * time.Millisecond)
-		shutdownClusters(t, clusters[nClusters-1:], mock[nClusters-1:])
+		c := clusters[nClusters-1]
+		c.Shutdown(context.Background())
+		c.dht.Close()
+		c.host.Close()
 		wg.Wait()
 	})
 }
@@ -196,7 +199,11 @@ func TestAddAllPeersFail(t *testing.T) {
 		// Important that we shut down the hosts, otherwise
 		// the RPC Servers keep working along with BlockPuts.
 		// Note that this kills raft.
-		shutdownClusters(t, clusters[1:], mock[1:])
+		runF(t, clusters[1:], func(t *testing.T, c *Cluster) {
+			c.Shutdown(ctx)
+			c.dht.Close()
+			c.host.Close()
+		})
 		wg.Wait()
 	})
 }

--- a/adder/adder_test.go
+++ b/adder/adder_test.go
@@ -137,6 +137,7 @@ func TestAdder_ContextCancelled(t *testing.T) {
 		}
 		t.Log(err)
 	}()
+	// adder.FromMultipart will finish, if sleep more
 	time.Sleep(100 * time.Millisecond)
 	cancel()
 	wg.Wait()

--- a/adder/sharding/shard.go
+++ b/adder/sharding/shard.go
@@ -21,6 +21,7 @@ type shard struct {
 	rpc         *rpc.Client
 	allocations []peer.ID
 	pinOptions  api.PinOptions
+	ba          *adder.BlockAdder
 	// dagNode represents a node with links and will be converted
 	// to Cbor.
 	dagNode     map[string]cid.Cid
@@ -50,6 +51,7 @@ func newShard(ctx context.Context, rpc *rpc.Client, opts api.PinOptions) (*shard
 		rpc:         rpc,
 		allocations: allocs,
 		pinOptions:  opts,
+		ba:          adder.NewBlockAdder(rpc, allocs),
 		dagNode:     make(map[string]cid.Cid),
 		currentSize: 0,
 		sizeLimit:   opts.ShardSize,
@@ -82,7 +84,7 @@ func (sh *shard) Flush(ctx context.Context, shardN int, prev cid.Cid) (cid.Cid, 
 		return cid.Undef, err
 	}
 
-	err = putDAG(ctx, sh.rpc, nodes, sh.allocations)
+	err = sh.ba.AddMany(ctx, nodes)
 	if err != nil {
 		return cid.Undef, err
 	}

--- a/adder/util.go
+++ b/adder/util.go
@@ -14,15 +14,19 @@ import (
 	rpc "github.com/libp2p/go-libp2p-gorpc"
 )
 
+// ErrBlockAdder is returned when adding a to multiple destinations
+// block fails on all of them.
+var ErrBlockAdder = errors.New("failed to put block on all destinations")
+
 // BlockAdder implements "github.com/ipfs/go-ipld-format".NodeAdder.
-// It is efficient because it doesn't try failed peers again as long as
-// block is stored with at least one peer.
+// It helps sending nodes to multiple destinations, as long as one of
+// them is still working.
 type BlockAdder struct {
 	dests     []peer.ID
 	rpcClient *rpc.Client
 }
 
-// NewBlockAdder creates a BlockAdder given an rpc client and allocation peers.
+// NewBlockAdder creates a BlockAdder given an rpc client and allocated peers.
 func NewBlockAdder(rpcClient *rpc.Client, dests []peer.ID) *BlockAdder {
 	return &BlockAdder{
 		dests:     dests,
@@ -30,28 +34,10 @@ func NewBlockAdder(rpcClient *rpc.Client, dests []peer.ID) *BlockAdder {
 	}
 }
 
-// Add puts an ipld node to allocated destinations.
+// Add puts an ipld node to the allocated destinations.
 func (ba *BlockAdder) Add(ctx context.Context, node ipld.Node) error {
-	size, err := node.Size()
-	if err != nil {
-		logger.Warning(err)
-	}
-	nodeSerial := &api.NodeWithMeta{
-		Cid:     node.Cid(),
-		Data:    node.RawData(),
-		CumSize: size,
-	}
+	nodeSerial := ipldNodeToNodeWithMeta(node)
 
-	format, ok := cid.CodecToStr[nodeSerial.Cid.Type()]
-	if !ok {
-		format = ""
-		logger.Warning("unsupported cid type, treating as v0")
-	}
-	if nodeSerial.Cid.Prefix().Version == 0 {
-		format = "v0"
-	}
-
-	nodeSerial.Format = format
 	ctxs, cancels := rpcutil.CtxsWithCancel(ctx, len(ba.dests))
 	defer rpcutil.MultiCancel(cancels)
 
@@ -65,20 +51,27 @@ func (ba *BlockAdder) Add(ctx context.Context, node ipld.Node) error {
 		rpcutil.RPCDiscardReplies(len(ba.dests)),
 	)
 
-	var actDests []peer.ID
+	var sucessfulDests []peer.ID
 	for i, e := range errs {
-		if rpc.IsAuthorizationError(e) || rpc.IsServerError(e) {
+		if e != nil {
+			logger.Errorf("BlockPut on %s: %s", ba.dests[i], e)
+		}
+
+		// RPCErrors include server errors (wrong RPC methods), client
+		// errors (creating, writing or reading streams) and
+		// authorization errors, but not IPFS errors from a failed blockput
+		// for example.
+		if rpc.IsRPCError(e) {
 			continue
 		}
-		actDests = append(actDests, ba.dests[i])
+		sucessfulDests = append(sucessfulDests, ba.dests[i])
 	}
 
-	if len(actDests) == 0 {
-		// request to all peers failed
-		return fmt.Errorf("could not put block on any peer: %s", rpcutil.CheckErrs(errs))
+	if len(sucessfulDests) == 0 {
+		return ErrBlockAdder
 	}
 
-	ba.dests = actDests
+	ba.dests = sucessfulDests
 	return nil
 }
 
@@ -91,6 +84,30 @@ func (ba *BlockAdder) AddMany(ctx context.Context, nodes []ipld.Node) error {
 		}
 	}
 	return nil
+}
+
+// ipldNodeToNodeSerial converts an ipld.Node to NodeWithMeta.
+func ipldNodeToNodeWithMeta(n ipld.Node) *api.NodeWithMeta {
+	size, err := n.Size()
+	if err != nil {
+		logger.Warning(err)
+	}
+
+	format, ok := cid.CodecToStr[n.Cid().Type()]
+	if !ok {
+		format = ""
+		logger.Warning("unsupported cid type, treating as v0")
+	}
+	if n.Cid().Prefix().Version == 0 {
+		format = "v0"
+	}
+
+	return &api.NodeWithMeta{
+		Cid:     n.Cid(),
+		Data:    n.RawData(),
+		CumSize: size,
+		Format:  format,
+	}
 }
 
 // BlockAllocate helps allocating blocks to peers.

--- a/api/types.go
+++ b/api/types.go
@@ -814,7 +814,7 @@ func (pin *Pin) IsRemotePin(pid peer.ID) bool {
 // carrying information about the encoded ipld node
 type NodeWithMeta struct {
 	Data    []byte  `codec:"d,omitempty"`
-	Cid     cid.Cid `codec:"c, omitempty"`
+	Cid     cid.Cid `codec:"c,omitempty"`
 	CumSize uint64  `codec:"s,omitempty"` // Cumulative size
 	Format  string  `codec:"f,omitempty"`
 }

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -313,7 +313,7 @@ func (mock *mockCluster) BlockAllocate(ctx context.Context, in *api.Pin, out *[]
 	if in.ReplicationFactorMin > 1 {
 		return errors.New("replMin too high: can only mock-allocate to 1")
 	}
-	*out = in.Allocations
+	*out = []peer.ID{""} // allocate to local peer
 	return nil
 }
 

--- a/test/sharding.go
+++ b/test/sharding.go
@@ -22,7 +22,6 @@ var (
 	ShardingDirBalancedRootCID        = "QmdHXJgxeCFf6qDZqYYmMesV2DbZCVPEdEhj2oVTxP1y7Y"
 	ShardingDirBalancedRootCIDWrapped = "QmbfGRPTUd7L1xsAZZ1A3kUFP1zkEZ9kHdb6AGaajBzGGX"
 	ShardingDirTrickleRootCID         = "QmYMbx56GFNBDAaAMchtjmWjDTdqNKCSGuFxtRosiPgJL6"
-
 	// These hashes should match all the blocks produced when adding
 	// the files resulting from GetShardingDir*
 	// They have been obtained by adding the "shardTesting" folder


### PR DESCRIPTION
With this commit
- We don't stop adding if one peer failed. We keep adding to peers that
never errored
- We remember peers(only till current `/add` request) that errored and
don't try to put more block them

TODO: Tests

Fixes #852