### PR TITLE
Fixes #996 pin expiry is updated if set in options

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1496,7 +1496,9 @@ func (c *Cluster) PinUpdate(ctx context.Context, from cid.Cid, to cid.Cid, opts 
 	if opts.Name != "" {
 		existing.Name = opts.Name
 	}
-
+	if !opts.ExpireAt.IsZero() && opts.ExpireAt.After(time.Now()) {
+		existing.ExpireAt = opts.ExpireAt
+	}
 	return existing, c.consensus.LogPin(ctx, existing)
 }
 

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -736,11 +736,12 @@ func TestClustersPinUpdate(t *testing.T) {
 	}
 
 	pinDelay()
-
+	expiry := time.Now().AddDate(1, 0, 0)
 	opts2 := api.PinOptions{
 		UserAllocations: []peer.ID{clusters[0].host.ID()}, // should not be used
 		PinUpdate:       h,
 		Name:            "new name",
+		ExpireAt:        expiry,
 	}
 
 	_, err = clusters[0].Pin(ctx, h2, opts2) // should call PinUpdate
@@ -762,6 +763,10 @@ func TestClustersPinUpdate(t *testing.T) {
 
 		if pinget.MaxDepth != -1 {
 			t.Error("updated pin should be recursive like pin1")
+		}
+		if pinget.ExpireAt != expiry {
+			t.Errorf("Expiry time didn't match. Expected: %s. Got: %s",
+				expiry.String(), pinget.ExpireAt.String())
 		}
 
 		if pinget.Name != "new name" {

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -764,8 +764,9 @@ func TestClustersPinUpdate(t *testing.T) {
 		if pinget.MaxDepth != -1 {
 			t.Error("updated pin should be recursive like pin1")
 		}
+		expiry = expiry.Round(2 * time.Second)
 		if pinget.ExpireAt != expiry {
-			t.Errorf("Expiry time didn't match. Expected: %s. Got: %s",
+			t.Errorf("Expiry didn't match. Expected: %s. Got: %s",
 				expiry.String(), pinget.ExpireAt.String())
 		}
 


### PR DESCRIPTION
Running `$ go test `in ipfs-cluster repo shows the following error:
```
23:39:46.480 ERROR     engine: datastore closed engine.go:291
23:39:46.481 ERROR     engine: datastore closed engine.go:291
```
Am I missing a step ?