### PR TITLE
add ipv6 listening addresses to the default config

### DIFF
--- a/cluster_config.go
+++ b/cluster_config.go
@@ -23,7 +23,7 @@ import (
 const configKey = "cluster"
 
 // DefaultListenAddrs contains TCP and QUIC listen addresses
-var DefaultListenAddrs = []string{"/ip4/0.0.0.0/tcp/9096", "/ip4/0.0.0.0/udp/9096/quic"}
+var DefaultListenAddrs = []string{"/ip4/0.0.0.0/tcp/9096", "/ip4/0.0.0.0/udp/9096/quic", "/ip6/::/tcp/9096", "/ip6/::/udp/9096/quic"}
 
 // Configuration defaults
 const (

--- a/cmd/ipfs-cluster-service/main_test.go
+++ b/cmd/ipfs-cluster-service/main_test.go
@@ -11,6 +11,8 @@ import (
 func TestRandomPorts(t *testing.T) {
 	m1, _ := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/9096")
 	m2, _ := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/9096")
+	m3, _ := ma.NewMultiaddr("/ip6/::/tcp/9096")
+	m4, _ := ma.NewMultiaddr("/ip6/::/tcp/9096")
 
 	m1, err := cmdutils.RandomizePorts(m1)
 	if err != nil {
@@ -28,6 +30,25 @@ func TestRandomPorts(t *testing.T) {
 	}
 
 	if v1 == v2 {
-		t.Error("expected different ports")
+		t.Error("expected different ipv4 ports")
+	}
+
+	m3, err := cmdutils.RandomizePorts(m3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v3, err := m3.ValueForProtocol(ma.P_TCP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v4, err := m4.ValueForProtocol(ma.P_TCP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v3 == v4 {
+		t.Error("expected different ipv6 ports")
 	}
 }

--- a/sharness/config/basic_auth/service.json
+++ b/sharness/config/basic_auth/service.json
@@ -3,7 +3,10 @@
     "peername": "testname",
     "secret": "84399cd0be811c2ca372d6ca473ffd73c09034f991c5e306fe9ada6c5fcfb641",
     "leave_on_shutdown": false,
-    "listen_multiaddress": "/ip4/0.0.0.0/tcp/9096",
+    "listen_multiaddress": [
+      "/ip4/0.0.0.0/tcp/9096",
+      "/ip6/::/tcp/9096"
+    ],
     "state_sync_interval": "1m0s",
     "replication_factor": -1,
     "monitor_ping_interval": "15s"

--- a/sharness/config/ssl-basic_auth/service.json
+++ b/sharness/config/ssl-basic_auth/service.json
@@ -3,7 +3,10 @@
     "peername": "testname",
     "secret": "84399cd0be811c2ca372d6ca473ffd73c09034f991c5e306fe9ada6c5fcfb641",
     "leave_on_shutdown": false,
-    "listen_multiaddress": "/ip4/0.0.0.0/tcp/9096",
+    "listen_multiaddress": [
+      "/ip4/0.0.0.0/tcp/9096",
+      "/ip6/::/tcp/9096"
+    ],
     "state_sync_interval": "1m0s",
     "replication_factor": -1,
     "monitor_ping_interval": "15s"

--- a/sharness/config/ssl/service.json
+++ b/sharness/config/ssl/service.json
@@ -5,7 +5,10 @@
       "private_key": "CAASqAkwggSkAgEAAoIBAQC/ZmfWDbwyI0nJdRxgHcTdEaBFQo8sky9E+OOvtwZa5WKoLdHyHOLWxCAdpIHUBbhxz5rkMEWLwPI6ykqLIJToMPO8lJbKVzphOjv4JwpiAPdmeSiYMKLjx5V8MpqU2rwj/Uf3sRL8Gg9/Tei3PZ8cftxN1rkQQeeaOtk0CBxUFZSHEsyut1fbgIeL7TAY+4vCmXW0DBr4wh9fnoES/YivOvSiN9rScgWg6N65LfkI78hzaOJ4Nok2S4vYFCxjTAI9NWFUbhP5eJIFzTU+bZuQZxOn2qsoyw8pNZwuF+JClA/RcgBcCvVZcDH2ueVq/zT++bGCN+EWsAEdvJqJ5bsjAgMBAAECggEAaGDUZ6t94mnUJ4UyQEh7v4OJP7wYkFqEAL0qjfzl/lPyBX1XbQ3Ltwul6AR6uMGV4JszARZCFwDWGLGRDWZrTmTDxyfRQ+9l6vfzFFVWGDQmtz+Dn9uGOWnyX5TJMDxJNec+hBmRHOKpaOd37dYxGz0jr19V9UO7piRJp1J1AHUCypUGv5x1IekioSCu5fEyc7dyWwnmITHBjD08st+bCcjrIUFeXSdJKC8SymYeXdaVE3xH3zVEISKnrfT7bhuKZY1iibZIlXbVLNpyX36LkYJOiCqsMum3u70LH0VvTypkqiDbD4S6qfJ4vvUakpmKpOPutikiP7jkSP+AkaO0AQKBgQDkTuhnDK6+Y0a/HgpHJisji0coO+g2gsIszargHk8nNY2AB8t+EUn7C+Qu8cmrem5V8EXcdxS6z7iAXpJmY1Xepnsz+JP7Q91Lgt3OoqK5EybzUXXKkmNCD65n70Xxn2fEFzm6+GJP3c/HymlDKU2KBCYIyuUeaREjT0Fu3v6tgQKBgQDWnXppJwn4LJHhzFOCeO4zomDJDbLTZCabdKZoFP9r+vtEHAnclDDKx4AYbomSqgERe+DX6HR/tPHRVizP63RYPf7al2mJmPzt1nTkoc1/q5hQoD+oE154dADsW1pUp7AQjwCtys4iq5S0qAwIDpuY8M8bOHwZ+QmBvHYAigJCowKBgQC3HH6TX/2rH463bE2MARXqXSPGJj45sigwrQfW1xhe9zm1LQtN4mn2mvP5nt1D1l82OA6gIzYSGtX8x10eF5/ggqAf78goZ6bOkHh76b8fNzgvQO97eGt5qYAVRjhP8azU/lfEGMEpE1s5/6LrRe41utwSg0C+YkBnlIKDfQDAgQKBgDoBTCF5hK9H1JHzuKpt5uubuo78ndWWnvyrNYKyEirsJddNwLiWcO2NqChyT8qNGkbQdX/Fex89F5KduPTlTYfAEc6g18xxxgK+UM+uj60vArbf6PSTb5gculcnha2VuPdwvx050Cb8uu9s7/uJfzKB+2f/B0O51ID1H+ubYWsDAoGBAKrwGKHyqFTHSPg3XuRA1FgDAoOsfzP9ZJvMEXUWyu/VxjNt+0mRlyGeZ5qb9UZG+K/In4FbC/ux2P/PucCUIbgy/XGPtPXVavMwNbx0MquAcU0FihKXP0CUpi8zwiYc42MF7n/SztQnismxigBMSuJEDurcXXazjfcSRTypduNn",
     "secret": "84399cd0be811c2ca372d6ca473ffd73c09034f991c5e306fe9ada6c5fcfb641",
     "leave_on_shutdown": false,
-    "listen_multiaddress": "/ip4/0.0.0.0/tcp/9096",
+    "listen_multiaddress": [
+      "/ip4/0.0.0.0/tcp/9096",
+      "/ip6/::/tcp/9096"
+    ],
     "state_sync_interval": "1m0s",
     "replication_factor": -1,
     "monitor_ping_interval": "15s"

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -180,6 +180,7 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 			ID: PeerID1.Pretty(),
 			Addresses: []string{
 				"/ip4/0.0.0.0/tcp/1234",
+				"/ip6/::/tcp/1234",
 			},
 		}
 		j, _ := json.Marshal(resp)


### PR DESCRIPTION
Fixes https://github.com/ipfs/ipfs-cluster/issues/1000

@hsanjuan on ```Dockerfile-test``` and ```docker/start-daemons.sh``` I'm not sure how the syntax works. I really don't want to break things ;)

Since I don't know no go, take the change on ```cmd/ipfs-cluster-service/main_test.go``` also with a grain of salt.