### PR TITLE
Improve Docker support for CRDTs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
 ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
+ENV IPFS_CLUSTER_CONSENSUS crdt
 
 EXPOSE 9094
 EXPOSE 9095

--- a/Dockerfile-bundle
+++ b/Dockerfile-bundle
@@ -1,4 +1,4 @@
-FROM golang:1.9-stretch AS builder
+FROM golang:1.12-stretch AS builder
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
 
 # This dockerfile builds cluster and runs it along with go-ipfs.
@@ -22,6 +22,7 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
 ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
+ENV IPFS_CLUSTER_CONSENSUS crdt
 
 EXPOSE 9094
 EXPOSE 9095
@@ -38,4 +39,4 @@ VOLUME $IPFS_CLUSTER_PATH
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start-daemons.sh"]
 
 # Defaults for ipfs-cluster-service go here
-CMD ["daemon", "--upgrade"]
+CMD ["daemon"]

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -27,6 +27,9 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   /go/src/github.com/ipfs/ipfs-cluster
 ENV IPFS_CLUSTER_PATH /data/ipfs-cluster
+ENV IPFS_CLUSTER_CONSENSUS crdt
+ENV IPFS_CLUSTER_RESTAPI_HTTPLISTENMULTIADDRESS /ip4/0.0.0.0/tcp/9094
+ENV IPFS_CLUSTER_IPFSPROXY_LISTENMULTIADDRESS /ip4/0.0.0.0/tcp/9095
 
 EXPOSE 9094
 EXPOSE 9095
@@ -34,7 +37,7 @@ EXPOSE 9096
 
 COPY --from=builder $GOPATH/bin/ipfs-cluster-service /usr/local/bin/ipfs-cluster-service
 COPY --from=builder $GOPATH/bin/ipfs-cluster-ctl /usr/local/bin/ipfs-cluster-ctl
-COPY --from=builder $SRC_PATH/docker/test-entrypoint.sh /usr/local/bin/start-daemons.sh
+COPY --from=builder $SRC_PATH/docker/test-entrypoint.sh /usr/local/bin/test-entrypoint.sh
 COPY --from=builder $SRC_PATH/docker/random-stopper.sh /usr/local/bin/random-stopper.sh
 COPY --from=builder $SRC_PATH/docker/random-killer.sh /usr/local/bin/random-killer.sh
 COPY --from=builder $SRC_PATH/docker/wait-killer-stopper.sh /usr/local/bin/wait-killer-stopper.sh
@@ -55,7 +58,7 @@ RUN mkdir -p $IPFS_CLUSTER_PATH && \
 USER ipfs
 
 VOLUME $IPFS_CLUSTER_PATH
-ENTRYPOINT ["/usr/local/bin/start-daemons.sh"]
+ENTRYPOINT ["/usr/local/bin/test-entrypoint.sh"]
 
 # Defaults would go here
 CMD ["daemon"]

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ docker-compose:
 	mkdir -p compose/ipfs0 compose/ipfs1 compose/cluster0 compose/cluster1
 	chmod -R 0777 compose
 	CLUSTER_SECRET=$(shell od -vN 32 -An -tx1 /dev/urandom | tr -d ' \n') docker-compose up -d
-	sleep 20
-	docker exec cluster0 ipfs-cluster-ctl peers ls | grep -o "Sees 1 other peers" | uniq -c | grep 2
-	docker exec cluster1 ipfs-cluster-ctl peers ls | grep -o "Sees 1 other peers" | uniq -c | grep 2
+	sleep 35
+	docker exec cluster0 ipfs-cluster-ctl peers ls | grep -o "Sees 2 other peers" | uniq -c | grep 3
+	docker exec cluster1 ipfs-cluster-ctl peers ls | grep -o "Sees 2 other peers" | uniq -c | grep 3
 	docker-compose down
 
 prcheck: check service ctl test

--- a/clusterhost.go
+++ b/clusterhost.go
@@ -3,17 +3,27 @@ package ipfscluster
 import (
 	"context"
 	"encoding/hex"
+	"time"
 
 	"github.com/ipfs/ipfs-cluster/config"
+	"github.com/ipfs/ipfs-cluster/pstoremgr"
 	libp2p "github.com/libp2p/go-libp2p"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	host "github.com/libp2p/go-libp2p-host"
 	ipnet "github.com/libp2p/go-libp2p-interface-pnet"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	pnet "github.com/libp2p/go-libp2p-pnet"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	discovery "github.com/libp2p/go-libp2p/p2p/discovery"
 	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
+)
+
+const (
+	mdnsServiceTag = "_ipfs-cluster-discovery._udp"
+	mdnsInterval   = 30 * time.Second
 )
 
 // NewClusterHost creates a libp2p Host with the options from the provided
