### PR TITLE
Fix #1009: support pinning in direct mode

### DIFF
--- a/adder/sharding/dag_service.go
+++ b/adder/sharding/dag_service.go
@@ -52,6 +52,8 @@ type DAGService struct {
 // New returns a new ClusterDAGService, which uses the given rpc client to perform
 // Allocate, IPFSBlockPut and Pin requests to other cluster components.
 func New(rpc *rpc.Client, opts api.PinOptions, out chan<- *api.AddedOutput) *DAGService {
+	// use a default value for this regardless of what is provided.
+	opts.Mode = api.PinModeRecursive
 	return &DAGService{
 		rpcClient: rpc,
 		pinOpts:   opts,

--- a/adder/single/dag_service.go
+++ b/adder/single/dag_service.go
@@ -36,6 +36,8 @@ type DAGService struct {
 // New returns a new Adder with the given rpc Client. The client is used
 // to perform calls to IPFS.BlockPut and Pin content on Cluster.
 func New(rpc *rpc.Client, opts api.PinOptions, local bool) *DAGService {
+	// ensure don't Add something and pin it in direct mode.
+	opts.Mode = api.PinModeRecursive
 	return &DAGService{
 		rpcClient: rpc,
 		dests:     nil,

--- a/allocate.go
+++ b/allocate.go
@@ -47,7 +47,7 @@ import (
 // into account if the given CID was previously in a "pin everywhere" mode,
 // and will consider such Pins as currently unallocated ones, providing
 // new allocations as available.
-func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, rplMin, rplMax int, blacklist []peer.ID, prioritylist []peer.ID) ([]peer.ID, error) {
+func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, currentPin *api.Pin, rplMin, rplMax int, blacklist []peer.ID, prioritylist []peer.ID) ([]peer.ID, error) {
 	ctx, span := trace.StartSpan(ctx, "cluster/allocate")
 	defer span.End()
 
@@ -61,8 +61,7 @@ func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, rplMin, rplMax int
 
 	// Figure out who is holding the CID
 	var currentAllocs []peer.ID
-	currentPin, err := c.PinGet(ctx, hash)
-	if err == nil {
+	if currentPin != nil {
 		currentAllocs = currentPin.Allocations
 	}
 	metrics := c.monitor.LatestMetrics(ctx, c.informers[0].Name())

--- a/api/add.go
+++ b/api/add.go
@@ -61,6 +61,7 @@ func DefaultAddParams() *AddParams {
 			ReplicationFactorMin: 0,
 			ReplicationFactorMax: 0,
 			Name:                 "",
+			Mode:                 PinModeRecursive,
 			ShardSize:            DefaultShardSize,
 			Metadata:             make(map[string]string),
 		},

--- a/api/ipfsproxy/ipfsproxy.go
+++ b/api/ipfsproxy/ipfsproxy.go
@@ -345,7 +345,8 @@ func ipfsErrorResponder(w http.ResponseWriter, errMsg string, code int) {
 func (proxy *Server) pinOpHandler(op string, w http.ResponseWriter, r *http.Request) {
 	proxy.setHeaders(w.Header(), r)
 
-	arg := r.URL.Query().Get("arg")
+	q := r.URL.Query()
+	arg := q.Get("arg")
 	p, err := path.ParsePath(arg)
 	if err != nil {
 		ipfsErrorResponder(w, "Error parsing IPFS Path: "+err.Error(), -1)
@@ -353,6 +354,8 @@ func (proxy *Server) pinOpHandler(op string, w http.ResponseWriter, r *http.Requ
 	}
 
 	pinPath := &api.PinPath{Path: p.String()}
+	pinPath.Mode = api.PinModeFromString(q.Get("type"))
+
 	var pin api.Pin
 	err = proxy.rpcClient.Call(
 		"",

--- a/api/pb/types.proto
+++ b/api/pb/types.proto
@@ -4,7 +4,6 @@ package api.pb;
 option go_package=".;pb";
 
 message Pin {
-  bytes Cid = 1;
   enum PinType {
     BadType = 0; // 1 << iota
     DataType = 1; // 2 << iota
@@ -12,6 +11,8 @@ message Pin {
     ClusterDAGType = 3;
     ShardType = 4;
   }
+
+  bytes Cid = 1;
   PinType Type = 2;
   repeated bytes Allocations = 3;
   sint32 MaxDepth = 4;

--- a/cluster.go
+++ b/cluster.go
@@ -1308,8 +1308,8 @@ func checkPinType(pin *api.Pin) error {
 
 // setupPin ensures that the Pin object is fit for pinning. We check
 // and set the replication factors and ensure that the pinType matches the
-// metadata consistently.
-func (c *Cluster) setupPin(ctx context.Context, pin *api.Pin) error {
+// metadata consistently. Returns the existing Pin object for this Cid if it exists.
+func (c *Cluster) setupPin(ctx context.Context, pin, existing *api.Pin) error {
 	ctx, span := trace.StartSpan(ctx, "cluster/setupPin")
 	defer span.End()
 
@@ -1322,16 +1322,22 @@ func (c *Cluster) setupPin(ctx context.Context, pin *api.Pin) error {
 		return errors.New("pin.ExpireAt set before current time")
 	}
 
-	existing, err := c.PinGet(ctx, pin.Cid)
-	if err != nil && err != state.ErrNotFound {
-		return err
+	if existing == nil {
+		return nil
 	}
 
-	if existing != nil && existing.Type != pin.Type {
+	// If an pin CID is already pin, we do a couple more checks
+	if existing.Type != pin.Type {
 		msg := "cannot repin CID with different tracking method, "
 		msg += "clear state with pin rm to proceed. "
 		msg += "New: %s. Was: %s"
 		return fmt.Errorf(msg, pin.Type, existing.Type)
+	}
+
+	if existing.Mode == api.PinModeRecursive && pin.Mode != api.PinModeRecursive {
+		msg := "cannot repin a CID which is already pinned in "
+		msg += "recursive mode (new pin is pinned as %s). Unpin it first."
+		return fmt.Errorf(msg, pin.Mode)
 	}
 
 	return checkPinType(pin)
@@ -1365,8 +1371,13 @@ func (c *Cluster) pin(
 		return pin, true, err
 	}
 
+	existing, err := c.PinGet(ctx, pin.Cid)
+	if err != nil && err != state.ErrNotFound {
+		return pin, false, err
+	}
+
 	// setup pin might produce some side-effects to our pin
-	err := c.setupPin(ctx, pin)
+	err = c.setupPin(ctx, pin, existing)
 	if err != nil {
 		return pin, false, err
 	}
@@ -1379,8 +1390,7 @@ func (c *Cluster) pin(
 	// pins to the consensus layer even if they are, this should trigger the
 	// pin tracker and allows users to get re-pin operations by re-adding
 	// without having to use recover, which is naturally expected.
-	existing, err := c.PinGet(ctx, pin.Cid)
-	if err == nil &&
+	if existing != nil &&
 		pin.PinOptions.Equals(&existing.PinOptions) &&
 		len(blacklist) == 0 {
 		pin = existing
@@ -1396,6 +1406,7 @@ func (c *Cluster) pin(
 		allocs, err := c.allocate(
 			ctx,
 			pin.Cid,
+			existing,
 			pin.ReplicationFactorMin,
 			pin.ReplicationFactorMax,
 			blacklist,

--- a/cluster.go
+++ b/cluster.go
@@ -1308,7 +1308,7 @@ func checkPinType(pin *api.Pin) error {
 
 // setupPin ensures that the Pin object is fit for pinning. We check
 // and set the replication factors and ensure that the pinType matches the
-// metadata consistently. Returns the existing Pin object for this Cid if it exists.
+// metadata consistently.
 func (c *Cluster) setupPin(ctx context.Context, pin, existing *api.Pin) error {
 	ctx, span := trace.StartSpan(ctx, "cluster/setupPin")
 	defer span.End()

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -71,8 +71,8 @@ func (ipfs *mockConnector) Unpin(ctx context.Context, c cid.Cid) error {
 	return nil
 }
 
-func (ipfs *mockConnector) PinLsCid(ctx context.Context, c cid.Cid) (api.IPFSPinStatus, error) {
-	dI, ok := ipfs.pins.Load(c.String())
+func (ipfs *mockConnector) PinLsCid(ctx context.Context, pin *api.Pin) (api.IPFSPinStatus, error) {
+	dI, ok := ipfs.pins.Load(pin.Cid.String())
 	if !ok {
 		return api.IPFSPinStatusUnpinned, nil
 	}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -76,7 +76,7 @@ func (ipfs *mockConnector) PinLsCid(ctx context.Context, pin *api.Pin) (api.IPFS
 	if !ok {
 		return api.IPFSPinStatusUnpinned, nil
 	}
-	depth := dI.(int)
+	depth := dI.(api.PinDepth)
 	if depth == 0 {
 		return api.IPFSPinStatusDirect, nil
 	}
@@ -87,7 +87,7 @@ func (ipfs *mockConnector) PinLs(ctx context.Context, filter string) (map[string
 	m := make(map[string]api.IPFSPinStatus)
 	var st api.IPFSPinStatus
 	ipfs.pins.Range(func(k, v interface{}) bool {
-		switch v.(int) {
+		switch v.(api.PinDepth) {
 		case 0:
 			st = api.IPFSPinStatusDirect
 		default:
@@ -477,7 +477,7 @@ func TestUnpinShard(t *testing.T) {
 				t.Errorf("%s should have been unpinned but is %s", c, st.Status)
 			}
 
-			st2, err := cl.ipfs.PinLsCid(context.Background(), c)
+			st2, err := cl.ipfs.PinLsCid(context.Background(), api.PinCid(c))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -167,7 +167,12 @@ func textFormatPrintVersion(obj *api.Version) {
 }
 
 func textFormatPrintPin(obj *api.Pin) {
-	fmt.Printf("%s | %s | %s | ", obj.Cid, obj.Name, strings.ToUpper(obj.Type.String()))
+	t := strings.ToUpper(obj.Type.String())
+	if obj.Mode == api.PinModeDirect {
+		t = t + "-DIRECT"
+	}
+
+	fmt.Printf("%s | %s | %s | ", obj.Cid, obj.Name, t)
 
 	if obj.ReplicationFactorMin < 0 {
 		fmt.Printf("Repl. Factor: -1 | Allocations: [everywhere]")

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -138,6 +138,7 @@ requires authorization. implies --https, which you can disable with --force-http
 
 		if c.Bool("debug") {
 			logging.SetLogLevel("cluster-ctl", "debug")
+			logging.SetLogLevel("apitypes", "debug")
 			cfg.LogLevel = "debug"
 			logger.Debug("debug level enabled")
 		}
@@ -546,6 +547,11 @@ would stil be respected.
 							Usage: "Sets a name for this pin",
 						},
 						cli.StringFlag{
+							Name:  "mode",
+							Value: "recursive",
+							Usage: "Select a way to pin: recursive or direct",
+						},
+						cli.StringFlag{
 							Name:  "expire-in",
 							Usage: "Duration after which pin should be unpinned automatically",
 						},
@@ -599,6 +605,7 @@ would stil be respected.
 							ReplicationFactorMin: rplMin,
 							ReplicationFactorMax: rplMax,
 							Name:                 c.String("name"),
+							Mode:                 api.PinModeFromString(c.String("mode")),
 							UserAllocations:      userAllocs,
 							ExpireAt:             expireAt,
 							Metadata:             parseMetadata(c.StringSlice("metadata")),
@@ -730,10 +737,10 @@ the cluster. For IPFS-status information about the pins, use "status".
 
 The filter only takes effect when listing all pins. The possible values are:
   - all
-  - pin
-  - meta-pin
-  - clusterdag-pin
-  - shard-pin
+  - pin (normal pins, recursive or direct)
+  - meta-pin (sharded pins)
+  - clusterdag-pin (sharding-dag root pins)
+  - shard-pin (individual shard pins)
 `,
 					ArgsUsage: "[CID]",
 					Flags: []cli.Flag{

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/ipfs/go-ipfs-config v0.5.2
 	github.com/ipfs/go-ipfs-ds-help v1.0.0
 	github.com/ipfs/go-ipfs-files v0.0.8
+	github.com/ipfs/go-ipfs-pinner v0.0.4
 	github.com/ipfs/go-ipfs-posinfo v0.0.1
 	github.com/ipfs/go-ipld-cbor v0.0.4
 	github.com/ipfs/go-ipld-format v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,7 @@ github.com/ipfs/go-datastore v0.1.0 h1:TOxI04l8CmO4zGtesENhzm4PwkFwJXY3rKiYaaMf9
 github.com/ipfs/go-datastore v0.1.0/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=
 github.com/ipfs/go-datastore v0.1.1 h1:F4k0TkTAZGLFzBOrVKDAvch6JZtuN4NHkfdcEZL50aI=
 github.com/ipfs/go-datastore v0.1.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
+github.com/ipfs/go-datastore v0.3.0/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-datastore v0.3.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-datastore v0.4.0/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
 github.com/ipfs/go-datastore v0.4.1/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
@@ -362,6 +363,8 @@ github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjN
 github.com/ipfs/go-ipfs-files v0.0.6/go.mod h1:lVYE6sgAdtZN5825beJjSAHibw7WOBNPDWz5LaJeukg=
 github.com/ipfs/go-ipfs-files v0.0.8 h1:8o0oFJkJ8UkO/ABl8T6ac6tKF3+NIpj67aAB6ZpusRg=
 github.com/ipfs/go-ipfs-files v0.0.8/go.mod h1:wiN/jSG8FKyk7N0WyctKSvq3ljIa2NNTiZB55kpTdOs=
+github.com/ipfs/go-ipfs-pinner v0.0.4 h1:EmxhS3vDsCK/rZrsgxX0Le9m2drBcGlUd7ah/VyFYVE=
+github.com/ipfs/go-ipfs-pinner v0.0.4/go.mod h1:s4kFZWLWGDudN8Jyd/GTpt222A12C2snA2+OTdy/7p8=
 github.com/ipfs/go-ipfs-posinfo v0.0.1 h1:Esoxj+1JgSjX0+ylc0hUmJCOv6V2vFoZiETLR6OtpRs=
 github.com/ipfs/go-ipfs-posinfo v0.0.1/go.mod h1:SwyeVP+jCwiDu0C313l/8jg6ZxM0qqtlt2a0vILTc1A=
 github.com/ipfs/go-ipfs-pq v0.0.1 h1:zgUotX8dcAB/w/HidJh1zzc1yFq6Vm8J7T2F4itj/RU=
@@ -410,6 +413,7 @@ github.com/ipfs/go-merkledag v0.1.0 h1:CAEXjRFEDPvealQj3TgEjV1IJckwjvmxAqtq5QSXJ
 github.com/ipfs/go-merkledag v0.1.0/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-merkledag v0.2.3 h1:aMdkK9G1hEeNvn3VXfiEMLY0iJnbiQQUHnM0HFJREsE=
 github.com/ipfs/go-merkledag v0.2.3/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
+github.com/ipfs/go-merkledag v0.3.0/go.mod h1:4pymaZLhSLNVuiCITYrpViD6vmfZ/Ws4n/L9tfNv3S4=
 github.com/ipfs/go-merkledag v0.3.1 h1:3UqWINBEr3/N+r6OwgFXAddDP/8zpQX/8J7IGVOCqRQ=
 github.com/ipfs/go-merkledag v0.3.1/go.mod h1:fvkZNNZixVW6cKSZ/JfLlON5OlgTXNdRLz0p6QG/I2M=
 github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fGD6n0jO4kdg=

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -77,7 +77,7 @@ type IPFSConnector interface {
 	ID(context.Context) (*api.IPFSID, error)
 	Pin(context.Context, *api.Pin) error
 	Unpin(context.Context, cid.Cid) error
-	PinLsCid(context.Context, cid.Cid) (api.IPFSPinStatus, error)
+	PinLsCid(context.Context, *api.Pin) (api.IPFSPinStatus, error)
 	PinLs(ctx context.Context, typeFilter string) (map[string]api.IPFSPinStatus, error)
 	// ConnectSwarms make sure this peer's IPFS daemon is connected to
 	// other peers IPFS daemons.

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -413,6 +413,7 @@ func shutdownClusters(t *testing.T, clusters []*Cluster, m []*test.IpfsMock) {
 }
 
 func runF(t *testing.T, clusters []*Cluster, f func(*testing.T, *Cluster)) {
+	t.Helper()
 	var wg sync.WaitGroup
 	for _, c := range clusters {
 		wg.Add(1)
@@ -777,18 +778,18 @@ func TestClustersPinDirect(t *testing.T) {
 
 	pinDelay()
 
-	f := func(t *testing.T, c *Cluster) {
+	f := func(t *testing.T, c *Cluster, mode api.PinMode) {
 		pinget, err := c.PinGet(ctx, h)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if pinget.Mode != api.PinModeDirect {
+		if pinget.Mode != mode {
 			t.Error("pin should be pinned in direct mode")
 		}
 
-		if pinget.MaxDepth != 0 {
-			t.Error("pin should have max-depth = 0")
+		if pinget.MaxDepth != mode.ToPinDepth() {
+			t.Errorf("pin should have max-depth %d but has %d", mode.ToPinDepth(), pinget.MaxDepth)
 		}
 
 		pInfo := c.StatusLocal(ctx, h)
@@ -800,7 +801,28 @@ func TestClustersPinDirect(t *testing.T) {
 			t.Error("the status should show the hash as pinned")
 		}
 	}
-	runF(t, clusters, f)
+
+	runF(t, clusters, func(t *testing.T, c *Cluster) {
+		f(t, c, api.PinModeDirect)
+	})
+
+	// Convert into a recursive mode
+	_, err = clusters[0].Pin(ctx, h, api.PinOptions{Mode: api.PinModeRecursive})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pinDelay()
+
+	runF(t, clusters, func(t *testing.T, c *Cluster) {
+		f(t, c, api.PinModeRecursive)
+	})
+
+	// This should fail as we cannot convert back to direct
+	_, err = clusters[0].Pin(ctx, h, api.PinOptions{Mode: api.PinModeDirect})
+	if err == nil {
+		t.Error("a recursive pin cannot be converted back to direct pin")
+	}
 }
 
 func TestClustersStatusAll(t *testing.T) {

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -21,6 +21,7 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	files "github.com/ipfs/go-ipfs-files"
+	pinner "github.com/ipfs/go-ipfs-pinner"
 	logging "github.com/ipfs/go-log/v2"
 	gopath "github.com/ipfs/go-path"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -70,7 +71,18 @@ type Connector struct {
 }
 
 type ipfsError struct {
+	path    string
+	code    int
 	Message string
+}
+
+func (ie ipfsError) Error() string {
+	return fmt.Sprintf(
+		"IPFS request unsuccessful (%s). Code: %d. Message: %s",
+		ie.path,
+		ie.code,
+		ie.Message,
+	)
 }
 
 type ipfsPinType struct {
@@ -298,7 +310,7 @@ func (ipfs *Connector) Pin(ctx context.Context, pin *api.Pin) error {
 	hash := pin.Cid
 	maxDepth := pin.MaxDepth
 
-	pinStatus, err := ipfs.PinLsCid(ctx, hash)
+	pinStatus, err := ipfs.PinLsCid(ctx, pin)
 	if err != nil {
 		return err
 	}
@@ -317,7 +329,8 @@ func (ipfs *Connector) Pin(ctx context.Context, pin *api.Pin) error {
 	// is pinned recursively, then do pin/update.
 	// Otherwise do a normal pin.
 	if from := pin.PinUpdate; from != cid.Undef {
-		pinStatus, _ := ipfs.PinLsCid(ctx, from)
+		fromPin := api.PinWithOpts(from, pin.PinOptions)
+		pinStatus, _ := ipfs.PinLsCid(ctx, fromPin)
 		if pinStatus.IsPinned(-1) { // pinned recursively.
 			// As a side note, if PinUpdate == pin.Cid, we are
 			// somehow pinning an already pinned thing and we'd
@@ -433,31 +446,30 @@ func (ipfs *Connector) Unpin(ctx context.Context, hash cid.Cid) error {
 	ctx, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/Unpin")
 	defer span.End()
 
-	pinStatus, err := ipfs.PinLsCid(ctx, hash)
-	if err != nil {
-		return err
+	if ipfs.config.UnpinDisable {
+		return errors.New("ipfs unpinning is disallowed by configuration on this peer")
 	}
 
-	if pinStatus.IsPinned(-1) {
-		if ipfs.config.UnpinDisable {
-			return errors.New("ipfs unpinning is disallowed by configuration on this peer")
-		}
+	defer ipfs.updateInformerMetric(ctx)
 
-		defer ipfs.updateInformerMetric(ctx)
-		path := fmt.Sprintf("pin/rm?arg=%s", hash)
+	path := fmt.Sprintf("pin/rm?arg=%s", hash)
 
-		ctx, cancel := context.WithTimeout(ctx, ipfs.config.UnpinTimeout)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(ctx, ipfs.config.UnpinTimeout)
+	defer cancel()
 
-		_, err := ipfs.postCtx(ctx, path, "", nil)
-		if err != nil {
+	// We will call unpin in any case, if the CID is not pinned,
+	// then we ignore the error (although this is a bit flaky).
+	_, err := ipfs.postCtx(ctx, path, "", nil)
+	if err != nil {
+		ipfsErr, ok := err.(ipfsError)
+		if !ok || ipfsErr.Message != pinner.ErrNotPinned.Error() {
 			return err
 		}
-		logger.Info("IPFS Unpin request succeeded:", hash)
-		stats.Record(ctx, observations.Pins.M(-1))
+		logger.Debug("IPFS object is already unpinned: ", hash)
 	}
 
-	logger.Debug("IPFS object is already unpinned: ", hash)
+	logger.Info("IPFS Unpin request succeeded:", hash)
+	stats.Record(ctx, observations.Pins.M(-1))
 	return nil
 }
 
@@ -491,34 +503,21 @@ func (ipfs *Connector) PinLs(ctx context.Context, typeFilter string) (map[string
 	return statusMap, nil
 }
 
-// PinLsCid performs a "pin ls <hash>" request. It first tries with
-// "type=recursive" and then, if not found, with "type=direct". It returns an
-// api.IPFSPinStatus for that hash.
-func (ipfs *Connector) PinLsCid(ctx context.Context, hash cid.Cid) (api.IPFSPinStatus, error) {
+// PinLsCid performs a "pin ls <hash>" request. It will use "type=recursive" or
+// "type=direct" (or other) depending on the given pin's MaxDepth setting.
+// It returns an api.IPFSPinStatus for that hash.
+func (ipfs *Connector) PinLsCid(ctx context.Context, pin *api.Pin) (api.IPFSPinStatus, error) {
 	ctx, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/PinLsCid")
 	defer span.End()
 
-	pinLsType := func(pinType string) ([]byte, error) {
-		ctx, cancel := context.WithTimeout(ctx, ipfs.config.IPFSRequestTimeout)
-		defer cancel()
-		lsPath := fmt.Sprintf("pin/ls?arg=%s&type=%s", hash, pinType)
-		return ipfs.postCtx(ctx, lsPath, "", nil)
-	}
+	ctx, cancel := context.WithTimeout(ctx, ipfs.config.IPFSRequestTimeout)
+	defer cancel()
 
-	var body []byte
-	var err error
-	// FIXME: Sharding may need to check more pin types here.
-	for _, pinType := range []string{"recursive", "direct"} {
-		body, err = pinLsType(pinType)
-		// Network error, daemon down
-		if body == nil && err != nil {
-			return api.IPFSPinStatusError, err
-		}
-
-		// Pin found. Do not keep looking.
-		if err == nil {
-			break
-		}
+	pinType := pin.MaxDepth.ToPinMode().String()
+	lsPath := fmt.Sprintf("pin/ls?arg=%s&type=%s", pin.Cid, pinType)
+	body, err := ipfs.postCtx(ctx, lsPath, "", nil)
+	if body == nil && err != nil { // Network error, daemon down
+		return api.IPFSPinStatusError, err
 	}
 
 	if err != nil { // we could not find the pin
@@ -537,7 +536,7 @@ func (ipfs *Connector) PinLsCid(ctx context.Context, hash cid.Cid) (api.IPFSPinS
 	// we parse as CID. There should only be one returned key.
 	for k, pinObj := range res.Keys {
 		c, err := cid.Decode(k)
-		if err != nil || !c.Equals(hash) {
+		if err != nil || !c.Equals(pin.Cid) {
 			continue
 		}
 		return api.IPFSPinStatusFromString(pinObj.Type), nil
@@ -575,12 +574,9 @@ func checkResponse(path string, res *http.Response) ([]byte, error) {
 	if err == nil {
 		var ipfsErr ipfsError
 		if err := json.Unmarshal(body, &ipfsErr); err == nil {
-			return body, fmt.Errorf(
-				"IPFS request unsuccessful (%s). Code: %d. Message: %s",
-				path,
-				res.StatusCode,
-				ipfsErr.Message,
-			)
+			ipfsErr.code = res.StatusCode
+			ipfsErr.path = path
+			return body, ipfsErr
 		}
 	}
 

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -275,7 +275,7 @@ func (ipfs *Connector) ID(ctx context.Context) (*api.IPFSID, error) {
 	return id, nil
 }
 
-func pinArgs(maxDepth int) string {
+func pinArgs(maxDepth api.PinDepth) string {
 	q := url.Values{}
 	switch {
 	case maxDepth < 0:
@@ -284,7 +284,7 @@ func pinArgs(maxDepth int) string {
 		q.Set("recursive", "false")
 	default:
 		q.Set("recursive", "true")
-		q.Set("max-depth", strconv.Itoa(maxDepth))
+		q.Set("max-depth", strconv.Itoa(int(maxDepth)))
 	}
 	return q.Encode()
 }
@@ -370,7 +370,7 @@ func (ipfs *Connector) Pin(ctx context.Context, pin *api.Pin) error {
 // pinProgress pins an item and sends fetched node's progress on a
 // channel. Blocks until done or error. pinProgress will always close the out
 // channel.  pinProgress will not block on sending to the channel if it is full.
-func (ipfs *Connector) pinProgress(ctx context.Context, hash cid.Cid, maxDepth int, out chan<- int) error {
+func (ipfs *Connector) pinProgress(ctx context.Context, hash cid.Cid, maxDepth api.PinDepth, out chan<- int) error {
 	defer close(out)
 
 	ctx, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/pinsProgress")

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -75,12 +75,12 @@ func TestPin(t *testing.T) {
 	defer mock.Close()
 	defer ipfs.Shutdown(ctx)
 
-	c := test.Cid1
-	err := ipfs.Pin(ctx, api.PinCid(c))
+	pin := api.PinCid(test.Cid1)
+	err := ipfs.Pin(ctx, pin)
 	if err != nil {
 		t.Error("expected success pinning cid:", err)
 	}
-	pinSt, err := ipfs.PinLsCid(ctx, c)
+	pinSt, err := ipfs.PinLsCid(ctx, pin)
 	if err != nil {
 		t.Fatal("expected success doing ls:", err)
 	}
@@ -88,8 +88,8 @@ func TestPin(t *testing.T) {
 		t.Error("cid should have been pinned")
 	}
 
-	c2 := test.ErrorCid
-	err = ipfs.Pin(ctx, api.PinCid(c2))
+	pin2 := api.PinCid(test.ErrorCid)
+	err = ipfs.Pin(ctx, pin2)
 	if err == nil {
 		t.Error("expected error pinning cid")
 	}
@@ -178,8 +178,9 @@ func TestIPFSPinLsCid(t *testing.T) {
 	c := test.Cid1
 	c2 := test.Cid2
 
-	ipfs.Pin(ctx, api.PinCid(c))
-	ips, err := ipfs.PinLsCid(ctx, c)
+	pin := api.PinCid(c)
+	ipfs.Pin(ctx, pin)
+	ips, err := ipfs.PinLsCid(ctx, pin)
 	if err != nil {
 		t.Error(err)
 	}
@@ -188,7 +189,7 @@ func TestIPFSPinLsCid(t *testing.T) {
 		t.Error("c should appear pinned")
 	}
 
-	ips, err = ipfs.PinLsCid(ctx, c2)
+	ips, err = ipfs.PinLsCid(ctx, api.PinCid(c2))
 	if err != nil || ips != api.IPFSPinStatusUnpinned {
 		t.Error("c2 should appear unpinned")
 	}
@@ -201,8 +202,9 @@ func TestIPFSPinLsCid_DifferentEncoding(t *testing.T) {
 	defer ipfs.Shutdown(ctx)
 	c := test.Cid4 // ipfs mock treats this specially
 
-	ipfs.Pin(ctx, api.PinCid(c))
-	ips, err := ipfs.PinLsCid(ctx, c)
+	pin := api.PinCid(c)
+	ipfs.Pin(ctx, pin)
+	ips, err := ipfs.PinLsCid(ctx, pin)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pintracker/stateless/stateless.go
+++ b/pintracker/stateless/stateless.go
@@ -352,7 +352,7 @@ func (spt *Tracker) Status(ctx context.Context, c cid.Cid) *api.PinInfo {
 		"",
 		"IPFSConnector",
 		"PinLsCid",
-		c,
+		gpin,
 		&ips,
 	)
 	if err != nil {

--- a/pintracker/stateless/stateless_test.go
+++ b/pintracker/stateless/stateless_test.go
@@ -68,8 +68,8 @@ func (mock *mockIPFS) PinLs(ctx context.Context, in string, out *map[string]api.
 	return nil
 }
 
-func (mock *mockIPFS) PinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
-	switch in {
+func (mock *mockIPFS) PinLsCid(ctx context.Context, in *api.Pin, out *api.IPFSPinStatus) error {
+	switch in.Cid {
 	case test.Cid1, test.Cid2:
 		*out = api.IPFSPinStatusRecursive
 	default:

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -499,7 +499,7 @@ func (rpcapi *IPFSConnectorRPCAPI) Unpin(ctx context.Context, in *api.Pin, out *
 }
 
 // PinLsCid runs IPFSConnector.PinLsCid().
-func (rpcapi *IPFSConnectorRPCAPI) PinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
+func (rpcapi *IPFSConnectorRPCAPI) PinLsCid(ctx context.Context, in *api.Pin, out *api.IPFSPinStatus) error {
 	b, err := rpcapi.ipfs.PinLsCid(ctx, in)
 	if err != nil {
 		return err

--- a/sharness/t0030-ctl-pin.sh
+++ b/sharness/t0030-ctl-pin.sh
@@ -106,6 +106,18 @@ test_expect_success IPFS,CLUSTER "pin with metadata" '
    ipfs-cluster-ctl pin ls "$cid4" | grep -q "Metadata: no"
 '
 
+test_expect_success IPFS,CLUSTER "pin in direct mode" '
+   echo "direct" > expected_mode &&
+   cid=`docker exec ipfs sh -c "echo test-pin-direct | ipfs add -q -pin=false"` &&
+   echo "$cid direct" > expected_pin_ls &&
+   ipfs-cluster-ctl pin add --mode direct "$cid" &&
+   ipfs-cluster-ctl pin ls "$cid" | grep -q "PIN-DIRECT" &&
+   docker exec ipfs sh -c "ipfs pin ls --type direct $cid" > actual_pin_ls &&
+   ipfs-cluster-ctl --enc=json pin ls "$cid" | jq -r .mode > actual_mode &&
+   test_cmp expected_mode actual_mode &&
+   test_cmp expected_pin_ls actual_pin_ls
+'
+
 test_clean_ipfs
 test_clean_cluster
 

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -447,8 +447,8 @@ func (mock *mockIPFSConnector) Unpin(ctx context.Context, in *api.Pin, out *stru
 	return nil
 }
 
-func (mock *mockIPFSConnector) PinLsCid(ctx context.Context, in cid.Cid, out *api.IPFSPinStatus) error {
-	if in.Equals(Cid1) || in.Equals(Cid3) {
+func (mock *mockIPFSConnector) PinLsCid(ctx context.Context, in *api.Pin, out *api.IPFSPinStatus) error {
+	if in.Cid.Equals(Cid1) || in.Cid.Equals(Cid3) {
 		*out = api.IPFSPinStatusRecursive
 	} else {
 		*out = api.IPFSPinStatusUnpinned


### PR DESCRIPTION
This exposes pinning modes (direct/recursive) with a new `mode` API parameter and a new flag in pin/add.

Implementation-wise, this is a new PinOption, which is made to match the MaxDepth field when creating the Pin object. Since Max Depth is already stored we do not need to change the disk serialization.

Additionally some improvements have been added around pinning and unpinning, for speed and resilience.