### PR TITLE
Use `p2p` protocol name over `ipfs` for multiaddr

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -349,7 +349,7 @@ func IsPeerAddress(addr ma.Multiaddr) bool {
 	if addr == nil {
 		return false
 	}
-	pid, err := addr.ValueForProtocol(ma.P_IPFS)
+	pid, err := addr.ValueForProtocol(ma.P_P2P)
 	dnsaddr, err2 := addr.ValueForProtocol(madns.DnsaddrProtocol.Code)
 	return (pid != "" && err == nil) || (dnsaddr != "" && err2 == nil)
 }

--- a/api/rest/client/client_test.go
+++ b/api/rest/client/client_test.go
@@ -62,7 +62,7 @@ func apiMAddr(a *rest.API) ma.Multiaddr {
 }
 
 func peerMAddr(a *rest.API) ma.Multiaddr {
-	ipfsAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s", peer.IDB58Encode(a.Host().ID())))
+	ipfsAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", peer.IDB58Encode(a.Host().ID())))
 	for _, a := range a.Host().Addrs() {
 		if _, err := a.ValueForProtocol(ma.P_IP4); err == nil {
 			return a.Encapsulate(ipfsAddr)

--- a/api/rest/client/client_test.go
+++ b/api/rest/client/client_test.go
@@ -228,7 +228,7 @@ func TestDNSMultiaddress(t *testing.T) {
 }
 
 func TestPeerAddress(t *testing.T) {
-	peerAddr, _ := ma.NewMultiaddr("/dns4/localhost/tcp/1234/ipfs/QmP7R7gWEnruNePxmCa9GBa4VmUNexLVnb1v47R8Gyo3LP")
+	peerAddr, _ := ma.NewMultiaddr("/dns4/localhost/tcp/1234/p2p/QmP7R7gWEnruNePxmCa9GBa4VmUNexLVnb1v47R8Gyo3LP")
 	cfg := &Config{
 		APIAddr:           peerAddr,
 		Host:              "localhost",

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -481,7 +481,7 @@ func (api *API) runLibp2pServer(ctx context.Context) {
 
 	listenMsg := ""
 	for _, a := range api.host.Addrs() {
-		listenMsg += fmt.Sprintf("        %s/ipfs/%s\n", a, api.host.ID().Pretty())
+		listenMsg += fmt.Sprintf("        %s/p2p/%s\n", a, api.host.ID().Pretty())
 	}
 
 	logger.Infof("REST API (libp2p-http): ENABLED. Listening on:\n%s\n", listenMsg)

--- a/api/types.go
+++ b/api/types.go
@@ -36,6 +36,9 @@ import (
 var logger = logging.Logger("apitypes")
 
 func init() {
+	// Use /p2p/ multiaddresses
+	multiaddr.SwapToP2pMultiaddrs()
+
 	// intialize trackerStatusString
 	stringTrackerStatus = make(map[string]TrackerStatus)
 	for k, v := range trackerStatusString {

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -18,7 +18,7 @@ import (
 var testTime = time.Date(2017, 12, 31, 15, 45, 50, 0, time.UTC)
 var testMAddr, _ = ma.NewMultiaddr("/ip4/1.2.3.4")
 var testMAddr2, _ = ma.NewMultiaddr("/dns4/a.b.c.d")
-var testMAddr3, _ = ma.NewMultiaddr("/ip4/127.0.0.1/tcp/8081/ws/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd")
+var testMAddr3, _ = ma.NewMultiaddr("/ip4/127.0.0.1/tcp/8081/ws/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd")
 var testCid1, _ = cid.Decode("QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq")
 var testCid2, _ = cid.Decode("QmYCLpFCj9Av8NFjkQogvtXspnTDFWaizLpVFEijHTH4eV")
 var testCid3, _ = cid.Decode("QmZmdA3UZKuHuy9FrWsxJ82q21nbEh97NUnxTzF5EHxZia")

--- a/api/util.go
+++ b/api/util.go
@@ -35,7 +35,7 @@ func StringsToPeers(strs []string) []peer.ID {
 // peer ID is bad.
 func MustLibp2pMultiaddrJoin(addr Multiaddr, p peer.ID) Multiaddr {
 	v := addr.Value()
-	pidAddr, err := ma.NewMultiaddr("/ipfs/" + peer.IDB58Encode(p))
+	pidAddr, err := ma.NewMultiaddr("/p2p/" + peer.IDB58Encode(p))
 	// let this break badly
 	if err != nil {
 		panic("called MustLibp2pMultiaddrJoin with bad peer!")

--- a/api/util.go
+++ b/api/util.go
@@ -31,7 +31,7 @@ func StringsToPeers(strs []string) []peer.ID {
 }
 
 // MustLibp2pMultiaddrJoin takes a LibP2P multiaddress and a peer ID and
-// encapsulates a new /ipfs/<peerID> address. It will panic if the given
+// encapsulates a new /p2p/<peerID> address. It will panic if the given
 // peer ID is bad.
 func MustLibp2pMultiaddrJoin(addr Multiaddr, p peer.ID) Multiaddr {
 	v := addr.Value()

--- a/cluster.go
+++ b/cluster.go
@@ -120,7 +120,7 @@ func NewCluster(
 
 	listenAddrs := ""
 	for _, addr := range host.Addrs() {
-		listenAddrs += fmt.Sprintf("        %s/ipfs/%s\n", addr, host.ID().Pretty())
+		listenAddrs += fmt.Sprintf("        %s/p2p/%s\n", addr, host.ID().Pretty())
 	}
 
 	logger.Infof("IPFS Cluster v%s listening on:\n%s\n", version.Version, listenAddrs)

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -88,8 +88,6 @@ func checkErr(doing string, err error) {
 func main() {
 	ctx := context.Background()
 
-	ma.SwapToP2pMultiaddrs()
-
 	app := cli.NewApp()
 	app.Name = programName
 	app.Usage = "CLI for IPFS Cluster"

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -58,7 +58,7 @@ responses in a user-readable format. The location of the IPFS
 Cluster server is assumed to be %s, but can be
 configured with the --host option. To use the secure libp2p-http
 API endpoint, use "--host" with the full cluster libp2p listener
-address (including the "/ipfs/<peerID>" part), and --secret (the
+address (including the "/p2p/<peerID>" part), and --secret (the
 32-byte cluster secret as it appears in the cluster configuration).
 
 For feedback, bug reports or any additional information, visit

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -88,6 +88,8 @@ func checkErr(doing string, err error) {
 func main() {
 	ctx := context.Background()
 
+	ma.SwapToP2pMultiaddrs()
+
 	app := cli.NewApp()
 	app.Name = programName
 	app.Usage = "CLI for IPFS Cluster"

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -52,8 +52,6 @@ func daemon(c *cli.Context) error {
 
 	logger.Info("Initializing. For verbose output run with \"-l debug\". Please wait...")
 
-	ma.SwapToP2pMultiaddrs()
-
 	ctx, cancel := context.WithCancel(context.Background())
 
 	bootstraps := parseBootstraps(c.StringSlice("bootstrap"))

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -52,6 +52,8 @@ func daemon(c *cli.Context) error {
 
 	logger.Info("Initializing. For verbose output run with \"-l debug\". Please wait...")
 
+	ma.SwapToP2pMultiaddrs()
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	bootstraps := parseBootstraps(c.StringSlice("bootstrap"))

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -95,7 +95,7 @@ $ ipfs-cluster-service daemon
 
 Launch a peer and join existing cluster:
 
-$ ipfs-cluster-service daemon --bootstrap /ip4/192.168.1.2/tcp/9096/ipfs/QmPSoSaPXpyunaBwHs1rZBKYSqRV4bLRk32VGYLuvdrypL
+$ ipfs-cluster-service daemon --bootstrap /ip4/192.168.1.2/tcp/9096/p2p/QmPSoSaPXpyunaBwHs1rZBKYSqRV4bLRk32VGYLuvdrypL
 `,
 	programName,
 	programName,

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -542,7 +542,7 @@ func (cc *Consensus) Peers(ctx context.Context) ([]peer.ID, error) {
 }
 
 func parsePIDFromMultiaddr(addr ma.Multiaddr) string {
-	pidstr, err := addr.ValueForProtocol(ma.P_IPFS)
+	pidstr, err := addr.ValueForProtocol(ma.P_P2P)
 	if err != nil {
 		panic("peer badly encoded")
 	}

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -73,7 +73,7 @@ func clusterAddr(c *Cluster) ma.Multiaddr {
 	for _, a := range c.host.Addrs() {
 		if _, err := a.ValueForProtocol(ma.P_IP4); err == nil {
 			p := peer.IDB58Encode(c.id)
-			cAddr, _ := ma.NewMultiaddr(fmt.Sprintf("%s/ipfs/%s", a, p))
+			cAddr, _ := ma.NewMultiaddr(fmt.Sprintf("%s/p2p/%s", a, p))
 			return cAddr
 		}
 	}

--- a/pstoremgr/pstoremgr.go
+++ b/pstoremgr/pstoremgr.go
@@ -57,7 +57,7 @@ func New(ctx context.Context, h host.Host, peerstorePath string) *Manager {
 }
 
 // ImportPeer adds a new peer address to the host's peerstore, optionally
-// dialing to it. The address is expected to include the /ipfs/<peerID>
+// dialing to it. The address is expected to include the /p2p/<peerID>
 // protocol part or to be a /dnsaddr/multiaddress
 // Peers are added with the given ttl.
 func (pm *Manager) ImportPeer(addr ma.Multiaddr, connect bool, ttl time.Duration) (peer.ID, error) {

--- a/pstoremgr/pstoremgr_test.go
+++ b/pstoremgr/pstoremgr_test.go
@@ -28,7 +28,7 @@ func clean(pm *Manager) {
 }
 
 func testAddr(loc string, pid peer.ID) ma.Multiaddr {
-	m, _ := ma.NewMultiaddr(loc + "/ipfs/" + peer.IDB58Encode(pid))
+	m, _ := ma.NewMultiaddr(loc + "/p2p/" + peer.IDB58Encode(pid))
 	return m
 }
 

--- a/sharness/t0021-service-init.sh
+++ b/sharness/t0021-service-init.sh
@@ -5,8 +5,8 @@ test_description="Test init functionality"
 . lib/test-lib.sh
 
 test_expect_success "cluster-service init with --peers succeeds and fills peerstore" '
-    PEER1=/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWRN8KRjpyg9rsW2w7StbBRGper65psTZm68cjud9KAkaW
-    PEER2=/ip4/192.168.0.129/tcp/9196/ipfs/12D3KooWPwrYNj7VficHw5qYidepMGA85756kYgMdNmRM9A1ZHjN
+    PEER1=/ip4/192.168.0.129/tcp/9196/p2p/12D3KooWRN8KRjpyg9rsW2w7StbBRGper65psTZm68cjud9KAkaW
+    PEER2=/ip4/192.168.0.129/tcp/9196/p2p/12D3KooWPwrYNj7VficHw5qYidepMGA85756kYgMdNmRM9A1ZHjN
     ipfs-cluster-service --config "test-config" init --peers $PEER1,$PEER2 &&
     grep -q $PEER1 test-config/peerstore &&
     grep -q $PEER2 test-config/peerstore

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -154,7 +154,7 @@ func (mock *mockCluster) ID(ctx context.Context, in struct{}, out *api.ID) error
 	//	DefaultConfigCrypto,
 	//	DefaultConfigKeyLength)
 
-	addr, _ := api.NewMultiaddr("/ip4/127.0.0.1/tcp/4001/ipfs/" + PeerID1.Pretty())
+	addr, _ := api.NewMultiaddr("/ip4/127.0.0.1/tcp/4001/p2p/" + PeerID1.Pretty())
 	*out = api.ID{
 		ID: PeerID1,
 		//PublicKey: pubkey,


### PR DESCRIPTION
Fixes #431 