### PR TITLE
Fix #1358: Set RawLeaves to true when unset and CidVersion=1

### DIFF
--- a/api/add.go
+++ b/api/add.go
@@ -154,10 +154,6 @@ func AddParamsFromQuery(query url.Values) (*AddParams, error) {
 		return nil, err
 	}
 
-	err = parseBoolParam(query, "raw-leaves", &params.RawLeaves)
-	if err != nil {
-		return nil, err
-	}
 	err = parseBoolParam(query, "hidden", &params.Hidden)
 	if err != nil {
 		return nil, err
@@ -177,6 +173,19 @@ func AddParamsFromQuery(query url.Values) (*AddParams, error) {
 	}
 
 	err = parseIntParam(query, "cid-version", &params.CidVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// This mimics go-ipfs behaviour.
+	if params.CidVersion > 0 {
+		params.RawLeaves = true
+	}
+
+	// If the raw-leaves param is empty, the default RawLeaves value will
+	// take place (which may be true or false depending on
+	// CidVersion). Otherwise, it will be explicitally set.
+	err = parseBoolParam(query, "raw-leaves", &params.RawLeaves)
 	if err != nil {
 		return nil, err
 	}

--- a/api/add.go
+++ b/api/add.go
@@ -184,7 +184,7 @@ func AddParamsFromQuery(query url.Values) (*AddParams, error) {
 
 	// If the raw-leaves param is empty, the default RawLeaves value will
 	// take place (which may be true or false depending on
-	// CidVersion). Otherwise, it will be explicitally set.
+	// CidVersion). Otherwise, it will be explicitly set.
 	err = parseBoolParam(query, "raw-leaves", &params.RawLeaves)
 	if err != nil {
 		return nil, err

--- a/api/add_test.go
+++ b/api/add_test.go
@@ -71,7 +71,7 @@ func TestAddParams_FromQueryRawLeaves(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !p.RawLeaves {
-		t.Error("RawLeaves should be true when explicitally set")
+		t.Error("RawLeaves should be true when explicitly set")
 	}
 }
 

--- a/api/add_test.go
+++ b/api/add_test.go
@@ -28,6 +28,53 @@ func TestAddParams_FromQuery(t *testing.T) {
 	}
 }
 
+func TestAddParams_FromQueryRawLeaves(t *testing.T) {
+	qStr := "cid-version=1"
+
+	q, err := url.ParseQuery(qStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := AddParamsFromQuery(q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.RawLeaves {
+		t.Error("RawLeaves should be true with cid-version=1")
+	}
+
+	qStr = "cid-version=1&raw-leaves=false"
+
+	q, err = url.ParseQuery(qStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err = AddParamsFromQuery(q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.RawLeaves {
+		t.Error("RawLeaves should be false when explicitally set")
+	}
+
+	qStr = "cid-version=0&raw-leaves=true"
+
+	q, err = url.ParseQuery(qStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err = AddParamsFromQuery(q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.RawLeaves {
+		t.Error("RawLeaves should be true when explicitally set")
+	}
+}
+
 func TestAddParams_ToQueryString(t *testing.T) {
 	p := DefaultAddParams()
 	p.ReplicationFactorMin = 3


### PR DESCRIPTION
Fixes #1358. Mimics go-ipfs defaults.