### PR TITLE
Error queue is full

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ipfs/ipfs-cluster/adder/local"
 	"github.com/ipfs/ipfs-cluster/adder/sharding"
 	"github.com/ipfs/ipfs-cluster/api"
-	"github.com/ipfs/ipfs-cluster/pintracker/maptracker"
 	"github.com/ipfs/ipfs-cluster/pstoremgr"
 	"github.com/ipfs/ipfs-cluster/rpcutil"
 	"github.com/ipfs/ipfs-cluster/state"
@@ -944,7 +943,7 @@ func (c *Cluster) StateSync(ctx context.Context) error {
 		if !tracked {
 			logger.Debugf("StateSync: tracking %s, part of the shared state", pin.Cid)
 			err = c.tracker.Track(ctx, pin)
-			if err == maptracker.ErrFullQueue {
+			if err != nil {
 				return err
 			}
 		}
@@ -976,7 +975,7 @@ func (c *Cluster) StateSync(ctx context.Context) error {
 			logger.Debugf("StateSync: Tracking %s as remote (currently local)", pCid)
 			err = c.tracker.Track(ctx, currentPin)
 		}
-		if err == maptracker.ErrFullQueue {
+		if err != nil {
 			return err
 		}
 	}

--- a/pintracker/maptracker/config.go
+++ b/pintracker/maptracker/config.go
@@ -14,7 +14,7 @@ const envConfigKey = "cluster_maptracker"
 
 // Default values for this Config.
 const (
-	DefaultMaxPinQueueSize = 50000
+	DefaultMaxPinQueueSize = 1000000
 	DefaultConcurrentPins  = 10
 )
 
@@ -31,7 +31,7 @@ type Config struct {
 }
 
 type jsonConfig struct {
-	MaxPinQueueSize int `json:"max_pin_queue_size"`
+	MaxPinQueueSize int `json:"max_pin_queue_size,omitempty"`
 	ConcurrentPins  int `json:"concurrent_pins"`
 }
 
@@ -104,8 +104,12 @@ func (cfg *Config) ToJSON() ([]byte, error) {
 }
 
 func (cfg *Config) toJSONConfig() *jsonConfig {
-	return &jsonConfig{
-		MaxPinQueueSize: cfg.MaxPinQueueSize,
-		ConcurrentPins:  cfg.ConcurrentPins,
+	jCfg := &jsonConfig{
+		ConcurrentPins: cfg.ConcurrentPins,
 	}
+	if cfg.MaxPinQueueSize != DefaultMaxPinQueueSize {
+		jCfg.MaxPinQueueSize = cfg.MaxPinQueueSize
+	}
+
+	return jCfg
 }

--- a/pintracker/maptracker/maptracker.go
+++ b/pintracker/maptracker/maptracker.go
@@ -23,6 +23,8 @@ var logger = logging.Logger("pintracker")
 
 var (
 	errUnpinned = errors.New("the item is unexpectedly not pinned on IPFS")
+	// ErrFullQueue is the error used when pin or unpin operation channel is full.
+	ErrFullQueue = errors.New("pin/unpin operation queue is full (too many operations), increasing max_pin_queue_size would help")
 )
 
 // MapPinTracker is a PinTracker implementation which uses a Go map
@@ -47,7 +49,7 @@ type MapPinTracker struct {
 	wg           sync.WaitGroup
 }
 
-// NewMapPinTracker returns a new object which has been correcly
+// NewMapPinTracker returns a new object which has been correctly
 // initialized with the given configuration.
 func NewMapPinTracker(cfg *Config, pid peer.ID, peerName string) *MapPinTracker {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -180,7 +182,7 @@ func (mpt *MapPinTracker) enqueue(ctx context.Context, c *api.Pin, typ optracker
 	select {
 	case ch <- op:
 	default:
-		err := errors.New("queue is full")
+		err := ErrFullQueue
 		op.SetError(err)
 		op.Cancel()
 		logger.Error(err.Error())


### PR DESCRIPTION
- abort if a Track() calls fails due to queue being full
- increase max pin queue size to 1 million
- hind max_pin_queue_size from configuration
- use an elaborated error message

Fixes #377