### PR TITLE
Use string flag instead of string slice

### DIFF
--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -508,7 +508,7 @@ would stil be respected.
 							Value: 0,
 							Usage: "Sets the maximum replication factor for this pin",
 						},
-						cli.StringSliceFlag{
+						cli.StringFlag{
 							Name:  "allocations, allocs",
 							Usage: "Optional comma-separated list of peer IDs",
 						},
@@ -541,9 +541,16 @@ would stil be respected.
 							rplMax = rpl
 						}
 
-						userAllocs := api.StringsToPeers(c.StringSlice("allocations"))
-						if len(userAllocs) != len(c.StringSlice("allocations")) {
-							checkErr("", errors.New("error decoding manual allocations"))
+						var userAllocs []peer.ID
+						if c.String("allocations") != "" {
+							allocs := strings.Split(c.String("allocations"), ",")
+							for i := range allocs {
+								allocs[i] = strings.TrimSpace(allocs[i])
+							}
+							userAllocs = api.StringsToPeers(allocs)
+							if len(userAllocs) != len(allocs) {
+								checkErr("decoding allocations", errors.New("some peer IDs could not be decoded"))
+							}
 						}
 
 						opts := api.PinOptions{

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,7 +38,7 @@ import (
 
 func parseBootstraps(flagVal []string) (bootstraps []ma.Multiaddr) {
 	for _, a := range flagVal {
-		bAddr, err := ma.NewMultiaddr(a)
+		bAddr, err := ma.NewMultiaddr(strings.TrimSpace(a))
 		checkErr("error parsing bootstrap multiaddress (%s)", err, a)
 		bootstraps = append(bootstraps, bAddr)
 	}
@@ -53,8 +54,10 @@ func daemon(c *cli.Context) error {
 	logger.Info("Initializing. For verbose output run with \"-l debug\". Please wait...")
 
 	ctx, cancel := context.WithCancel(context.Background())
-
-	bootstraps := parseBootstraps(c.StringSlice("bootstrap"))
+	var bootstraps []ma.Multiaddr
+	if bootStr :=c.String("bootstrap"); bootStr != "" {
+		bootstraps = parseBootstraps(strings.Split(bootStr, ","))
+	}
 
 	// Execution lock
 	locker.lock()

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -367,9 +367,9 @@ multiaddresses.
 					Name:  "upgrade, u",
 					Usage: "run state migrations before starting (deprecated/unused)",
 				},
-				cli.StringSliceFlag{
+				cli.StringFlag{
 					Name:  "bootstrap, j",
-					Usage: "join a cluster providing an existing peers multiaddress(es)",
+					Usage: "join a cluster providing a comma-separated list of existing peers multiaddress(es)",
 				},
 				cli.BoolFlag{
 					Name:   "leave, x",


### PR DESCRIPTION
Because string slice is not very user friendly. Using string instead
would allow us to pass a comma separated list of arguments in one option

Fixes #841