### PR TITLE
 Fix: stateless: cluster should pin items that are in the state but not on ipfs

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -614,10 +614,10 @@ This might be due to one or several causes:
 		c.Shutdown(ctx)
 		return
 	case <-c.consensus.Ready(ctx):
-		// Consensus ready means the state is up to date so we can sync
-		// it to the tracker. We ignore errors (normal when state
-		// doesn't exist in new peers).
-		c.StateSync(ctx)
+		// Consensus ready means the state is up to date. Every item
+		// in the state that is not pinned will appear as PinError so
+		// we can proceed to recover all of those in the tracker.
+		c.RecoverAllLocal(ctx)
 	case <-c.ctx.Done():
 		return
 	}
@@ -966,7 +966,8 @@ func (c *Cluster) Join(ctx context.Context, addr ma.Multiaddr) error {
 		return err
 	}
 
-	c.StateSync(ctx)
+	// Start pinning items in the state that are not on IPFS yet.
+	c.RecoverAllLocal(ctx)
 
 	logger.Infof("%s: joined %s's cluster", c.id.Pretty(), pid.Pretty())
 	return nil
@@ -1092,7 +1093,7 @@ func (c *Cluster) localPinInfoOp(
 
 }
 
-// RecoverAll triggers a RecoverAllLocal operation on all peer.
+// RecoverAll triggers a RecoverAllLocal operation on all peers.
 func (c *Cluster) RecoverAll(ctx context.Context) ([]*api.GlobalPinInfo, error) {
 	_, span := trace.StartSpan(ctx, "cluster/RecoverAll")
 	defer span.End()
@@ -1107,6 +1108,8 @@ func (c *Cluster) RecoverAll(ctx context.Context) ([]*api.GlobalPinInfo, error) 
 // Recover operations ask IPFS to pin or unpin items in error state. Recover
 // is faster than calling Pin on the same CID as it avoids committing an
 // identical pin to the consensus layer.
+//
+// RecoverAllLocal is called automatically every PinRecoverInterval.
 func (c *Cluster) RecoverAllLocal(ctx context.Context) ([]*api.PinInfo, error) {
 	_, span := trace.StartSpan(ctx, "cluster/RecoverAllLocal")
 	defer span.End()

--- a/cluster_config.go
+++ b/cluster_config.go
@@ -28,8 +28,8 @@ var DefaultListenAddrs = []string{"/ip4/0.0.0.0/tcp/9096", "/ip4/0.0.0.0/udp/909
 // Configuration defaults
 const (
 	DefaultEnableRelayHop      = true
-	DefaultStateSyncInterval   = 600 * time.Second
-	DefaultPinRecoverInterval  = 1 * time.Hour
+	DefaultStateSyncInterval   = 5 * time.Minute
+	DefaultPinRecoverInterval  = 5 * time.Minute
 	DefaultMonitorPingInterval = 15 * time.Second
 	DefaultPeerWatchInterval   = 5 * time.Second
 	DefaultReplicationFactor   = -1

--- a/cluster_config.go
+++ b/cluster_config.go
@@ -29,7 +29,7 @@ var DefaultListenAddrs = []string{"/ip4/0.0.0.0/tcp/9096", "/ip4/0.0.0.0/udp/909
 const (
 	DefaultEnableRelayHop      = true
 	DefaultStateSyncInterval   = 5 * time.Minute
-	DefaultPinRecoverInterval  = 5 * time.Minute
+	DefaultPinRecoverInterval  = 12 * time.Minute
 	DefaultMonitorPingInterval = 15 * time.Second
 	DefaultPeerWatchInterval   = 5 * time.Second
 	DefaultReplicationFactor   = -1

--- a/config_test.go
+++ b/config_test.go
@@ -31,6 +31,7 @@ var testingClusterCfg = []byte(`{
          "grace_period": "2m0s"
     },
     "state_sync_interval": "1m0s",
+    "pin_recover_interval": "1m0s",
     "replication_factor": -1,
     "monitor_ping_interval": "1s",
     "peer_watch_interval": "1s",

--- a/pintracker/stateless/stateless_test.go
+++ b/pintracker/stateless/stateless_test.go
@@ -20,17 +20,69 @@ import (
 var (
 	pinCancelCid      = test.Cid3
 	unpinCancelCid    = test.Cid2
-	ErrPinCancelCid   = errors.New("should not have received rpc.IPFSPin operation")
-	ErrUnpinCancelCid = errors.New("should not have received rpc.IPFSUnpin operation")
+	errPinCancelCid   = errors.New("should not have received rpc.IPFSPin operation")
+	errUnpinCancelCid = errors.New("should not have received rpc.IPFSUnpin operation")
 	pinOpts           = api.PinOptions{
 		ReplicationFactorMax: -1,
 		ReplicationFactorMin: -1,
 	}
 )
 
-type mockIPFS struct{}
+// func TestMain(m *testing.M) {
+// 	logging.SetLogLevel("pintracker", "debug")
 
-func mockRPCClient(t *testing.T) *rpc.Client {
+// 	os.Exit(m.Run())
+// }
+
+// Overwrite Pin and Unpin methods on the normal mock in order to return
+// special errors when unwanted operations have been triggered.
+type mockIPFS struct {
+}
+
+func (mock *mockIPFS) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
+	switch in.Cid {
+	case pinCancelCid:
+		return errPinCancelCid
+	case test.SlowCid1:
+		time.Sleep(time.Second)
+	}
+	return nil
+}
+
+func (mock *mockIPFS) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+	switch in.Cid {
+	case unpinCancelCid:
+		return errUnpinCancelCid
+	case test.SlowCid1:
+		time.Sleep(time.Second)
+	}
+	return nil
+}
+
+func (mock *mockIPFS) PinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
+	// Must be consistent with PinLsCid
+	m := map[string]api.IPFSPinStatus{
+		test.Cid1.String(): api.IPFSPinStatusRecursive,
+		test.Cid2.String(): api.IPFSPinStatusRecursive,
+	}
+	*out = m
+	return nil
+}
+
+func (mock *mockIPFS) PinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
+	switch in {
+	case test.Cid1, test.Cid2:
+		*out = api.IPFSPinStatusRecursive
+	default:
+		*out = api.IPFSPinStatusUnpinned
+		return nil
+	}
+	return nil
+}
+
+func mockRPCClient(t testing.TB) *rpc.Client {
+	t.Helper()
+
 	s := rpc.NewServer(nil, "mock")
 	c := rpc.NewClientWithServer(nil, "mock", s)
 
@@ -41,77 +93,35 @@ func mockRPCClient(t *testing.T) *rpc.Client {
 	return c
 }
 
-func (mock *mockIPFS) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
-	switch in.Cid.String() {
-	case test.SlowCid1.String():
-		time.Sleep(2 * time.Second)
-	case pinCancelCid.String():
-		return ErrPinCancelCid
+func getStateFunc(t testing.TB, items ...*api.Pin) func(context.Context) (state.ReadOnly, error) {
+	t.Helper()
+	ctx := context.Background()
+
+	st, err := dsstate.New(inmem.New(), "", dsstate.DefaultHandle())
+	if err != nil {
+		t.Fatal(err)
 	}
-	return nil
+
+	for _, item := range items {
+		err := st.Add(ctx, item)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return func(ctx context.Context) (state.ReadOnly, error) {
+		return st, nil
+	}
+
 }
 
-func (mock *mockIPFS) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
-	switch in.Cid.String() {
-	case test.SlowCid1.String():
-		time.Sleep(2 * time.Second)
-	case unpinCancelCid.String():
-		return ErrUnpinCancelCid
-	}
-	return nil
-}
-
-func (mock *mockIPFS) PinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
-	m := map[string]api.IPFSPinStatus{
-		test.Cid1.String(): api.IPFSPinStatusRecursive,
-	}
-	*out = m
-	return nil
-}
-
-func (mock *mockIPFS) PinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
-	switch in.String() {
-	case test.Cid1.String(), test.Cid2.String():
-		*out = api.IPFSPinStatusRecursive
-	default:
-		*out = api.IPFSPinStatusUnpinned
-	}
-	return nil
-}
-
-func testSlowStatelessPinTracker(t *testing.T) *Tracker {
+func testStatelessPinTracker(t testing.TB, pins ...*api.Pin) *Tracker {
 	t.Helper()
 
 	cfg := &Config{}
 	cfg.Default()
 	cfg.ConcurrentPins = 1
-	st, err := dsstate.New(inmem.New(), "", dsstate.DefaultHandle())
-	if err != nil {
-		t.Fatal(err)
-	}
-	getState := func(ctx context.Context) (state.ReadOnly, error) {
-		return st, nil
-	}
-	spt := New(cfg, test.PeerID1, test.PeerName1, getState)
+	spt := New(cfg, test.PeerID1, test.PeerName1, getStateFunc(t, pins...))
 	spt.SetClient(mockRPCClient(t))
-	return spt
-}
-
-func testStatelessPinTracker(t testing.TB) *Tracker {
-	t.Helper()
-
-	cfg := &Config{}
-	cfg.Default()
-	cfg.ConcurrentPins = 1
-	st, err := dsstate.New(inmem.New(), "", dsstate.DefaultHandle())
-	if err != nil {
-		t.Fatal(err)
-	}
-	getState := func(ctx context.Context) (state.ReadOnly, error) {
-		return st, nil
-	}
-	spt := New(cfg, test.PeerID1, test.PeerName1, getState)
-	spt.SetClient(test.NewMockRPCClient(t))
 	return spt
 }
 
@@ -159,7 +169,7 @@ func TestUntrackTrack(t *testing.T) {
 
 func TestTrackUntrackWithCancel(t *testing.T) {
 	ctx := context.Background()
-	spt := testSlowStatelessPinTracker(t)
+	spt := testStatelessPinTracker(t)
 	defer spt.Shutdown(ctx)
 
 	slowPinCid := test.SlowCid1
@@ -167,27 +177,27 @@ func TestTrackUntrackWithCancel(t *testing.T) {
 	// LocalPin
 	slowPin := api.PinWithOpts(slowPinCid, pinOpts)
 
-	err := spt.Track(context.Background(), slowPin)
+	err := spt.Track(ctx, slowPin)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(100 * time.Millisecond) // let pinning start
 
-	pInfo := spt.optracker.Get(context.Background(), slowPin.Cid)
+	pInfo := spt.optracker.Get(ctx, slowPin.Cid)
 	if pInfo.Status == api.TrackerStatusUnpinned {
 		t.Fatal("slowPin should be tracked")
 	}
 
 	if pInfo.Status == api.TrackerStatusPinning {
 		go func() {
-			err = spt.Untrack(context.Background(), slowPinCid)
+			err = spt.Untrack(ctx, slowPinCid)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}()
 		select {
-		case <-spt.optracker.OpContext(context.Background(), slowPinCid).Done():
+		case <-spt.optracker.OpContext(ctx, slowPinCid).Done():
 			return
 		case <-time.Tick(100 * time.Millisecond):
 			t.Errorf("operation context should have been cancelled by now")
@@ -204,7 +214,7 @@ func TestTrackUntrackWithCancel(t *testing.T) {
 // cancelling of the pinning operation happens (unlike on WithCancel).
 func TestTrackUntrackWithNoCancel(t *testing.T) {
 	ctx := context.Background()
-	spt := testSlowStatelessPinTracker(t)
+	spt := testStatelessPinTracker(t)
 	defer spt.Shutdown(ctx)
 
 	slowPinCid := test.SlowCid1
@@ -216,7 +226,7 @@ func TestTrackUntrackWithNoCancel(t *testing.T) {
 	// LocalPin
 	fastPin := api.PinWithOpts(fastPinCid, pinOpts)
 
-	err := spt.Track(context.Background(), slowPin)
+	err := spt.Track(ctx, slowPin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,18 +234,18 @@ func TestTrackUntrackWithNoCancel(t *testing.T) {
 	// Otherwise fails when running with -race
 	time.Sleep(300 * time.Millisecond)
 
-	err = spt.Track(context.Background(), fastPin)
+	err = spt.Track(ctx, fastPin)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// fastPin should be queued because slow pin is pinning
-	fastPInfo := spt.optracker.Get(context.Background(), fastPin.Cid)
+	fastPInfo := spt.optracker.Get(ctx, fastPin.Cid)
 	if fastPInfo.Status == api.TrackerStatusUnpinned {
 		t.Fatal("fastPin should be tracked")
 	}
 	if fastPInfo.Status == api.TrackerStatusPinQueued {
-		err = spt.Untrack(context.Background(), fastPinCid)
+		err = spt.Untrack(ctx, fastPinCid)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -247,7 +257,7 @@ func TestTrackUntrackWithNoCancel(t *testing.T) {
 		t.Errorf("fastPin should be queued to pin but is %s", fastPInfo.Status)
 	}
 
-	pi := spt.optracker.Get(context.Background(), fastPin.Cid)
+	pi := spt.optracker.Get(ctx, fastPin.Cid)
 	if pi.Cid == cid.Undef {
 		t.Error("fastPin should have been removed from tracker")
 	}
@@ -255,7 +265,7 @@ func TestTrackUntrackWithNoCancel(t *testing.T) {
 
 func TestUntrackTrackWithCancel(t *testing.T) {
 	ctx := context.Background()
-	spt := testSlowStatelessPinTracker(t)
+	spt := testStatelessPinTracker(t)
 	defer spt.Shutdown(ctx)
 
 	slowPinCid := test.SlowCid1
@@ -263,7 +273,7 @@ func TestUntrackTrackWithCancel(t *testing.T) {
 	// LocalPin
 	slowPin := api.PinWithOpts(slowPinCid, pinOpts)
 
-	err := spt.Track(context.Background(), slowPin)
+	err := spt.Track(ctx, slowPin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,27 +282,27 @@ func TestUntrackTrackWithCancel(t *testing.T) {
 
 	// Untrack should cancel the ongoing request
 	// and unpin right away
-	err = spt.Untrack(context.Background(), slowPinCid)
+	err = spt.Untrack(ctx, slowPinCid)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(100 * time.Millisecond)
 
-	pi := spt.optracker.Get(context.Background(), slowPin.Cid)
+	pi := spt.optracker.Get(ctx, slowPin.Cid)
 	if pi.Cid == cid.Undef {
 		t.Fatal("expected slowPin to be tracked")
 	}
 
 	if pi.Status == api.TrackerStatusUnpinning {
 		go func() {
-			err = spt.Track(context.Background(), slowPin)
+			err = spt.Track(ctx, slowPin)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}()
 		select {
-		case <-spt.optracker.OpContext(context.Background(), slowPinCid).Done():
+		case <-spt.optracker.OpContext(ctx, slowPinCid).Done():
 			return
 		case <-time.Tick(100 * time.Millisecond):
 			t.Errorf("operation context should have been cancelled by now")
@@ -317,35 +327,35 @@ func TestUntrackTrackWithNoCancel(t *testing.T) {
 	// LocalPin
 	fastPin := api.PinWithOpts(fastPinCid, pinOpts)
 
-	err := spt.Track(context.Background(), slowPin)
+	err := spt.Track(ctx, slowPin)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = spt.Track(context.Background(), fastPin)
+	err = spt.Track(ctx, fastPin)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(3 * time.Second)
 
-	err = spt.Untrack(context.Background(), slowPin.Cid)
+	err = spt.Untrack(ctx, slowPin.Cid)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = spt.Untrack(context.Background(), fastPin.Cid)
+	err = spt.Untrack(ctx, fastPin.Cid)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pi := spt.optracker.Get(context.Background(), fastPin.Cid)
+	pi := spt.optracker.Get(ctx, fastPin.Cid)
 	if pi.Cid == cid.Undef {
 		t.Fatal("c untrack operation should be tracked")
 	}
 
 	if pi.Status == api.TrackerStatusUnpinQueued {
-		err = spt.Track(context.Background(), fastPin)
+		err = spt.Track(ctx, fastPin)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -359,6 +369,102 @@ func TestUntrackTrackWithNoCancel(t *testing.T) {
 	}
 }
 
+// TestStatusAll checks that StatusAll correctly reports tracked
+// items and mismatches between what's on IPFS and on the state.
+func TestStatusAll(t *testing.T) {
+	ctx := context.Background()
+
+	normalPin := api.PinWithOpts(test.Cid1, pinOpts)
+	normalPin2 := api.PinWithOpts(test.Cid4, pinOpts)
+
+	// - Build a state with one pins (Cid1,Cid4)
+	// - The IPFS Mock reports Cid1 and Cid2
+	// - Track a SlowCid additionally
+
+	spt := testStatelessPinTracker(t, normalPin, normalPin2)
+	defer spt.Shutdown(ctx)
+
+	slowPin := api.PinWithOpts(test.SlowCid1, pinOpts)
+	err := spt.Track(ctx, slowPin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second / 2)
+
+	// Needs to return:
+	// * A slow CID pinning
+	// * Cid1 is pinned
+	// * Cid4 should be in PinError (it's in the state but not on IPFS)
+	stAll := spt.StatusAll(ctx)
+	if len(stAll) != 3 {
+		t.Errorf("wrong status length. Expected 3, got: %d", len(stAll))
+	}
+
+	for _, pi := range stAll {
+		switch pi.Cid {
+		case test.Cid1:
+			if pi.Status != api.TrackerStatusPinned {
+				t.Error("cid1 should be pinned")
+			}
+		case test.Cid4:
+			if pi.Status != api.TrackerStatusPinError {
+				t.Error("cid2 should be in pin_error status")
+			}
+		case test.SlowCid1:
+			if pi.Status != api.TrackerStatusPinning {
+				t.Error("slowCid1 should be pinning")
+			}
+		default:
+			t.Error("Unexpected pin:", pi.Cid)
+		}
+	}
+}
+
+// TestStatus checks that the Status calls correctly reports tracked
+// items and mismatches between what's on IPFS and on the state.
+func TestStatus(t *testing.T) {
+	ctx := context.Background()
+
+	normalPin := api.PinWithOpts(test.Cid1, pinOpts)
+	normalPin2 := api.PinWithOpts(test.Cid4, pinOpts)
+
+	// - Build a state with one pins (Cid1,Cid4)
+	// - The IPFS Mock reports Cid1 and Cid2
+	// - Track a SlowCid additionally
+
+	spt := testStatelessPinTracker(t, normalPin, normalPin2)
+	defer spt.Shutdown(ctx)
+
+	slowPin := api.PinWithOpts(test.SlowCid1, pinOpts)
+	err := spt.Track(ctx, slowPin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second / 2)
+
+	// Status needs to return:
+	// * For slowCid1: A slow CID pinning
+	// * For Cid1: pinned
+	// * For Cid4: pin error
+
+	st := spt.Status(ctx, test.Cid1)
+	if st.Status != api.TrackerStatusPinned {
+		t.Error("cid1 should be pinned")
+	}
+
+	st = spt.Status(ctx, test.Cid4)
+	if st.Status != api.TrackerStatusPinError {
+		t.Error("cid2 should be in pin_error status")
+	}
+
+	st = spt.Status(ctx, test.SlowCid1)
+	if st.Status != api.TrackerStatusPinning {
+		t.Error("slowCid1 should be pinning")
+	}
+}
+
 var sortPinInfoByCid = func(p []*api.PinInfo) {
 	sort.Slice(p, func(i, j int) bool {
 		return p[i].Cid.String() < p[j].Cid.String()
@@ -367,8 +473,9 @@ var sortPinInfoByCid = func(p []*api.PinInfo) {
 
 func BenchmarkTracker_localStatus(b *testing.B) {
 	tracker := testStatelessPinTracker(b)
+	ctx := context.Background()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tracker.localStatus(context.Background(), true)
+		tracker.localStatus(ctx, true)
 	}
 }

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -432,10 +432,18 @@ func (mock *mockPeerMonitor) MetricNames(ctx context.Context, in struct{}, out *
 /* IPFSConnector methods */
 
 func (mock *mockIPFSConnector) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
+	switch in.Cid {
+	case SlowCid1:
+		time.Sleep(2 * time.Second)
+	}
 	return nil
 }
 
 func (mock *mockIPFSConnector) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+	switch in.Cid {
+	case SlowCid1:
+		time.Sleep(2 * time.Second)
+	}
 	return nil
 }
 


### PR DESCRIPTION
StateSync() used to take care of this by issuing Track() calls. But this
functionality was removed.

This starts returning items that are in the state but not on IPFS as
PIN_ERRORs. It ensures that the Recover methods see them so that they can
trigger repinnings for missing items. This covers cases where the user
modifies the ipfs state manually, or resets the ipfs daemon but keeps the
cluster state, and cases where cluster was stopped half-way through a pinning.