### PR TITLE
Fixes #1319: Status wrongly shows pins as REMOTE

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -792,6 +792,11 @@ func (pin *Pin) String() string {
 	return b.String()
 }
 
+// IsPinEverywhere returns when the both replication factors are set to -1.
+func (pin *Pin) IsPinEverywhere() bool {
+	return pin.ReplicationFactorMin == -1 && pin.ReplicationFactorMax == -1
+}
+
 // PinPath is a wrapper for holding pin options and path of the content.
 type PinPath struct {
 	PinOptions
@@ -985,7 +990,7 @@ func (pin *Pin) Equals(pin2 *Pin) bool {
 // IsRemotePin determines whether a Pin's ReplicationFactor has
 // been met, so as to either pin or unpin it from the peer.
 func (pin *Pin) IsRemotePin(pid peer.ID) bool {
-	if pin.ReplicationFactorMax < 0 || pin.ReplicationFactorMin < 0 {
+	if pin.IsPinEverywhere() {
 		return false
 	}
 

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -189,7 +189,7 @@ func textFormatPrintPin(obj *api.Pin) {
 
 	fmt.Printf("%s | %s | %s | ", obj.Cid, obj.Name, t)
 
-	if obj.ReplicationFactorMin < 0 {
+	if obj.IsPinEverywhere() {
 		fmt.Printf("Repl. Factor: -1 | Allocations: [everywhere]")
 	} else {
 		sortAlloc := api.PeersToStrings(obj.Allocations)


### PR DESCRIPTION
The Allocations of a pin that has been added with default replication factor
are kept even when the replication factor turns out to be -1.

This resulted in the Status(cid) code skipping calls to a number of peers
and setting the pin directly as REMOTE.

The fix, on one side makes sure Allocations is always nil when the replication
factor is -1. On the other size, lets the globalPinInfoCid method check the
replication factor value, rather than the number of allocations to decide if
any nodes are bound to be remote.

On the plus side, the pin tracker used the IsRemotePin method, which uses the
replication factor, so things were pinned even if the Status(cid) method shows
them as remote.

#1319 