### PR TITLE
Use index endpoint with a trailing slash

### DIFF
--- a/observations/setup.go
+++ b/observations/setup.go
@@ -113,7 +113,7 @@ func setupMetrics(cfg *MetricsConfig) error {
 		zpages.Handle(mux, "/debug")
 		mux.Handle("/metrics", pe)
 		mux.Handle("/debug/vars", expvar.Handler())
-		mux.HandleFunc("/debug/pprof", pprof.Index)
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
 		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)


### PR DESCRIPTION
On using `/debug/pprof` as index endpoint, profiles contained by it
would point to wrong url. For example, link for `allocs` would be
`/debug/allocs` (results in 404), whereas it should actually be
`/debug/pprof/allocs`.

Use a trailing slash to get correct links. `/debug/pprof` will
automatically be redirected to `/debug/pprof/`