### PR TITLE
ipfsproxy: fix 'undefined cid' string appeareance in progress output

### DIFF
--- a/api/ipfsproxy/ipfsproxy.go
+++ b/api/ipfsproxy/ipfsproxy.go
@@ -563,9 +563,13 @@ func (proxy *Server) addHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Warnf("Proxy/add does not support all IPFS params. Current options: %+v", params)
 
 	outputTransform := func(in *api.AddedOutput) interface{} {
+		cidStr := ""
+		if in.Cid.Defined() {
+			cidStr = in.Cid.String()
+		}
 		r := &ipfsAddResp{
 			Name:  in.Name,
-			Hash:  in.Cid.String(),
+			Hash:  cidStr,
 			Bytes: int64(in.Bytes),
 		}
 		if in.Size != 0 {

--- a/api/pb/types.pb.go
+++ b/api/pb/types.pb.go
@@ -7,12 +7,12 @@
 package pb
 
 import (
-	//lint:ignore SA1019 protobuf generates deprecated imports
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
Fixes #1286. Some AddedOutput objects carry an undefined CID. This was getting
stringified as 'b', making the proxy responses include this rather than
skipping setting the field.