### PR TITLE
Fixes #998 Added object expiry time to pin ls cmd.

### DIFF
--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -178,7 +178,7 @@ func textFormatPrintVersion(obj *api.Version) {
 }
 
 func textFormatPrintPin(obj *api.Pin) {
-	fmt.Printf("%s | %s | %s | ", obj.Cid, obj.Name, strings.ToUpper(obj.Type.String()))
+	fmt.Printf("%s | %s | %s | %s | ", obj.Cid, obj.Name, strings.ToUpper(obj.Type.String()), obj.ExpireAt.String())
 
 	if obj.ReplicationFactorMin < 0 {
 		fmt.Printf("Repl. Factor: -1 | Allocations: [everywhere]")


### PR DESCRIPTION
Tested manually by firing an ipfs-cluster and building the ctl tool