### PR TITLE
Fix: handling allocations

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -478,6 +478,10 @@ func (po *PinOptions) Equals(po2 *PinOptions) bool {
 		return false
 	}
 
+	if po.Name != po2.Name {
+		return false
+	}
+
 	if po.ReplicationFactorMax != po2.ReplicationFactorMax {
 		return false
 	}
@@ -763,10 +767,6 @@ func (pin *Pin) Equals(pin2 *Pin) bool {
 	}
 
 	if !pin.Cid.Equals(pin2.Cid) {
-		return false
-	}
-
-	if pin.Name != pin2.Name {
 		return false
 	}
 

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -1665,8 +1665,7 @@ func TestClustersReplicationNotEnoughPeers(t *testing.T) {
 	ttlDelay()
 
 	j := rand.Intn(nClusters)
-	h := test.Cid1
-	_, err := clusters[j].Pin(ctx, h, api.PinOptions{})
+	_, err := clusters[j].Pin(ctx, test.Cid1, api.PinOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1679,7 +1678,7 @@ func TestClustersReplicationNotEnoughPeers(t *testing.T) {
 
 	waitForLeaderAndMetrics(t, clusters)
 
-	_, err = clusters[2].Pin(ctx, h, api.PinOptions{})
+	_, err = clusters[2].Pin(ctx, test.Cid2, api.PinOptions{})
 	if err == nil {
 		t.Fatal("expected an error")
 	}

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -3,6 +3,7 @@ package ipfscluster
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -395,14 +396,12 @@ func TestClustersPeerRemoveLeader(t *testing.T) {
 }
 
 func TestClustersPeerRemoveReallocsPins(t *testing.T) {
+	// This test is testing that the peers are vacated upon
+	// removal.
+
 	ctx := context.Background()
 	clusters, mocks := createClusters(t)
 	defer shutdownClusters(t, clusters, mocks)
-
-	if consensus == "crdt" {
-		t.Log("FIXME when re-alloc changes come through")
-		return
-	}
 
 	if len(clusters) < 3 {
 		t.Skip("test needs at least 3 clusters")
@@ -415,31 +414,33 @@ func TestClustersPeerRemoveReallocsPins(t *testing.T) {
 	}
 
 	// We choose to remove the leader, to make things even more interesting
-	leaderID, err := clusters[0].consensus.Leader(ctx)
+	chosenID, err := clusters[0].consensus.Leader(ctx)
 	if err != nil {
-		t.Fatal(err)
+		// choose a random peer
+		i := rand.Intn(nClusters)
+		chosenID = clusters[i].host.ID()
 	}
 
-	var leader *Cluster
-	var leaderi int
+	var chosen *Cluster
+	var chosenIndex int
 	for i, cl := range clusters {
-		if id := cl.ID(ctx).ID; id == leaderID {
-			leader = cl
-			leaderi = i
+		if id := cl.ID(ctx).ID; id == chosenID {
+			chosen = cl
+			chosenIndex = i
 			break
 		}
 	}
-	if leader == nil {
-		t.Fatal("did not find a leader?")
+	if chosen == nil {
+		t.Fatal("did not get to choose a peer?")
 	}
 
-	leaderMock := mocks[leaderi]
+	chosenMock := mocks[chosenIndex]
 
-	// Remove leader from set
-	clusters = append(clusters[:leaderi], clusters[leaderi+1:]...)
-	mocks = append(mocks[:leaderi], mocks[leaderi+1:]...)
-	defer leader.Shutdown(ctx)
-	defer leaderMock.Close()
+	// Remove the chosen peer from set
+	clusters = append(clusters[:chosenIndex], clusters[chosenIndex+1:]...)
+	mocks = append(mocks[:chosenIndex], mocks[chosenIndex+1:]...)
+	defer chosen.Shutdown(ctx)
+	defer chosenMock.Close()
 
 	prefix := test.Cid1.Prefix()
 
@@ -448,7 +449,7 @@ func TestClustersPeerRemoveReallocsPins(t *testing.T) {
 	for i := 0; i < nClusters; i++ {
 		h, err := prefix.Sum(randomBytes())
 		checkErr(t, err)
-		_, err = leader.Pin(ctx, h, api.PinOptions{})
+		_, err = chosen.Pin(ctx, h, api.PinOptions{})
 		checkErr(t, err)
 		ttlDelay()
 	}
@@ -457,10 +458,10 @@ func TestClustersPeerRemoveReallocsPins(t *testing.T) {
 
 	// At this point, all peers must have nClusters -1  pins
 	// associated to them.
-	// Find out which pins are associated to the leader.
+	// Find out which pins are associated to the chosen peer.
 	interestingCids := []cid.Cid{}
 
-	pins, err := leader.Pins(ctx)
+	pins, err := chosen.Pins(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,23 +469,20 @@ func TestClustersPeerRemoveReallocsPins(t *testing.T) {
 		t.Fatal("expected number of tracked pins to be nClusters")
 	}
 	for _, p := range pins {
-		if containsPeer(p.Allocations, leaderID) {
-			//t.Logf("%s pins %s", leaderID, p.Cid)
+		if containsPeer(p.Allocations, chosenID) {
+			//t.Logf("%s pins %s", chosenID, p.Cid)
 			interestingCids = append(interestingCids, p.Cid)
 		}
 	}
 
 	if len(interestingCids) != nClusters-1 {
-		//t.Fatal("The number of allocated Cids is not expected")
 		t.Fatalf("Expected %d allocated CIDs but got %d", nClusters-1,
 			len(interestingCids))
 	}
 
-	// Now the leader removes itself
-	err = leader.PeerRemove(ctx, leaderID)
-	if err != nil {
-		t.Fatal("error removing peer:", err)
-	}
+	// Now the chosen removes itself. Ignoring errors as they will
+	// be caught below and crdt does error here.
+	chosen.PeerRemove(ctx, chosenID)
 
 	delay()
 	waitForLeaderAndMetrics(t, clusters)
@@ -496,7 +494,7 @@ func TestClustersPeerRemoveReallocsPins(t *testing.T) {
 		if err != nil {
 			t.Fatal("error getting the new allocations for", icid)
 		}
-		if containsPeer(newPin.Allocations, leaderID) {
+		if containsPeer(newPin.Allocations, chosenID) {
 			t.Fatal("pin should not be allocated to the removed peer")
 		}
 	}


### PR DESCRIPTION
* pin() should not allocate if allocations are already provided
* pin() should not skip pinning if the exact same pin exists
  * Additionally this was unreliable as it allocated it before
    so the pin may have existed but the allocations may have been
    artificially changed.
* pin() re-uses existing pin when pin options are the same and thus
  avoids changing the allocations of a pin.

As a side effect, this fixes re-allocations which were broken: peers
called `shouldPeerRepinCid()` and instead of repinning that single
cid proceeded to repin the full state. For every pin.

Additionally tests have been adapted. It may be that some re-alloc tests
were very unreliable for the problems above.