### PR TITLE
Fix #1184: Pin update options (name, expire) in ipfs-cluster-ctl

### DIFF
--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -686,6 +686,15 @@ existing item from the cluster. Please run "pin rm" for that.
 `,
 					ArgsUsage: "<existing-CID> <new-CID|Path>",
 					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "name, n",
+							Value: "",
+							Usage: "Sets a name for this updated pin",
+						},
+						cli.StringFlag{
+							Name:  "expire-in",
+							Usage: "Duration after which the pin should be unpinned automatically after updating",
+						},
 						cli.BoolFlag{
 							Name:  "no-status, ns",
 							Usage: "Prevents fetching pin status after updating (faster, quieter)",
@@ -707,8 +716,17 @@ existing item from the cluster. Please run "pin rm" for that.
 						fromCid, err := cid.Decode(from)
 						checkErr("parsing from Cid", err)
 
+						var expireAt time.Time
+						if expireIn := c.String("expire-in"); expireIn != "" {
+							d, err := time.ParseDuration(expireIn)
+							checkErr("parsing expire-in", err)
+							expireAt = time.Now().Add(d)
+						}
+
 						opts := api.PinOptions{
 							PinUpdate: fromCid,
+							Name:      c.String("name"),
+							ExpireAt:  expireAt,
 						}
 
 						pin, cerr := globalClient.PinPath(ctx, to, opts)


### PR DESCRIPTION
Fixes #1184 

Changes: 
- Adds name and expire-in flags to the pin update command in ipfs-cluster-ctl.
- Updates PinOptions used

[PinUpdate](https://github.com/ipfs/ipfs-cluster/blob/d2a83e45f1ad5f84a3eae70b46fb9b521b90ab03/cluster.go#L1498) handles changes in name and expire