@@ -24,7 +34,7 @@ func NewClusterHost(
 	ctx context.Context,
 	ident *config.Identity,
 	cfg *Config,
-) (host.Host, *pubsub.PubSub, *dht.IpfsDHT, error) {
+) (host.Host, *pubsub.PubSub, *dht.IpfsDHT, discovery.Service, error) {
 
 	connman := connmgr.NewConnManager(cfg.ConnMgr.LowWater, cfg.ConnMgr.HighWater, cfg.ConnMgr.GracePeriod)
 
@@ -37,22 +47,29 @@ func NewClusterHost(
 		libp2p.ConnectionManager(connman),
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	psub, err := newPubSub(ctx, h)
 	if err != nil {
 		h.Close()
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	idht, err := newDHT(ctx, h)
 	if err != nil {
 		h.Close()
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	return routedHost(h, idht), psub, idht, nil
+	mdns, err := discovery.NewMdnsService(ctx, h, mdnsInterval, mdnsServiceTag)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	mdns.RegisterNotifee(&mdnsNotifee{mgr: pstoremgr.New(ctx, h, "")})
+
+	return routedHost(h, idht), psub, idht, mdns, nil
 }
 
 func newHost(ctx context.Context, secret []byte, priv crypto.PrivKey, opts ...libp2p.Option) (host.Host, error) {
@@ -96,6 +113,26 @@ func newPubSub(ctx context.Context, h host.Host) (*pubsub.PubSub, error) {
 
 func routedHost(h host.Host, d *dht.IpfsDHT) host.Host {
 	return routedhost.Wrap(h, d)
+}
+
+type mdnsNotifee struct {
+	mgr *pstoremgr.Manager
+}
+
+func (mdnsNot *mdnsNotifee) HandlePeerFound(p peer.AddrInfo) {
+	addrs, err := peer.AddrInfoToP2pAddrs(&p)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+	// actually mdns returns a single address but let's do things
+	// as if there were several
+	for _, a := range addrs {
+		_, err = mdnsNot.mgr.ImportPeer(a, true, peerstore.ConnectedAddrTTL)
+		if err != nil {
+			logger.Error(err)
+		}
+	}
 }
 
 // EncodeProtectorKey converts a byte slice to its hex string representation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,28 @@
 version: '3.4'
 
-# This is an example docker-compose file for IPFS Cluster
-# It runs two Cluster peers (cluster0, cluster1) attached to two
-# IPFS daemons (ipfs0, ipfs1).
+# This is an example docker-compose file to quickly test an IPFS Cluster
+# with multiple peers on a contained environment.
+
+# It runs 3 cluster peers (cluster0, cluster1...) attached to go-ipfs daemons
+# (ipfs0, ipfs1...) using the CRDT consensus component. Cluster peers
+# autodiscover themselves using mDNS on the docker internal network.
 #
-# It expects a "compose" subfolder as follows where it will store configurations
-# and states permanently:
+# To interact with the cluster use "ipfs-cluster-ctl" (the cluster0 API port is
+# exposed to the locahost. You can also "docker exec -ti cluster0 sh" and run
+# it from the container. "ipfs-cluster-ctl peers ls" should show all 3 peers a few
+# seconds after start.
+#
+# For persistance, a "compose" folder is created and used to store configurations
+# and states. This can be used to edit configurations in subsequent runs. It looks
+# as follows:
 #
 # compose/
 # |-- cluster0
 # |-- cluster1
+# |-- ...
 # |-- ipfs0
 # |-- ipfs1
-#
+# |-- ...
 # 
 # During the first start, default configurations are created for all peers.
 
@@ -25,10 +35,10 @@ services:
   ipfs0:
     container_name: ipfs0
     image: ipfs/go-ipfs:release
-    ports:
-          - "4001:4001" # ipfs swarm
-#         - "5001:5001" # expose if needed/wanted
-#         - "8080:8080" # exposes if needed/wanted
+#   ports:
+#     - "4001:4001" # ipfs swarm - expose if needed/wanted
+#     - "5001:5001" # ipfs api - expose if needed/wanted
+#     - "8080:8080" # ipfs gateway - expose if needed/wanted
     volumes:
       - ./compose/ipfs0:/data/ipfs
       
@@ -38,61 +48,67 @@ services:
     depends_on:
       - ipfs0
     environment:
-      CLUSTER_SECRET: ${CLUSTER_SECRET} # From shell variable
-      IPFS_API: /dns4/ipfs0/tcp/5001
+      CLUSTER_PEERNAME: cluster0
+      CLUSTER_SECRET: ${CLUSTER_SECRET} # From shell variable if set
+      CLUSTER_IPFSHTTP_NODEMULTIADDRESS: /dns4/ipfs0/tcp/5001
+      CLUSTER_CRDT_TRUSTEDPEERS: '*' # Trust all peers in Cluster
     ports:
-          - "127.0.0.1:9094:9094" # API
-#         - "9096:9096" # Cluster IPFS Proxy endpoint
+          # Open API port (allows ipfs-cluster-ctl usage on host)
+          - "127.0.0.1:9094:9094"
+          # The cluster swarm port would need  to be exposed if this container
+          # was to connect to cluster peers on other hosts.
+          # But this is just a testing cluster.
+          # - "9096:9096" # Cluster IPFS Proxy endpoint
     volumes:
       - ./compose/cluster0:/data/ipfs-cluster
 
 ##################################################################################
 ## Cluster PEER 1 ################################################################
 ##################################################################################
-      
+
+# See Cluster PEER 0 for comments (all removed here and below)
   ipfs1:
     container_name: ipfs1
     image: ipfs/go-ipfs:release
-    ports:
-          - "4101:4001" # ipfs swarm
-#         - "5101:5001" # expose if needed/wanted
-#         - "8180:8080" # exposes if needed/wanted
     volumes:
       - ./compose/ipfs1:/data/ipfs
 
-  # cluster1 bootstraps to cluster0 if not bootstrapped before
   cluster1:
     container_name: cluster1
     image: ipfs/ipfs-cluster:latest
     depends_on:
-      - cluster0
       - ipfs1
     environment:
-      CLUSTER_SECRET: ${CLUSTER_SECRET} # From shell variable
-      IPFS_API: /dns4/ipfs1/tcp/5001
-    ports:
-          - "127.0.0.1:9194:9094" # API
-#         - "9196:9096" # Cluster IPFS Proxy endpoint
+      CLUSTER_PEERNAME: cluster1
+      CLUSTER_SECRET: ${CLUSTER_SECRET}
+      CLUSTER_IPFSHTTP_NODEMULTIADDRESS: /dns4/ipfs1/tcp/5001
+      CLUSTER_CRDT_TRUSTEDPEERS: '*'
     volumes:
       - ./compose/cluster1:/data/ipfs-cluster
-    entrypoint:
-      - "/sbin/tini"
-      - "--"
-    # Translation: if state folder does not exist, find cluster0 id and bootstrap
-    # to it.
-    command: >-
-      sh -c '
-        cmd="daemon"
-        if [ ! -d /data/ipfs-cluster/badger ]; then
-          while ! ipfs-cluster-ctl --host /dns4/cluster0/tcp/9094 id; do
-            sleep 1
-          done
-          pid=`ipfs-cluster-ctl --host /dns4/cluster0/tcp/9094 id | grep -o -E "^(\w+)"`
-          sleep 10
-          cmd="daemon --bootstrap /dns4/cluster0/tcp/9096/ipfs/$$pid"
-        fi
-        exec /usr/local/bin/entrypoint.sh $$cmd
-      '
+
+##################################################################################
+## Cluster PEER 2 ################################################################
+##################################################################################
+
+# See Cluster PEER 0 for comments (all removed here and below)
+  ipfs2:
+    container_name: ipfs2
+    image: ipfs/go-ipfs:release
+    volumes:
+      - ./compose/ipfs2:/data/ipfs
+
+  cluster2:
+    container_name: cluster2
+    image: ipfs/ipfs-cluster:latest
+    depends_on:
+      - ipfs2
+    environment:
+      CLUSTER_PEERNAME: cluster2
+      CLUSTER_SECRET: ${CLUSTER_SECRET}
+      CLUSTER_IPFSHTTP_NODEMULTIADDRESS: /dns4/ipfs2/tcp/5001
+      CLUSTER_CRDT_TRUSTEDPEERS: '*'
+    volumes:
+      - ./compose/cluster2:/data/ipfs-cluster
 
 # For adding more peers, copy PEER 1 and rename things to ipfs2, cluster2.
 # Keep bootstrapping to cluster0.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,16 +21,8 @@ if [ -e "${IPFS_CLUSTER_PATH}/service.json" ]; then
     echo "Found IPFS cluster configuration at ${IPFS_CLUSTER_PATH}"
 else
     echo "This container only runs ipfs-cluster-service. ipfs needs to be run separately!"
-    echo "Initializing default configuration"
-    ipfs-cluster-service init
-    if [ -n "$IPFS_API" ]; then
-        echo "Using \$IPFS_API as value for ipfs_connector.ipfshttp.node_multiaddress in configuration"
-        sed -i "s;/ip4/127\.0\.0\.1/tcp/5001;$IPFS_API;" "${IPFS_CLUSTER_PATH}/service.json"
-    fi
-
-    echo "Warning: By default, the API and Proxy endpoints will listen on 0.0.0.0!"
-    sed -i 's;127\.0\.0\.1/tcp/9094;0.0.0.0/tcp/9094;' "${IPFS_CLUSTER_PATH}/service.json"
-    sed -i 's;127\.0\.0\.1/tcp/9095;0.0.0.0/tcp/9095;' "${IPFS_CLUSTER_PATH}/service.json"
+    echo "Initializing default configuration..."
+    ipfs-cluster-service init --consensus "${IPFS_CLUSTER_CONSENSUS}"
 fi
 
 exec ipfs-cluster-service $@

--- a/docker/start-daemons.sh
+++ b/docker/start-daemons.sh
@@ -33,9 +33,7 @@ ipfs-cluster-service --version
 if [ -e "${IPFS_CLUSTER_PATH}/service.json" ]; then
     echo "Found IPFS cluster configuration at ${IPFS_CLUSTER_PATH}"
 else
-    ipfs-cluster-service init
-    sed -i 's/127\.0\.0\.1\/tcp\/9094/0.0.0.0\/tcp\/9094/' "${IPFS_CLUSTER_PATH}/service.json"
-    sed -i 's/127\.0\.0\.1\/tcp\/9095/0.0.0.0\/tcp\/9095/' "${IPFS_CLUSTER_PATH}/service.json"
+    ipfs-cluster-service init --consensus "${IPFS_CLUSTER_CONSENSUS}"
 fi
 
 exec ipfs-cluster-service $@

--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -33,9 +33,7 @@ if [ -e "$IPFS_CLUSTER_PATH/service.json" ]; then
     echo "Found IPFS cluster configuration at $IPFS_CLUSTER_PATH"
 else
     export CLUSTER_SECRET=""
-    ipfs-cluster-service init
-    sed -i 's/127\.0\.0\.1\/tcp\/9094/0.0.0.0\/tcp\/9094/' "$IPFS_CLUSTER_PATH/service.json"
-    sed -i 's/127\.0\.0\.1\/tcp\/9095/0.0.0.0\/tcp\/9095/' "$IPFS_CLUSTER_PATH/service.json"
+    ipfs-cluster-service init --consensus "${IPFS_CLUSTER_CONSENSUS}"
 fi
 
 ipfs-cluster-service --debug $@ &

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 contrib.go.opencensus.io/exporter/jaeger v0.1.0 h1:WNc9HbA38xEQmsI40Tjd/MNU/g8byN2Of7lwIjv0Jdc=
 contrib.go.opencensus.io/exporter/jaeger v0.1.0/go.mod h1:VYianECmuFPwU37O699Vc1GOcy+y8kOsfaxHRImmjbA=
@@ -555,6 +556,7 @@ github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/miekg/dns v1.1.12 h1:WMhc1ik4LNkTg8U9l3hI1LvxKmIL+f1+WV/SZtCbDDA=
 github.com/miekg/dns v1.1.12/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
@@ -718,6 +720,7 @@ github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f h1:M/lL3
 github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f/go.mod h1:cZNvX9cFybI01GriPRMXDtczuvUhgbcYr9iCGaNlRv8=
 github.com/whyrusleeping/mafmt v1.2.8 h1:TCghSl5kkwEE0j+sU/gudyhVMRlpBin8fMBBHg59EbA=
 github.com/whyrusleeping/mafmt v1.2.8/go.mod h1:faQJFPbLSxzD9xpA02ttW/tS9vZykNvXwGvqIpk20FA=
+github.com/whyrusleeping/mdns v0.0.0-20180901202407-ef14215e6b30 h1:nMCC9Pwz1pxfC1Y6mYncdk+kq8d5aLx0Q+/gyZGE44M=
 github.com/whyrusleeping/mdns v0.0.0-20180901202407-ef14215e6b30/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
@@ -803,6 +806,7 @@ golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smto
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -45,10 +45,11 @@ func peerManagerClusters(t *testing.T) ([]*Cluster, []*test.IpfsMock, host.Host)
 	cfg.Secret = testingClusterSecret
 
 	// Create a bootstrapping libp2p host
-	h, _, dht, err := NewClusterHost(context.Background(), ident, cfg)
+	h, _, dht, mdns, err := NewClusterHost(context.Background(), ident, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+	mdns.Close()
 
 	// Connect all peers to that host. This will allow that they
 	// can discover each others via DHT.


### PR DESCRIPTION
cluster: add mDNS service discovery

I always thought the libp2p node would do this, but it is not the case.
With this, CRDT peers are able to autodiscover on local networks.

More commits coming.