### PR TITLE
mDNS: attach mDNS inside the Cluster. Allow interval configuration.

### DIFF
--- a/cluster_config.go
+++ b/cluster_config.go
@@ -37,6 +37,7 @@ const (
 	DefaultConnMgrLowWater     = 100
 	DefaultConnMgrGracePeriod  = 2 * time.Minute
 	DefaultFollowerMode        = false
+	DefaultMDNSInterval        = 10 * time.Second
 )
 
 // ConnMgrConfig configures the libp2p host connection manager.
@@ -74,8 +75,9 @@ type Config struct {
 	// the RPC and Consensus components.
 	ListenAddr ma.Multiaddr
 
-	// ConnMgr holds configuration values for the connection manager
-	// for the libp2p host.
+	// ConnMgr holds configuration values for the connection manager for
+	// the libp2p host.
+	// FIXME: This only applies to ipfs-cluster-service.
 	ConnMgr ConnMgrConfig
 
 	// Time between syncs of the consensus state to the
@@ -125,6 +127,11 @@ type Config struct {
 	// been removed from a cluster.
 	PeerWatchInterval time.Duration
 
+	// MDNSInterval controls the time between mDNS broadcasts to the
+	// network announcing the peer addresses. Set to 0 to disable
+	// mDNS.
+	MDNSInterval time.Duration
+
 	// If true, DisableRepinning, ensures that no repinning happens
 	// when a node goes down.
 	// This is useful when doing certain types of maintainance, or simply
@@ -162,6 +169,7 @@ type configJSON struct {
 	ReplicationFactorMax int                `json:"replication_factor_max"`
 	MonitorPingInterval  string             `json:"monitor_ping_interval"`
 	PeerWatchInterval    string             `json:"peer_watch_interval"`
+	MDNSInterval         string             `json:"mdns_interval"`
 	DisableRepinning     bool               `json:"disable_repinning"`
 	FollowerMode         bool               `json:"follower_mode,omitempty"`
 	PeerstoreFile        string             `json:"peerstore_file,omitempty"`
@@ -341,6 +349,7 @@ func (cfg *Config) setDefaults() {
 	cfg.ReplicationFactorMax = DefaultReplicationFactor
 	cfg.MonitorPingInterval = DefaultMonitorPingInterval
 	cfg.PeerWatchInterval = DefaultPeerWatchInterval
+	cfg.MDNSInterval = DefaultMDNSInterval
 	cfg.DisableRepinning = DefaultDisableRepinning
 	cfg.PeerstoreFile = "" // empty so it gets ommited.
 	cfg.FollowerMode = DefaultFollowerMode
@@ -406,6 +415,7 @@ func (cfg *Config) applyConfigJSON(jcfg *configJSON) error {
 		&config.DurationOpt{Duration: jcfg.PinRecoverInterval, Dst: &cfg.PinRecoverInterval, Name: "pin_recover_interval"},
 		&config.DurationOpt{Duration: jcfg.MonitorPingInterval, Dst: &cfg.MonitorPingInterval, Name: "monitor_ping_interval"},
 		&config.DurationOpt{Duration: jcfg.PeerWatchInterval, Dst: &cfg.PeerWatchInterval, Name: "peer_watch_interval"},
+		&config.DurationOpt{Duration: jcfg.MDNSInterval, Dst: &cfg.MDNSInterval, Name: "mdns_interval"},
 	)
 	if err != nil {
 		return err
@@ -456,6 +466,7 @@ func (cfg *Config) toConfigJSON() (jcfg *configJSON, err error) {
 	jcfg.PinRecoverInterval = cfg.PinRecoverInterval.String()
 	jcfg.MonitorPingInterval = cfg.MonitorPingInterval.String()
 	jcfg.PeerWatchInterval = cfg.PeerWatchInterval.String()
+	jcfg.MDNSInterval = cfg.MDNSInterval.String()
 	jcfg.DisableRepinning = cfg.DisableRepinning
 	jcfg.PeerstoreFile = cfg.PeerstoreFile
 	jcfg.FollowerMode = cfg.FollowerMode

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -29,7 +29,6 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	discovery "github.com/libp2p/go-libp2p/p2p/discovery"
 
 	ma "github.com/multiformats/go-multiaddr"
 
@@ -91,7 +90,7 @@ func daemon(c *cli.Context) error {
 		cfgs.Cluster.LeaveOnShutdown = true
 	}
 
-	host, pubsub, dht, mdns, err := ipfscluster.NewClusterHost(ctx, cfgHelper.Identity(), cfgs.Cluster)
+	host, pubsub, dht, err := ipfscluster.NewClusterHost(ctx, cfgHelper.Identity(), cfgs.Cluster)
 	checkErr("creating libp2p host", err)
 
 	cluster, err := createCluster(ctx, c, cfgHelper, host, pubsub, dht, raftStaging)
@@ -104,7 +103,7 @@ func daemon(c *cli.Context) error {
 	// will realize).
 	go bootstrap(ctx, cluster, bootstraps)
 
-	return handleSignals(ctx, cancel, cluster, host, dht, mdns)
+	return handleSignals(ctx, cancel, cluster, host, dht)
 }
 
 // createCluster creates all the necessary things to produce the cluster
@@ -224,7 +223,6 @@ func handleSignals(
 	cluster *ipfscluster.Cluster,
 	host host.Host,
 	dht *dht.IpfsDHT,
-	mdns discovery.Service,
 ) error {
 	signalChan := make(chan os.Signal, 20)
 	signal.Notify(
@@ -243,7 +241,6 @@ func handleSignals(
 		case <-cluster.Done():
 			cancel()
 			dht.Close()
-			mdns.Close()
 			host.Close()
 			return nil
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -36,7 +36,8 @@ var testingClusterCfg = []byte(`{
     "replication_factor": -1,
     "monitor_ping_interval": "350ms",
     "peer_watch_interval": "200ms",
-    "disable_repinning": false
+    "disable_repinning": false,
+    "mdns_interval": "0s"
 }`)
 
 var testingRaftCfg = []byte(`{

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -45,11 +45,10 @@ func peerManagerClusters(t *testing.T) ([]*Cluster, []*test.IpfsMock, host.Host)
 	cfg.Secret = testingClusterSecret
 
 	// Create a bootstrapping libp2p host
-	h, _, dht, mdns, err := NewClusterHost(context.Background(), ident, cfg)
+	h, _, dht, err := NewClusterHost(context.Background(), ident, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mdns.Close()
 
 	// Connect all peers to that host. This will allow that they
 	// can discover each others via DHT.

--- a/pstoremgr/pstoremgr.go
+++ b/pstoremgr/pstoremgr.go
@@ -341,6 +341,23 @@ func (pm *Manager) SetPriority(pid peer.ID, prio int) error {
 	return pm.host.Peerstore().Put(pid, PriorityTag, prio)
 }
 
+// HandlePeerFound implements the Notifee interface for discovery.
+func (pm *Manager) HandlePeerFound(p peer.AddrInfo) {
+	addrs, err := peer.AddrInfoToP2pAddrs(&p)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+	// actually mdns returns a single address but let's do things
+	// as if there were several
+	for _, a := range addrs {
+		_, err = pm.ImportPeer(a, true, peerstore.ConnectedAddrTTL)
+		if err != nil {
+			logger.Error(err)
+		}
+	}
+}
+
 // peerSort is used to sort a slice of PinInfos given the PriorityTag in the
 // peerstore, from the lowest tag value (0 is the highest priority) to the
 // highest, Peers without a valid priority tag are considered as having a tag


### PR DESCRIPTION
Setting up mDNS outside the Cluster is dirtier and allows less configuration.

This adds MDNSInterval to the cluster config options and allow disabling it
when the option is set to 0.