### PR TITLE
Fix #1012: Trim paths on Makefile builds

### DIFF
--- a/cmd/ipfs-cluster-ctl/Makefile
+++ b/cmd/ipfs-cluster-ctl/Makefile
@@ -1,15 +1,17 @@
 # go source files
-SRC := $(shell find .. -type f -name '*.go')
+SRC := $(shell find ../.. -type f -name '*.go')
+GOPATH := $(shell go env GOPATH)
+GOFLAGS := "-asmflags=all='-trimpath=$(GOPATH)'" "-gcflags=all='-trimpath=$(GOPATH)'"
 
 all: ipfs-cluster-ctl
 
 ipfs-cluster-ctl: $(SRC)
-	go build -mod=readonly
+	go build $(GOFLAGS) -mod=readonly
 
 build: ipfs-cluster-ctl
 
 install:
-	go install
+	go install $(GOFLAGS)
 
 clean:
 	rm -f ipfs-cluster-ctl

--- a/cmd/ipfs-cluster-follow/Makefile
+++ b/cmd/ipfs-cluster-follow/Makefile
@@ -1,15 +1,17 @@
 # go source files
-SRC := $(shell find .. -type f -name '*.go')
+SRC := $(shell find ../.. -type f -name '*.go')
+GOPATH := $(shell go env GOPATH)
+GOFLAGS := "-asmflags=all='-trimpath=$(GOPATH)'" "-gcflags=all='-trimpath=$(GOPATH)'"
 
 all: ipfs-cluster-follow
 
 ipfs-cluster-follow: $(SRC)
-	go build -mod=readonly -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
+	go build $(GOFLAGS) -mod=readonly -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
 
 build: ipfs-cluster-follow
 
 install:
-	go install -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
+	go install $(GOFLAGS) -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
 
 clean:
 	rm -f ipfs-cluster-follow

--- a/cmd/ipfs-cluster-service/Makefile
+++ b/cmd/ipfs-cluster-service/Makefile
@@ -1,15 +1,17 @@
 # go source files
-SRC := $(shell find .. -type f -name '*.go')
+SRC := $(shell find ../.. -type f -name '*.go')
+GOPATH := $(shell go env GOPATH)
+GOFLAGS := "-asmflags=all='-trimpath=$(GOPATH)'" "-gcflags=all='-trimpath=$(GOPATH)'"
 
 all: ipfs-cluster-service
 
 ipfs-cluster-service: $(SRC)
-	go build -mod=readonly -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
+	go build $(GOFLAGS) -mod=readonly -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
 
 build: ipfs-cluster-service
 
 install:
-	go install -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
+	go install $(GOFLAGS) -ldflags "-X main.commit=$(shell git rev-parse HEAD)"
 
 clean:
 	rm -f ipfs-cluster-service


### PR DESCRIPTION
This results in more reproduceable builds.

Additionally, sources command to list all go-files and not just those
one directory below.