### PR TITLE
Allow and run multiple informer components

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -65,7 +65,7 @@ func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, rplMin, rplMax int
 	if err == nil {
 		currentAllocs = currentPin.Allocations
 	}
-	metrics := c.monitor.LatestMetrics(ctx, c.preferredMetric)
+	metrics := c.monitor.LatestMetrics(ctx, c.informers[0].Name())
 
 	currentMetrics := make(map[peer.ID]*api.Metric)
 	candidatesMetrics := make(map[peer.ID]*api.Metric)

--- a/allocate.go
+++ b/allocate.go
@@ -65,7 +65,7 @@ func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, rplMin, rplMax int
 	if err == nil {
 		currentAllocs = currentPin.Allocations
 	}
-	metrics := c.monitor.LatestMetrics(ctx, c.informer.Name())
+	metrics := c.monitor.LatestMetrics(ctx, c.preferredMetric)
 
 	currentMetrics := make(map[peer.ID]*api.Metric)
 	candidatesMetrics := make(map[peer.ID]*api.Metric)

--- a/cluster.go
+++ b/cluster.go
@@ -301,6 +301,8 @@ func (c *Cluster) sendInformersMetrics(ctx context.Context) ([]*api.Metric, erro
 // cluster monitor. Metrics are pushed normally at a TTL/2 rate. If an error
 // occurs, they are pushed at a TTL/4 rate.
 func (c *Cluster) pushInformerMetrics(ctx context.Context, informer Informer) {
+	defer c.wg.Done()
+
 	ctx, span := trace.StartSpan(ctx, "cluster/pushInformerMetrics")
 	defer span.End()
 
@@ -563,7 +565,6 @@ func (c *Cluster) run() {
 
 	c.wg.Add(len(c.informers))
 	for _, informer := range c.informers {
-		defer c.wg.Done()
 		go c.pushInformerMetrics(c.ctx, informer)
 	}
 

--- a/cluster.go
+++ b/cluster.go
@@ -301,8 +301,6 @@ func (c *Cluster) sendInformersMetrics(ctx context.Context) ([]*api.Metric, erro
 // cluster monitor. Metrics are pushed normally at a TTL/2 rate. If an error
 // occurs, they are pushed at a TTL/4 rate.
 func (c *Cluster) pushInformerMetrics(ctx context.Context, informer Informer) {
-	defer c.wg.Done()
-
 	ctx, span := trace.StartSpan(ctx, "cluster/pushInformerMetrics")
 	defer span.End()
 
@@ -565,7 +563,10 @@ func (c *Cluster) run() {
 
 	c.wg.Add(len(c.informers))
 	for _, informer := range c.informers {
-		go c.pushInformerMetrics(c.ctx, informer)
+		go func(inf Informer) {
+			defer c.wg.Done()
+			c.pushInformerMetrics(c.ctx, inf)
+		}(informer)
 	}
 
 	c.wg.Add(1)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -199,7 +199,6 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, PinTracke
 		alloc,
 		[]Informer{inf},
 		tracer,
-		inf.Name(),
 	)
 	if err != nil {
 		t.Fatal("cannot create cluster:", err)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -197,8 +197,9 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, PinTracke
 		tracker,
 		mon,
 		alloc,
-		inf,
+		[]Informer{inf},
 		tracer,
+		inf.Name(),
 	)
 	if err != nil {
 		t.Fatal("cannot create cluster:", err)

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -202,7 +202,6 @@ func createCluster(
 		alloc,
 		[]ipfscluster.Informer{informer},
 		tracer,
-		informer.Name(),
 	)
 }
 

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -200,8 +200,9 @@ func createCluster(
 		tracker,
 		mon,
 		alloc,
-		informer,
+		[]ipfscluster.Informer{informer},
 		tracer,
+		informer.Name(),
 	)
 }
 

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -282,7 +282,7 @@ func makePinTracker(t *testing.T, pid peer.ID, mptCfg *maptracker.Config, sptCfg
 }
 
 func createCluster(t *testing.T, host host.Host, dht *dht.IpfsDHT, clusterCfg *Config, store ds.Datastore, consensus Consensus, apis []API, ipfs IPFSConnector, tracker PinTracker, mon PeerMonitor, alloc PinAllocator, inf Informer, tracer Tracer) *Cluster {
-	cl, err := NewCluster(context.Background(), host, dht, clusterCfg, store, consensus, apis, ipfs, tracker, mon, alloc, []Informer{inf}, tracer, inf.Name())
+	cl, err := NewCluster(context.Background(), host, dht, clusterCfg, store, consensus, apis, ipfs, tracker, mon, alloc, []Informer{inf}, tracer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func waitForClustersHealthy(t *testing.T, clusters []*Cluster) {
 	timer := time.NewTimer(15 * time.Second)
 	for {
 		ttlDelay()
-		metrics := clusters[0].monitor.LatestMetrics(context.Background(), clusters[0].preferredMetric)
+		metrics := clusters[0].monitor.LatestMetrics(context.Background(), clusters[0].informers[0].Name())
 		healthy := 0
 		for _, m := range metrics {
 			if !m.Expired() {

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -282,7 +282,7 @@ func makePinTracker(t *testing.T, pid peer.ID, mptCfg *maptracker.Config, sptCfg
 }
 
 func createCluster(t *testing.T, host host.Host, dht *dht.IpfsDHT, clusterCfg *Config, store ds.Datastore, consensus Consensus, apis []API, ipfs IPFSConnector, tracker PinTracker, mon PeerMonitor, alloc PinAllocator, inf Informer, tracer Tracer) *Cluster {
-	cl, err := NewCluster(context.Background(), host, dht, clusterCfg, store, consensus, apis, ipfs, tracker, mon, alloc, inf, tracer)
+	cl, err := NewCluster(context.Background(), host, dht, clusterCfg, store, consensus, apis, ipfs, tracker, mon, alloc, []Informer{inf}, tracer, inf.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func waitForClustersHealthy(t *testing.T, clusters []*Cluster) {
 	timer := time.NewTimer(15 * time.Second)
 	for {
 		ttlDelay()
-		metrics := clusters[0].monitor.LatestMetrics(context.Background(), clusters[0].informer.Name())
+		metrics := clusters[0].monitor.LatestMetrics(context.Background(), clusters[0].preferredMetric)
 		healthy := 0
 		for _, m := range metrics {
 			if !m.Expired() {

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -952,14 +952,14 @@ func (ipfs *Connector) updateInformerMetric(ctx context.Context) error {
 		return nil
 	}
 
-	var metric []*api.Metric
+	var metrics []*api.Metric
 	err := ipfs.rpcClient.GoContext(
 		ctx,
 		"",
 		"Cluster",
 		"SendAllInformerMetric",
 		struct{}{},
-		&metric,
+		&metrics,
 		nil,
 	)
 	if err != nil {

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -952,13 +952,12 @@ func (ipfs *Connector) updateInformerMetric(ctx context.Context) error {
 		return nil
 	}
 
-	var metric api.Metric
-
+	var metric []*api.Metric
 	err := ipfs.rpcClient.GoContext(
 		ctx,
 		"",
 		"Cluster",
-		"SendInformerMetric",
+		"SendAllInformerMetric",
 		struct{}{},
 		&metric,
 		nil,

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -957,7 +957,7 @@ func (ipfs *Connector) updateInformerMetric(ctx context.Context) error {
 		ctx,
 		"",
 		"Cluster",
-		"SendAllInformerMetric",
+		"SendInformersMetrics",
 		struct{}{},
 		&metrics,
 		nil,

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -448,18 +448,14 @@ func (rpcapi *ClusterRPCAPI) SendInformerMetric(ctx context.Context, in struct{}
 	return nil
 }
 
-// SendAllInformerMetric runs Cluster.sendInformerMetric() on all informers.
-func (rpcapi *ClusterRPCAPI) SendAllInformerMetric(ctx context.Context, in struct{}, out *[]*api.Metric) error {
+// SendInformersMetrics runs Cluster.sendInformerMetric() on all informers.
+func (rpcapi *ClusterRPCAPI) SendInformersMetrics(ctx context.Context, in struct{}, out *[]*api.Metric) error {
 	var metrics []*api.Metric
-	for _, informer := range rpcapi.c.informers {
-		m, err := rpcapi.c.sendInformerMetric(ctx, informer)
-		if err != nil {
-			return err
-		}
-		metrics = append(metrics, m)
+	metrics, err := rpcapi.c.sendInformersMetrics(ctx)
+	if err != nil {
+		return err
 	}
-
-	out = &metrics
+	*out = metrics
 	return nil
 }
 

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -2,7 +2,6 @@ package ipfscluster
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/version"
@@ -441,18 +440,12 @@ func (rpcapi *ClusterRPCAPI) RepoGCLocal(ctx context.Context, in struct{}, out *
 
 // SendInformerMetric runs Cluster.sendInformerMetric().
 func (rpcapi *ClusterRPCAPI) SendInformerMetric(ctx context.Context, in struct{}, out *api.Metric) error {
-	for _, informer := range rpcapi.c.informers {
-		if informer.Name() == rpcapi.c.preferredMetric {
-			m, err := rpcapi.c.sendInformerMetric(ctx, informer)
-			if err != nil {
-				return err
-			}
-			*out = *m
-			return nil
-		}
+	m, err := rpcapi.c.sendInformerMetric(ctx, rpcapi.c.informers[0])
+	if err != nil {
+		return err
 	}
-
-	return errors.New("no informer available for preferred metric name")
+	*out = *m
+	return nil
 }
 
 // SendAllInformerMetric runs Cluster.sendInformerMetric() on all informers.

--- a/rpc_policy.go
+++ b/rpc_policy.go
@@ -7,35 +7,36 @@ package ipfscluster
 // without missing any endpoint.
 var DefaultRPCPolicy = map[string]RPCEndpointType{
 	// Cluster methods
-	"Cluster.BlockAllocate":      RPCClosed,
-	"Cluster.ConnectGraph":       RPCClosed,
-	"Cluster.ID":                 RPCOpen,
-	"Cluster.Join":               RPCClosed,
-	"Cluster.PeerAdd":            RPCOpen, // Used by Join()
-	"Cluster.PeerRemove":         RPCTrusted,
-	"Cluster.Peers":              RPCTrusted, // Used by ConnectGraph()
-	"Cluster.Pin":                RPCClosed,
-	"Cluster.PinGet":             RPCClosed,
-	"Cluster.PinPath":            RPCClosed,
-	"Cluster.Pins":               RPCClosed, // Used in stateless tracker, ipfsproxy, restapi
-	"Cluster.Recover":            RPCClosed,
-	"Cluster.RecoverAll":         RPCClosed,
-	"Cluster.RecoverAllLocal":    RPCTrusted,
-	"Cluster.RecoverLocal":       RPCTrusted,
-	"Cluster.RepoGC":             RPCClosed,
-	"Cluster.RepoGCLocal":        RPCTrusted,
-	"Cluster.SendInformerMetric": RPCClosed,
-	"Cluster.Status":             RPCClosed,
-	"Cluster.StatusAll":          RPCClosed,
-	"Cluster.StatusAllLocal":     RPCClosed,
-	"Cluster.StatusLocal":        RPCClosed,
-	"Cluster.Sync":               RPCClosed,
-	"Cluster.SyncAll":            RPCClosed,
-	"Cluster.SyncAllLocal":       RPCTrusted, // Called in broadcast from SyncAll()
-	"Cluster.SyncLocal":          RPCTrusted, // Called in broadcast from Sync()
-	"Cluster.Unpin":              RPCClosed,
-	"Cluster.UnpinPath":          RPCClosed,
-	"Cluster.Version":            RPCOpen,
+	"Cluster.BlockAllocate":         RPCClosed,
+	"Cluster.ConnectGraph":          RPCClosed,
+	"Cluster.ID":                    RPCOpen,
+	"Cluster.Join":                  RPCClosed,
+	"Cluster.PeerAdd":               RPCOpen, // Used by Join()
+	"Cluster.PeerRemove":            RPCTrusted,
+	"Cluster.Peers":                 RPCTrusted, // Used by ConnectGraph()
+	"Cluster.Pin":                   RPCClosed,
+	"Cluster.PinGet":                RPCClosed,
+	"Cluster.PinPath":               RPCClosed,
+	"Cluster.Pins":                  RPCClosed, // Used in stateless tracker, ipfsproxy, restapi
+	"Cluster.Recover":               RPCClosed,
+	"Cluster.RecoverAll":            RPCClosed,
+	"Cluster.RecoverAllLocal":       RPCTrusted,
+	"Cluster.RecoverLocal":          RPCTrusted,
+	"Cluster.RepoGC":                RPCClosed,
+	"Cluster.RepoGCLocal":           RPCTrusted,
+	"Cluster.SendInformerMetric":    RPCClosed,
+	"Cluster.SendAllInformerMetric": RPCClosed,
+	"Cluster.Status":                RPCClosed,
+	"Cluster.StatusAll":             RPCClosed,
+	"Cluster.StatusAllLocal":        RPCClosed,
+	"Cluster.StatusLocal":           RPCClosed,
+	"Cluster.Sync":                  RPCClosed,
+	"Cluster.SyncAll":               RPCClosed,
+	"Cluster.SyncAllLocal":          RPCTrusted, // Called in broadcast from SyncAll()
+	"Cluster.SyncLocal":             RPCTrusted, // Called in broadcast from Sync()
+	"Cluster.Unpin":                 RPCClosed,
+	"Cluster.UnpinPath":             RPCClosed,
+	"Cluster.Version":               RPCOpen,
 
 	// PinTracker methods
 	"PinTracker.Recover":    RPCTrusted, // Called in broadcast from Recover()

--- a/rpc_policy.go
+++ b/rpc_policy.go
@@ -7,36 +7,36 @@ package ipfscluster
 // without missing any endpoint.
 var DefaultRPCPolicy = map[string]RPCEndpointType{
 	// Cluster methods
-	"Cluster.BlockAllocate":         RPCClosed,
-	"Cluster.ConnectGraph":          RPCClosed,
-	"Cluster.ID":                    RPCOpen,
-	"Cluster.Join":                  RPCClosed,
-	"Cluster.PeerAdd":               RPCOpen, // Used by Join()
-	"Cluster.PeerRemove":            RPCTrusted,
-	"Cluster.Peers":                 RPCTrusted, // Used by ConnectGraph()
-	"Cluster.Pin":                   RPCClosed,
-	"Cluster.PinGet":                RPCClosed,
-	"Cluster.PinPath":               RPCClosed,
-	"Cluster.Pins":                  RPCClosed, // Used in stateless tracker, ipfsproxy, restapi
-	"Cluster.Recover":               RPCClosed,
-	"Cluster.RecoverAll":            RPCClosed,
-	"Cluster.RecoverAllLocal":       RPCTrusted,
-	"Cluster.RecoverLocal":          RPCTrusted,
-	"Cluster.RepoGC":                RPCClosed,
-	"Cluster.RepoGCLocal":           RPCTrusted,
-	"Cluster.SendInformerMetric":    RPCClosed,
-	"Cluster.SendAllInformerMetric": RPCClosed,
-	"Cluster.Status":                RPCClosed,
-	"Cluster.StatusAll":             RPCClosed,
-	"Cluster.StatusAllLocal":        RPCClosed,
-	"Cluster.StatusLocal":           RPCClosed,
-	"Cluster.Sync":                  RPCClosed,
-	"Cluster.SyncAll":               RPCClosed,
-	"Cluster.SyncAllLocal":          RPCTrusted, // Called in broadcast from SyncAll()
-	"Cluster.SyncLocal":             RPCTrusted, // Called in broadcast from Sync()
-	"Cluster.Unpin":                 RPCClosed,
-	"Cluster.UnpinPath":             RPCClosed,
-	"Cluster.Version":               RPCOpen,
+	"Cluster.BlockAllocate":        RPCClosed,
+	"Cluster.ConnectGraph":         RPCClosed,
+	"Cluster.ID":                   RPCOpen,
+	"Cluster.Join":                 RPCClosed,
+	"Cluster.PeerAdd":              RPCOpen, // Used by Join()
+	"Cluster.PeerRemove":           RPCTrusted,
+	"Cluster.Peers":                RPCTrusted, // Used by ConnectGraph()
+	"Cluster.Pin":                  RPCClosed,
+	"Cluster.PinGet":               RPCClosed,
+	"Cluster.PinPath":              RPCClosed,
+	"Cluster.Pins":                 RPCClosed, // Used in stateless tracker, ipfsproxy, restapi
+	"Cluster.Recover":              RPCClosed,
+	"Cluster.RecoverAll":           RPCClosed,
+	"Cluster.RecoverAllLocal":      RPCTrusted,
+	"Cluster.RecoverLocal":         RPCTrusted,
+	"Cluster.RepoGC":               RPCClosed,
+	"Cluster.RepoGCLocal":          RPCTrusted,
+	"Cluster.SendInformerMetric":   RPCClosed,
+	"Cluster.SendInformersMetrics": RPCClosed,
+	"Cluster.Status":               RPCClosed,
+	"Cluster.StatusAll":            RPCClosed,
+	"Cluster.StatusAllLocal":       RPCClosed,
+	"Cluster.StatusLocal":          RPCClosed,
+	"Cluster.Sync":                 RPCClosed,
+	"Cluster.SyncAll":              RPCClosed,
+	"Cluster.SyncAllLocal":         RPCTrusted, // Called in broadcast from SyncAll()
+	"Cluster.SyncLocal":            RPCTrusted, // Called in broadcast from Sync()
+	"Cluster.Unpin":                RPCClosed,
+	"Cluster.UnpinPath":            RPCClosed,
+	"Cluster.Version":              RPCOpen,
 
 	// PinTracker methods
 	"PinTracker.Recover":    RPCTrusted, // Called in broadcast from Recover()


### PR DESCRIPTION
- Cluster accepts multiple informer components
- function that expects only one informer component, will use a informer
which has name same as `Cluster.preferredMetric`
- Added rpc api for send all informer metrics

Fixes #940