### PR TITLE
feat: make MDNS failure on start non-fatal

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -141,10 +141,10 @@ func NewCluster(
 	if cfg.MDNSInterval > 0 {
 		mdns, err := discovery.NewMdnsService(ctx, host, cfg.MDNSInterval, mdnsServiceTag)
 		if err != nil {
-			logger.Warn(err, ", MDNS service will be disabled")
-		}
-		if mdns != nil {
+			logger.Warnf("mDNS could not be started: %s", err)
+		} else {
 			mdns.RegisterNotifee(peerManager)
+		}
 		}
 	}
 

--- a/cluster.go
+++ b/cluster.go
@@ -141,10 +141,11 @@ func NewCluster(
 	if cfg.MDNSInterval > 0 {
 		mdns, err := discovery.NewMdnsService(ctx, host, cfg.MDNSInterval, mdnsServiceTag)
 		if err != nil {
-			cancel()
-			return nil, err
+			logger.Warn(err, ", MDNS service will be disabled")
 		}
-		mdns.RegisterNotifee(peerManager)
+		if mdns != nil {
+			mdns.RegisterNotifee(peerManager)
+		}
 	}
 
 	c := &Cluster{

--- a/cluster.go
+++ b/cluster.go
@@ -145,7 +145,6 @@ func NewCluster(
 		} else {
 			mdns.RegisterNotifee(peerManager)
 		}
-		}
 	}
 
 	c := &Cluster{


### PR DESCRIPTION
- if discovery.NewMdnsService errors on start, show warning "error message, MDNS service will be disabled"
- same as setting MDNSInterval to 0: NewCluster is still created and daemon runs, but without MDNS

closes #1193 

needs review
branch was checked out from `v0.13.1`
`make test` [pass](https://github.com/sergeiudris/ipfs-lab/issues/4#issuecomment-778145792)
`make test_sharness` [returns same output ](https://github.com/sergeiudris/ipfs-lab/issues/4#issuecomment-778147032) with/without changes

