### PR TITLE
Revert "monitor: remove dependency to go-multicodec (#1313)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/libp2p/go-ws-transport v0.4.0
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multiaddr-dns v0.2.0
+	github.com/multiformats/go-multicodec v0.1.6
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -972,6 +972,8 @@ github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multicodec v0.1.6 h1:4u6lcjbE4VVVoigU4QJSSVYsGVP4j2jtDkR8lPwOrLE=
+github.com/multiformats/go-multicodec v0.1.6/go.mod h1:lliaRHbcG8q33yf4Ot9BGD7JqR/Za9HE7HTyVyKwrUQ=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/monitor/pubsubmon/pubsubmon.go
+++ b/monitor/pubsubmon/pubsubmon.go
@@ -15,7 +15,7 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	rpc "github.com/libp2p/go-libp2p-gorpc"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	gocodec "github.com/ugorji/go/codec"
+	msgpack "github.com/multiformats/go-multicodec/msgpack"
 
 	"go.opencensus.io/trace"
 )
@@ -25,7 +25,7 @@ var logger = logging.Logger("monitor")
 // PubsubTopic specifies the topic used to publish Cluster metrics.
 var PubsubTopic = "monitor.metrics"
 
-var msgpackHandle = &gocodec.MsgpackHandle{}
+var msgpackHandle = msgpack.DefaultMsgpackHandle()
 
 // Monitor is a component in charge of monitoring peers, logging
 // metrics and detecting failures
@@ -129,7 +129,7 @@ func (mon *Monitor) logFromPubsub() {
 
 			data := msg.GetData()
 			buf := bytes.NewBuffer(data)
-			dec := gocodec.NewDecoder(buf, msgpackHandle)
+			dec := msgpack.Multicodec(msgpackHandle).Decoder(buf)
 			metric := api.Metric{}
 			err = dec.Decode(&metric)
 			if err != nil {
@@ -203,7 +203,7 @@ func (mon *Monitor) PublishMetric(ctx context.Context, m *api.Metric) error {
 
 	var b bytes.Buffer
 
-	enc := gocodec.NewEncoder(&b, msgpackHandle)
+	enc := msgpack.Multicodec(msgpackHandle).Encoder(&b)
 	err := enc.Encode(m)
 	if err != nil {
 		logger.Error(err)


### PR DESCRIPTION
This reverts commit fab2ed814934a19b690bc402a7b499c99f661cfd.

It turns out that messages are serialized with a multicodec header prefix and removing this breaks metric broadcasts between older and newer peers, something we don't want to do until we have a properly breaking upgrade.