### PR TITLE
Feat 1085: Dockerfile to support multiple architectures

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -51,7 +51,7 @@ COPY --from=builder /tmp/jq-linux64 /usr/local/bin/jq
 
 # Add bash
 COPY --from=builder /bin/bash /bin/bash
-COPY --from=builder /lib/x86_64-linux-gnu/libtinfo.so* /lib64/
+COPY --from=builder /lib/*-linux-gnu*/libtinfo.so* /lib64/
 
 USER root
 


### PR DESCRIPTION
#1085 

Changes: 
- Downloads appropriate tini binary based on the machine architecture https://github.com/ipfs/go-ipfs/pull/7187
- Builds a static su-exec binary to make it robust (no dependency on libraries) and cross-platform support https://github.com/ipfs/go-ipfs/pull/7505

For uploading images with different machine architectures to DockerHub, [Buildx](https://docs.docker.com/buildx/working-with-buildx/) or some other tool may be required

Any suggestions on how to test this for architectures other than amd64? 
Other libraries required would have to be imported as shown here  https://github.com/ipfs/go-ipfs/pull/6854
  