### PR TITLE
Added Announce/NoAnnounce/FilterAddrs swarm options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/libp2p/go-libp2p-raft v0.1.4
 	github.com/libp2p/go-libp2p-secio v0.2.1
 	github.com/libp2p/go-libp2p-tls v0.1.2
+	github.com/libp2p/go-maddr-filter v0.0.5
 	github.com/libp2p/go-ws-transport v0.1.2
 	github.com/multiformats/go-multiaddr v0.1.2
 	github.com/multiformats/go-multiaddr-dns v0.2.0
@@ -72,6 +73,7 @@ require (
 	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926
 	github.com/ugorji/go/codec v1.1.7
 	github.com/urfave/cli v1.22.1
+	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 	go.opencensus.io v0.22.1
 	golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd
 	gonum.org/v1/gonum v0.0.0-20190926113837-94b2bbd8ac13

--- a/util.go
+++ b/util.go
@@ -166,3 +166,26 @@ func peersSubtract(a []peer.ID, b []peer.ID) []peer.ID {
 
 	return result
 }
+
+func toMultiAddrs(addrs []string) ([]ma.Multiaddr, error) {
+	var mAddrs []ma.Multiaddr
+	for _, addr := range addrs {
+		mAddr, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			//err = fmt.Errorf("error parsing a listen_multiaddress: %s", err)
+			return nil, err
+		}
+		mAddrs = append(mAddrs, mAddr)
+	}
+
+	return mAddrs, nil
+}
+
+func multiAddrstoStrings(mAddrs []ma.Multiaddr) []string {
+	var addrs []string
+	for _, addr := range mAddrs {
+		addrs = append(addrs, addr.String())
+	}
+
+	return addrs
+}

--- a/util.go
+++ b/util.go
@@ -172,7 +172,7 @@ func toMultiAddrs(addrs []string) ([]ma.Multiaddr, error) {
 	for _, addr := range addrs {
 		mAddr, err := ma.NewMultiaddr(addr)
 		if err != nil {
-			//err = fmt.Errorf("error parsing a listen_multiaddress: %s", err)
+			
 			return nil, err
 		}
 		mAddrs = append(mAddrs, mAddr)


### PR DESCRIPTION
Same as corresponding IPFS Options
announce - the swarm addresses to announce to the network
no_announce - swarm addresses not to announce to the network
addrs_filters - addresses (multiaddr netmasks) to not dial

Fixes #952 

Code inspired/copied from https://github.com/ipfs/go-ipfs/blob/master/core/node/libp2p/addrs.go
I guess that should be fine because these options are same as IPFS and IPFS functions used to set this options cannot be reused nicely in cluster since those functions return `func() (opts Libp2pOpts, err error) ` instead of the options.