### PR TITLE
Better timeouts

### DIFF
--- a/clusterhost.go
+++ b/clusterhost.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/hex"
 
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/namespace"
+	datastore "github.com/ipfs/go-datastore"
+	namespace "github.com/ipfs/go-datastore/namespace"
 	ipns "github.com/ipfs/go-ipns"
-	"github.com/ipfs/ipfs-cluster/config"
+	config "github.com/ipfs/ipfs-cluster/config"
 	libp2p "github.com/libp2p/go-libp2p"
 	relay "github.com/libp2p/go-libp2p-circuit"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	host "github.com/libp2p/go-libp2p-core/host"
+	network "github.com/libp2p/go-libp2p-core/network"
 	corepnet "github.com/libp2p/go-libp2p-core/pnet"
 	routing "github.com/libp2p/go-libp2p-core/routing"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
@@ -51,6 +52,12 @@ func NewClusterHost(
 	cfg *Config,
 	ds datastore.Datastore,
 ) (host.Host, *pubsub.PubSub, *dual.DHT, error) {
+
+	// Set the default dial timeout for all libp2p connections.  It is not
+	// very good to touch this global variable here, but the alternative
+	// is to used a modify context everywhere, even if the user supplies
+	// it.
+	network.DialPeerTimeout = cfg.DialPeerTimeout
 
 	connman := connmgr.NewConnManager(cfg.ConnMgr.LowWater, cfg.ConnMgr.HighWater, cfg.ConnMgr.GracePeriod)
 

--- a/pstoremgr/pstoremgr.go
+++ b/pstoremgr/pstoremgr.go
@@ -104,8 +104,7 @@ func (pm *Manager) ImportPeer(addr ma.Multiaddr, connect bool, ttl time.Duration
 
 	if connect {
 		go func() {
-			ctx, cancel := context.WithTimeout(pm.ctx, ConnectTimeout)
-			defer cancel()
+			ctx := net.WithDialPeerTimeout(pm.ctx, ConnectTimeout)
 			pm.host.Connect(ctx, *pinfo)
 		}()
 	}


### PR DESCRIPTION
This PR improves some timeout behaviours.

It introduces an option to control the dial timeout and sets 15 second deadlines for broadcast calls triggered by Peers() and StatusCID(), which should be relatively fast.