### PR TITLE
feat: add --wait flag to ipfs-cluster-ctl add

### DIFF
--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -385,6 +385,15 @@ content.
 					Name:  "nocopy",
 					Usage: "Add the URL using filestore. Implies raw-leaves. (experimental)",
 				},
+				cli.BoolFlag{
+					Name:  "wait",
+					Usage: "Wait for all nodes to report a status of pinned before returning",
+				},
+				cli.DurationFlag{
+					Name:  "wait-timeout, wt",
+					Value: 0,
+					Usage: "How long to --wait (in seconds), default is indefinitely",
+				},
 				// TODO: Uncomment when sharding is supported.
 				// cli.BoolFlag{
 				//	Name:  "shard",
@@ -490,6 +499,12 @@ content.
 					if lastBuf == nil || lastBuf.AddedOutput == nil {
 						return // no elements at all
 					}
+
+					if c.Bool("wait") {
+						var _, cerr = waitFor(lastBuf.AddedOutput.Cid, api.TrackerStatusPinned, c.Duration("wait-timeout"))
+						checkErr("waiting for pin status", cerr)
+					}
+
 					if bufferResults { // we buffered.
 						if qq { // [last elem]
 							formatResponse(c, []*addedOutputQuiet{lastBuf}, nil)

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -499,12 +499,6 @@ content.
 					if lastBuf == nil || lastBuf.AddedOutput == nil {
 						return // no elements at all
 					}
-
-					if c.Bool("wait") {
-						var _, cerr = waitFor(lastBuf.AddedOutput.Cid, api.TrackerStatusPinned, c.Duration("wait-timeout"))
-						checkErr("waiting for pin status", cerr)
-					}
-
 					if bufferResults { // we buffered.
 						if qq { // [last elem]
 							formatResponse(c, []*addedOutputQuiet{lastBuf}, nil)
@@ -515,6 +509,10 @@ content.
 					} else if qq { // we already printed unless Quieter
 						formatResponse(c, lastBuf, nil)
 						return
+					}
+					if c.Bool("wait") {
+						var _, cerr = waitFor(lastBuf.AddedOutput.Cid, api.TrackerStatusPinned, c.Duration("wait-timeout"))
+						checkErr("waiting for pin status", cerr)
 					}
 				}()
 

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -502,13 +502,11 @@ content.
 					if bufferResults { // we buffered.
 						if qq { // [last elem]
 							formatResponse(c, []*addedOutputQuiet{lastBuf}, nil)
-							return
+						} else { // [all elems]
+							formatResponse(c, buffered, nil)
 						}
-						// [all elems]
-						formatResponse(c, buffered, nil)
 					} else if qq { // we already printed unless Quieter
 						formatResponse(c, lastBuf, nil)
-						return
 					}
 					if c.Bool("wait") {
 						var _, cerr = waitFor(lastBuf.AddedOutput.Cid, api.TrackerStatusPinned, c.Duration("wait-timeout"))


### PR DESCRIPTION
A "simplest thing that could work" implementation of adding a `--wait` flag to the ipfs-cluster-ctl add command. Allows CI to wait for cluster to fully replicate the files just added before continuting, or fail if replication fails.

A dull thing with this change is that `add -w` is already used as the alias for `add --wrap-with-directory`, so the meaning of `-w` is inconsistent between the `add` and `pin` commands. It seemed unwise to change the existing meaning of `add -w` so I have not updated it here.

Fixes #1285

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>