### PR TITLE
config manager: Improve source-fetch error handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,9 @@ var logger = logging.Logger("config")
 
 var (
 	// Error when downloading a Source-based configuration
-	errFetchingSource = errors.New("could not fetch configuration source")
+	errFetchingSource = errors.New("could not fetch configuration from source")
+	// Error when remote source points to another remote-source
+	errSourceRedirect = errors.New("a sourced configuration cannot point to another source")
 )
 
 // IsErrFetchingSource reports whether this error happened when trying to
@@ -34,8 +36,6 @@ func IsErrFetchingSource(err error) bool {
 // ConfigSaveInterval specifies how often to save the configuration file if
 // it needs saving.
 var ConfigSaveInterval = time.Second
-
-var errSourceRedirect = errors.New("a sourced configuration cannot point to another source")
 
 // The ComponentConfig interface allows components to define configurations
 // which can be managed as part of the ipfs-cluster configuration file by the
@@ -149,9 +149,6 @@ func NewManager() *Manager {
 // Shutdown makes sure all configuration save operations are finished
 // before returning.
 func (cfg *Manager) Shutdown() {
-	if cfg == nil {
-		return
-	}
 	cfg.cancel()
 	cfg.wg.Wait()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -351,8 +351,7 @@ func (cfg *Manager) LoadJSONFromFile(path string) error {
 		return err
 	}
 
-	err = cfg.LoadJSON(file)
-	return err
+	return cfg.LoadJSON(file)
 }
 
 // LoadJSONFromHTTPSource reads a Configuration file from a URL and parses it.
@@ -361,7 +360,6 @@ func (cfg *Manager) LoadJSONFromHTTPSource(url string) error {
 	cfg.Source = url
 	resp, err := http.Get(url)
 	if err != nil {
-		logger.Error(err)
 		return errFetchingSource
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
* Allow detection of source-download errors by adding IsSourceDownloadError method.
* Treat non-success response codes as a failure to fetch the source.
* Set the Source url before errors happens so it can be consulted even in that case.