### PR TITLE
Dockerfiles: download modules in advance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,8 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
 ENV GO111MODULE on
+# ENV CGO_ENABLED 0
 ENV GOPROXY=https://proxy.golang.org
-
-COPY . $SRC_PATH
-WORKDIR $SRC_PATH
-RUN make install
 
 ENV SUEXEC_VERSION v0.2
 ENV TINI_VERSION v0.16.1
@@ -26,6 +23,14 @@ RUN set -x \
 
 # Get the TLS CA certificates, they're not provided by busybox.
 RUN apt-get update && apt-get install -y ca-certificates
+
+COPY go.* go.* $SRC_PATH/
+WORKDIR $SRC_PATH
+RUN go mod download
+
+COPY . $SRC_PATH
+RUN make install
+
 
 #------------------------------------------------------
 FROM busybox:1-glibc

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
 ENV GO111MODULE on
-# ENV CGO_ENABLED 0
 ENV GOPROXY=https://proxy.golang.org
 
 ENV SUEXEC_VERSION v0.2
@@ -24,7 +23,7 @@ RUN set -x \
 # Get the TLS CA certificates, they're not provided by busybox.
 RUN apt-get update && apt-get install -y ca-certificates
 
-COPY go.* go.* $SRC_PATH/
+COPY go.* $SRC_PATH/
 WORKDIR $SRC_PATH
 RUN go mod download
 

--- a/Dockerfile-bundle
+++ b/Dockerfile-bundle
@@ -8,10 +8,9 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
 ENV GO111MODULE on
-# ENV CGO_ENABLED 0
 ENV GOPROXY=https://proxy.golang.org
 
-COPY go.* go.* $SRC_PATH/
+COPY go.* $SRC_PATH/
 WORKDIR $SRC_PATH
 RUN go mod download
 

--- a/Dockerfile-bundle
+++ b/Dockerfile-bundle
@@ -7,9 +7,15 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 # This builder just builds the cluster binaries
 ENV GOPATH     /go
 ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
+ENV GO111MODULE on
+# ENV CGO_ENABLED 0
+ENV GOPROXY=https://proxy.golang.org
+
+COPY go.* go.* $SRC_PATH/
+WORKDIR $SRC_PATH
+RUN go mod download
 
 COPY . $SRC_PATH
-WORKDIR $SRC_PATH
 RUN make install
 
 #------------------------------------------------------

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -6,14 +6,13 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
 ENV GO111MODULE on
-# ENV CGO_ENABLED 0
 ENV GOPROXY=https://proxy.golang.org
 
 RUN cd /tmp && \
     wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
     chmod +x jq-linux64
 
-COPY go.* go.* $SRC_PATH/
+COPY go.* $SRC_PATH/
 WORKDIR $SRC_PATH
 RUN go mod download
 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -6,16 +6,19 @@ MAINTAINER Hector Sanjuan <hector@protocol.ai>
 ENV GOPATH     /go
 ENV SRC_PATH   $GOPATH/src/github.com/ipfs/ipfs-cluster
 ENV GO111MODULE on
+# ENV CGO_ENABLED 0
 ENV GOPROXY=https://proxy.golang.org
-
-COPY . $SRC_PATH
-WORKDIR $SRC_PATH
-RUN make install
 
 RUN cd /tmp && \
     wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
     chmod +x jq-linux64
-    
+
+COPY go.* go.* $SRC_PATH/
+WORKDIR $SRC_PATH
+RUN go mod download
+
+COPY . $SRC_PATH
+RUN make install
 
 #------------------------------------------------------
 FROM ipfs/go-ipfs:master

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ install:
 	$(MAKE) -C cmd/ipfs-cluster-ctl install
 
 build:
-	go build -ldflags "-X ipfscluster.Commit=$(shell git rev-parse HEAD)"
 	$(MAKE) -C cmd/ipfs-cluster-service build
 	$(MAKE) -C cmd/ipfs-cluster-ctl build
 

--- a/cmd/ipfs-cluster-ctl/Makefile
+++ b/cmd/ipfs-cluster-ctl/Makefile
@@ -4,7 +4,7 @@ SRC := $(shell find .. -type f -name '*.go')
 all: ipfs-cluster-ctl
 
 ipfs-cluster-ctl: $(SRC)
-	go build
+	go build -mod=readonly
 
 build: ipfs-cluster-ctl
 

--- a/cmd/ipfs-cluster-service/Makefile
+++ b/cmd/ipfs-cluster-service/Makefile
@@ -4,7 +4,7 @@ SRC := $(shell find .. -type f -name '*.go')
 all: ipfs-cluster-service
 
 ipfs-cluster-service: $(SRC)
-	go build -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
+	go build -mod=readonly -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
 
 build: ipfs-cluster-service
 

--- a/go.mod
+++ b/go.mod
@@ -55,8 +55,6 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.1.1
 	github.com/libp2p/go-libp2p-raft v0.1.3
 	github.com/libp2p/go-ws-transport v0.1.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/multiformats/go-multiaddr-dns v0.1.1
 	github.com/multiformats/go-multiaddr-net v0.1.0


### PR DESCRIPTION
This should speed up Dockerfile builds, particularly when building after
updating the code since the modules will not be to be re-downloaded.