### PR TITLE
Use the updated sharness library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ test_problem:
 
 $(sharness):
 	@echo "Downloading sharness"
-	@curl -L -s -o sharness/lib/sharness.tar.gz http://github.com/chriscool/sharness/archive/8fa4b9b0465d21b7ec114ec4528fa17f5a6eb361.tar.gz
+	@curl -L -s -o sharness/lib/sharness.tar.gz http://github.com/chriscool/sharness/archive/28c7490f5cdf1e95a8ebebf8b06ed5588db13875.tar.gz
 	@cd sharness/lib; tar -zxf sharness.tar.gz; cd ../..
-	@mv sharness/lib/sharness-8fa4b9b0465d21b7ec114ec4528fa17f5a6eb361 sharness/lib/sharness
+	@mv sharness/lib/sharness-28c7490f5cdf1e95a8ebebf8b06ed5588db13875 sharness/lib/sharness
 	@rm sharness/lib/sharness.tar.gz
 
 clean_sharness:

--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -5,6 +5,7 @@
 # We are using sharness (https://github.com/chriscool/sharness)
 # which was extracted from the Git test framework.
 
+SHARNESS_TEST_SRCDIR="lib/sharness/test"
 SHARNESS_LIB="lib/sharness/sharness.sh"
 
 # Daemons output will be redirected to...


### PR DESCRIPTION
Last tag was made on v1.1.0 (2018-09-30), so I have used latest commit instead.

Fixes #797 