### PR TITLE
chore: use latest go ipfs in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
 # See Cluster PEER 0 for comments (all removed here and below)
   ipfs1:
     container_name: ipfs1
-    image: ipfs/go-ipfs:release
+    image: ipfs/go-ipfs:latest
     volumes:
       - ./compose/ipfs1:/data/ipfs
 
@@ -96,7 +96,7 @@ services:
 # See Cluster PEER 0 for comments (all removed here and below)
   ipfs2:
     container_name: ipfs2
-    image: ipfs/go-ipfs:release
+    image: ipfs/go-ipfs:latest
     volumes:
       - ./compose/ipfs2:/data/ipfs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   ipfs0:
     container_name: ipfs0
-    image: ipfs/go-ipfs:release
+    image: ipfs/go-ipfs:latest
 #   ports:
 #     - "4001:4001" # ipfs swarm - expose if needed/wanted
 #     - "5001:5001" # ipfs api - expose if needed/wanted


### PR DESCRIPTION
The [quick start guide](https://cluster.ipfs.io/documentation/quickstart/) references this file, which ends up using older `go-ipfs` 0.4.23.

The `release` tag seems to not be used anymore, and `latest` seems the correct one to use here per https://hub.docker.com/r/ipfs/go-ipfs/tags?page=1&ordering=last_updated&name=latest