### PR TITLE
Feat #1222: Integrates the failover client in ipfs-cluster-ctl

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -166,21 +166,21 @@ type Config struct {
 }
 
 // AsTemplateFor creates client configs from resolved multiaddresses
-func (c *Config) AsTemplateFor(resolvedAddrs []ma.Multiaddr) ([]*Config) {
+func (c *Config) AsTemplateFor(addrs []ma.Multiaddr) ([]*Config) {
 	var cfgs []*Config
-	for _, multiaddress := range resolvedAddrs{
+	for _, addr := range addrs {
 		cfg := *c
-		cfg.APIAddr = multiaddress
+		cfg.APIAddr = addr
 		cfgs = append(cfgs, &cfg)
 	}
 	return cfgs
 }
 
 // AsTemplateForResolvedAddress creates client configs from a multiaddress
-func (c *Config) AsTemplateForResolvedAddress(addr ma.Multiaddr) ([]*Config, error) {
-	resolvedAddrs, err := resolveAddr(context.Background(), addr)
+func (c *Config) AsTemplateForResolvedAddress(ctx context.Context, addr ma.Multiaddr) ([]*Config, error) {
+	resolvedAddrs, err := resolveAddr(ctx, addr)
 	if err != nil {
-		return []*Config{}, err
+		return nil, err
 	}
 	return c.AsTemplateFor(resolvedAddrs), nil
 }
@@ -386,11 +386,11 @@ func resolveAddr(ctx context.Context, addr ma.Multiaddr) ([]ma.Multiaddr, error)
 	defer cancel()
 	resolved, err := madns.Resolve(resolveCtx, addr)
 	if err != nil {
-		return []ma.Multiaddr{}, err
+		return nil, err
 	}
 	
 	if len(resolved) == 0 {
-		return []ma.Multiaddr{}, fmt.Errorf("resolving %s returned 0 results", addr)
+		return nil, fmt.Errorf("resolving %s returned 0 results", addr)
 	}
 
 	return resolved, nil

--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -414,8 +414,7 @@ func resolveDNSAddr(addr ma.Multiaddr) ([]ma.Multiaddr, error) {
 	for len(currResolved) != len(prevResolved) {
 		var tobeResolved []ma.Multiaddr
 		for _, addr := range currResolved {
-			ctx, cancel := context.WithCancel(context.Background())
-			resolveCtx, cancel := context.WithTimeout(ctx, ResolveTimeout)
+			resolveCtx, cancel := context.WithTimeout(context.Background(), ResolveTimeout)
 			defer cancel()
 			resolved, err := madns.Resolve(resolveCtx, addr)
 			if err != nil {

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -92,7 +92,8 @@ func main() {
 		cli.StringFlag{
 			Name:  "host, l",
 			Value: defaultHost, 
-			Usage: "Cluster's HTTP or LibP2P-HTTP API endpoint. For multiple hosts: --host addr1,addr2",
+			Usage: `Cluster's HTTP or LibP2P-HTTP API endpoint. 
+To provide multiple hosts: --host addr1,addr2`,
 		},
 		cli.StringFlag{
 			Name:  "secret",

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -92,7 +92,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "host, l",
 			Value: defaultHost, 
-			Usage: "Cluster's HTTP or LibP2P-HTTP API endpoint. To provide multiple hosts: --host addr1,addr2",
+			Usage: "Cluster's HTTP or LibP2P-HTTP API endpoint. For multiple hosts: --host addr1,addr2",
 		},
 		cli.StringFlag{
 			Name:  "secret",


### PR DESCRIPTION
#1222 

Changes:
- adds methods to create client configs from a dnsaddr host input
- uses the LBClient in ipfs-cluster-ctl