### PR TITLE
Test that expired PeerMetrics gets deleted

### DIFF
--- a/monitor/metrics/checker.go
+++ b/monitor/metrics/checker.go
@@ -19,7 +19,7 @@ import (
 var AlertChannelCap = 256
 
 // MaxAlertThreshold specifies how many alerts will occur per a peer is
-// removed the list of monitored peers.
+// removed from the list of monitored peers.
 var MaxAlertThreshold = 1
 
 // ErrAlertChannelFull is returned if the alert channel is full.
@@ -191,7 +191,7 @@ func (mc *Checker) failed(metric string, pid peer.ID) (float64, []float64, float
 		return 0.0, nil, 0.0, true
 	}
 
-	// A peer is never failed if the latest metric from is has
+	// A peer is never failed if the latest metric from it has
 	// not expired or we do not have enough number of metrics
 	// for accrual detection
 	if !latest.Expired() {

--- a/monitor/pubsubmon/pubsubmon_test.go
+++ b/monitor/pubsubmon/pubsubmon_test.go
@@ -312,3 +312,26 @@ func TestPeerMonitorAlerts(t *testing.T) {
 		}
 	}
 }
+
+func TestMetricsGetsDeleted(t *testing.T) {
+	ctx := context.Background()
+
+	pm, _, shutdown := testPeerMonitor(t)
+	defer shutdown()
+	mf := newMetricFactory()
+
+	pm.LogMetric(ctx, mf.newMetric("test", test.PeerID1))
+	metrics := pm.metrics.PeerMetrics(test.PeerID1)
+	if len(metrics) == 0 {
+		t.Error("expected metrics")
+	}
+
+	// TODO: expiry time + checkInterval is 7 sec
+	// Why does it need 9 or more?
+	time.Sleep(9 * time.Second)
+
+	metrics = pm.metrics.PeerMetrics(test.PeerID1)
+	if len(metrics) > 0 {
+		t.Error("expected no metrics")
+	}
+}


### PR DESCRIPTION
Fixes #410 

> The problem is: if a peer is removed from the peerset (from the cluster), the Store will still keep a key containing the metrics.Window for that peer, as this is never cleaned up.

metrics.Window gets cleaned up already https://github.com/ipfs/ipfs-cluster/issues/410#issuecomment-523044477

We can use PeersFunc to get the peerset, which we can get from consensus.Peers
- Raft has information about the peers, but you would not expect many coming and going peers in raft, so there isn't really a point doing this.
- CRDT uses metrics for consensus.Peers, so no new information there

So for both of crdt and raft we can use this way:
if peer metrics fail for a threshold time, consider that peer to be not part of peer set and remove metrics. 

This PR just adds a test to check that those expired peer metrics gets deleted