### PR TITLE
Fix pubsub validation check

### DIFF
--- a/cluster_config.go
+++ b/cluster_config.go
@@ -439,15 +439,16 @@ func (cfg *Config) applyConfigJSON(jcfg *configJSON) error {
 	}
 
 	// PeerAddresses
+	peerAddrs := []ma.Multiaddr{}
 	for _, addr := range jcfg.PeerAddresses {
 		peerAddr, err := ma.NewMultiaddr(addr)
 		if err != nil {
 			err = fmt.Errorf("error parsing peer_addresses: %s", err)
 			return err
 		}
-		cfg.PeerAddresses = append(cfg.PeerAddresses, peerAddr)
+		peerAddrs = append(peerAddrs, peerAddr)
 	}
-
+	cfg.PeerAddresses = peerAddrs
 	cfg.LeaveOnShutdown = jcfg.LeaveOnShutdown
 	cfg.DisableRepinning = jcfg.DisableRepinning
 	cfg.FollowerMode = jcfg.FollowerMode

--- a/consensus/crdt/config.go
+++ b/consensus/crdt/config.go
@@ -108,6 +108,7 @@ func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
 
 	// Whenever we parse JSON, TrustAll is false unless an '*' peer exists
 	cfg.TrustAll = false
+	cfg.TrustedPeers = []peer.ID{}
 
 	for _, p := range jcfg.TrustedPeers {
 		if p == "*" {

--- a/consensus/crdt/consensus.go
+++ b/consensus/crdt/consensus.go
@@ -162,8 +162,13 @@ func (css *Consensus) setup() {
 	// from trusted sources)
 	err = css.pubsub.RegisterTopicValidator(
 		topicName,
-		func(ctx context.Context, p peer.ID, msg *pubsub.Message) bool {
-			return css.IsTrustedPeer(ctx, p)
+		func(ctx context.Context, _ peer.ID, msg *pubsub.Message) bool {
+			signer := msg.GetFrom()
+			trusted := css.IsTrustedPeer(ctx, signer)
+			if !trusted {
+				logger.Debug("discarded pubsub message from non trusted source %s ", signer)
+			}
+			return trusted
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Currently, it was not looking at the signer of the message, but at the
peer that relayed it, to verify the validity of the message.

This caused that under certain gossip graph configurations, some nodes would only
get messages via untrusted peers, and thus be unable to sync the chain.