### PR TITLE
cluster config: initialize peer addresses to [] rather than null.

### DIFF
--- a/cluster_config.go
+++ b/cluster_config.go
@@ -497,6 +497,7 @@ func (cfg *Config) toConfigJSON() (jcfg *configJSON, err error) {
 	jcfg.MDNSInterval = cfg.MDNSInterval.String()
 	jcfg.DisableRepinning = cfg.DisableRepinning
 	jcfg.PeerstoreFile = cfg.PeerstoreFile
+	jcfg.PeerAddresses = []string{}
 	for _, addr := range cfg.PeerAddresses {
 		jcfg.PeerAddresses = append(jcfg.PeerAddresses, addr.String())
 	}


### PR DESCRIPTION
User should see this is an array.