### PR TITLE
Restapi: API libp2p host and client should no longer use secio.

### DIFF
--- a/api/rest/client/transports.go
+++ b/api/rest/client/transports.go
@@ -12,7 +12,7 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	peerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	p2phttp "github.com/libp2p/go-libp2p-http"
-	secio "github.com/libp2p/go-libp2p-secio"
+	noise "github.com/libp2p/go-libp2p-noise"
 	libp2ptls "github.com/libp2p/go-libp2p-tls"
 	madns "github.com/multiformats/go-multiaddr-dns"
 	manet "github.com/multiformats/go-multiaddr/net"
@@ -59,8 +59,8 @@ func (c *defaultClient) enableLibp2p() error {
 
 	h, err := libp2p.New(c.ctx,
 		libp2p.PrivateNetwork(c.config.ProtectorKey),
+		libp2p.Security(noise.ID, noise.New),
 		libp2p.Security(libp2ptls.ID, libp2ptls.New),
-		libp2p.Security(secio.ID, secio.New),
 		// TODO: quic does not support private networks
 		//libp2p.Transport(libp2pquic.NewTransport),
 		libp2p.DefaultTransports,

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -35,8 +35,8 @@ import (
 	rpc "github.com/libp2p/go-libp2p-gorpc"
 	gostream "github.com/libp2p/go-libp2p-gostream"
 	p2phttp "github.com/libp2p/go-libp2p-http"
+	noise "github.com/libp2p/go-libp2p-noise"
 	libp2pquic "github.com/libp2p/go-libp2p-quic-transport"
-	secio "github.com/libp2p/go-libp2p-secio"
 	libp2ptls "github.com/libp2p/go-libp2p-tls"
 	manet "github.com/multiformats/go-multiaddr/net"
 
@@ -239,8 +239,8 @@ func (api *API) setupLibp2p() error {
 			context.Background(),
 			libp2p.Identity(api.config.PrivateKey),
 			libp2p.ListenAddrs(api.config.Libp2pListenAddr...),
+			libp2p.Security(noise.ID, noise.New),
 			libp2p.Security(libp2ptls.ID, libp2ptls.New),
-			libp2p.Security(secio.ID, secio.New),
 			libp2p.Transport(libp2pquic.NewTransport),
 			libp2p.DefaultTransports,
 		)

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/libp2p/go-libp2p-quic-transport v0.10.0
 	github.com/libp2p/go-libp2p-raft v0.1.7
 	github.com/libp2p/go-libp2p-record v0.1.3
-	github.com/libp2p/go-libp2p-secio v0.2.2
 	github.com/libp2p/go-libp2p-tls v0.1.3
 	github.com/libp2p/go-ws-transport v0.4.0
 	github.com/multiformats/go-multiaddr v0.3.1


### PR DESCRIPTION
Instead they should use noise, and fallback to tls.

This should not break compatibility with previous versions as both old and new
are able to speak tls.

Fixes #1315