### PR TITLE
Environment variable to set loglevels for individual identifiers

### DIFF
--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -602,7 +602,7 @@ func setupLogLevel(debug bool, compLogLevel []string) error {
 				return fmt.Errorf("%s is not a valid log level", lvl)
 			}
 			if logLevel != "" {
-				return errors.New("trying to set overall log level again")
+				fmt.Printf("overwriting existing overall log level\n")
 			}
 			logLevel = lvl
 		case 2:
@@ -612,7 +612,7 @@ func setupLogLevel(debug bool, compLogLevel []string) error {
 			}
 			_, ok := compLogFacs[identifierToLevel[0]]
 			if ok {
-				return fmt.Errorf("trying to set %s log level again", identifierToLevel[0])
+				fmt.Printf("overwriting existing %s log level\n", identifierToLevel[0])
 			}
 			compLogFacs[identifierToLevel[0]] = lvl
 		default:

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -615,9 +615,6 @@ func setupLogLevel(debug bool, l string) error {
 			return errors.New("log level not in expected format \"identifier:loglevel\" or \"loglevel\"")
 		}
 
-		if !ipfscluster.IsLogLevel(lvl) {
-			return fmt.Errorf("%s is not a valid log level", lvl)
-		}
 		_, ok := compLogFacs[comp]
 		if ok {
 			fmt.Printf("overwriting existing %s log level\n", comp)

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -98,6 +98,13 @@ $ ipfs-cluster-service daemon
 Launch a peer and join existing cluster:
 
 $ ipfs-cluster-service daemon --bootstrap /ip4/192.168.1.2/tcp/9096/p2p/QmPSoSaPXpyunaBwHs1rZBKYSqRV4bLRk32VGYLuvdrypL
+
+Customize logs using --loglevel flag. To customize component-level
+logging pass a comma-separated list of component-identifer:log-level
+pair or without identifier for overall loglevel. Valid loglevels
+are critical, error, warning, notice, info and debug.
+
+$ ipfs-cluster-service --loglevel info,cluster:debug,pintracker:debug daemon
 `,
 	programName,
 	programName,
@@ -192,7 +199,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "loglevel, l",
 			EnvVar: "IPFS_CLUSTER_LOG_LEVEL",
-			Usage:  "set loglevels for all or separate loglevels for individual log identifiers [loglevel, identifier:loglevel]. Valid loglevels are critical, error, warning, notice, info and debug.",
+			Usage:  "set overall and component-wise log levels",
 		},
 	}
 

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -627,8 +627,8 @@ func setupLogLevel(debug bool, compLogLevel []string) error {
 	// log service with logLevel
 	ipfscluster.SetFacilityLogLevel("service", logLevel)
 
-	logfacs := ipfscluster.LoggingFacilities
-	for key := range logfacs {
+	logfacs := make(map[string]string)
+	for key := range ipfscluster.LoggingFacilities {
 		logfacs[key] = logLevel
 	}
 

--- a/logging.go
+++ b/logging.go
@@ -66,3 +66,14 @@ func SetFacilityLogLevel(f, l string) {
 	*/
 	logging.SetLogLevel(f, l)
 }
+
+// IsLogLevel checks if given string is a valid log level.
+func IsLogLevel(s string) bool {
+	for _, level := range []string{"CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"} {
+		if s == level {
+			return true
+		}
+	}
+
+	return false
+}

--- a/logging.go
+++ b/logging.go
@@ -1,8 +1,6 @@
 package ipfscluster
 
 import (
-	"strings"
-
 	logging "github.com/ipfs/go-log"
 )
 
@@ -69,15 +67,4 @@ func SetFacilityLogLevel(f, l string) {
 		DEBUG
 	*/
 	logging.SetLogLevel(f, l)
-}
-
-// IsLogLevel checks if given string is a valid log level.
-func IsLogLevel(s string) bool {
-	for _, level := range []string{"DEBUG", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO"} {
-		if strings.ToUpper(s) == level {
-			return true
-		}
-	}
-
-	return false
 }

--- a/logging.go
+++ b/logging.go
@@ -1,6 +1,10 @@
 package ipfscluster
 
-import logging "github.com/ipfs/go-log"
+import (
+	"strings"
+
+	logging "github.com/ipfs/go-log"
+)
 
 var logger = logging.Logger("cluster")
 
@@ -70,7 +74,7 @@ func SetFacilityLogLevel(f, l string) {
 // IsLogLevel checks if given string is a valid log level.
 func IsLogLevel(s string) bool {
 	for _, level := range []string{"DEBUG", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO"} {
-		if s == level {
+		if strings.ToUpper(s) == level {
 			return true
 		}
 	}

--- a/logging.go
+++ b/logging.go
@@ -69,7 +69,7 @@ func SetFacilityLogLevel(f, l string) {
 
 // IsLogLevel checks if given string is a valid log level.
 func IsLogLevel(s string) bool {
-	for _, level := range []string{"CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"} {
+	for _, level := range []string{"DEBUG", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO"} {
 		if s == level {
 			return true
 		}


### PR DESCRIPTION
- Example: export LOG_FACS="cluster:debug,raft:debug"

`kelseyhightower/envconfig` works only with structs. I will look at this again and see if there a way to do this like `export LOG_CLUSTER=debug`

#938 