### PR TITLE
Support a levelDB backend for cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ jobs:
     - name: "Main Tests with raft consensus"
       script:
         - travis_wait go test -v -timeout 15m -failfast -consensus raft .
+    - name: "Main Tests with leveldb backend"
+      script:
+        - travis_wait go test -v -timeout 15m -failfast -datastore leveldb .
     - name: "Golint, go vet, binary builds"
       script:
         - go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -148,7 +148,7 @@ type mockTracer struct {
 }
 
 func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, PinTracker) {
-	ident, clusterCfg, _, _, _, badgerCfg, raftCfg, crdtCfg, statelesstrackerCfg, psmonCfg, _, _ := testingConfigs()
+	ident, clusterCfg, _, _, _, badgerCfg, levelDBCfg, raftCfg, crdtCfg, statelesstrackerCfg, psmonCfg, _, _ := testingConfigs()
 	ctx := context.Background()
 
 	host, pubsub, dht := createHost(t, ident.PrivateKey, clusterCfg.Secret, clusterCfg.ListenAddr)
@@ -158,6 +158,7 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, PinTracke
 	clusterCfg.SetBaseDir(folder)
 	raftCfg.DataFolder = folder
 	badgerCfg.Folder = filepath.Join(folder, "badger")
+	levelDBCfg.Folder = filepath.Join(folder, "leveldb")
 
 	api := &mockAPI{}
 	proxy := &mockProxy{}
@@ -165,7 +166,7 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, PinTracke
 
 	tracer := &mockTracer{}
 
-	store := makeStore(t, badgerCfg)
+	store := makeStore(t, badgerCfg, levelDBCfg)
 	cons := makeConsensus(t, store, host, pubsub, dht, raftCfg, false, crdtCfg)
 	tracker := stateless.New(statelesstrackerCfg, ident.ID, clusterCfg.Peername, cons.State)
 

--- a/clusterhost.go
+++ b/clusterhost.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 
-	datastore "github.com/ipfs/go-datastore"
+	ds "github.com/ipfs/go-datastore"
 	namespace "github.com/ipfs/go-datastore/namespace"
 	ipns "github.com/ipfs/go-ipns"
 	config "github.com/ipfs/ipfs-cluster/config"
@@ -50,7 +50,7 @@ func NewClusterHost(
 	ctx context.Context,
 	ident *config.Identity,
 	cfg *Config,
-	ds datastore.Datastore,
+	ds ds.Datastore,
 ) (host.Host, *pubsub.PubSub, *dual.DHT, error) {
 
 	// Set the default dial timeout for all libp2p connections.  It is not
@@ -131,7 +131,7 @@ func baseOpts(psk corepnet.PSK) []libp2p.Option {
 	}
 }
 
-func newDHT(ctx context.Context, h host.Host, store datastore.Datastore, extraopts ...dual.Option) (*dual.DHT, error) {
+func newDHT(ctx context.Context, h host.Host, store ds.Datastore, extraopts ...dual.Option) (*dual.DHT, error) {
 	opts := []dual.Option{
 		dual.DHTOption(dht.NamespacedValidator("pk", record.PublicKeyValidator{})),
 		dual.DHTOption(dht.NamespacedValidator("ipns", ipns.Validator{KeyBook: h.Peerstore()})),
@@ -140,8 +140,8 @@ func newDHT(ctx context.Context, h host.Host, store datastore.Datastore, extraop
 
 	opts = append(opts, extraopts...)
 
-	if batchingDs, ok := store.(datastore.Batching); ok {
-		dhtDatastore := namespace.Wrap(batchingDs, datastore.NewKey(dhtNamespace))
+	if batchingDs, ok := store.(ds.Batching); ok {
+		dhtDatastore := namespace.Wrap(batchingDs, ds.NewKey(dhtNamespace))
 		opts = append(opts, dual.DHTOption(dht.Datastore(dhtDatastore)))
 		logger.Debug("enabling DHT record persistence to datastore")
 	}

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -224,7 +224,7 @@ func bootstrap(ctx context.Context, cluster *ipfscluster.Cluster, bootstraps []m
 }
 
 func setupDatastore(cfgHelper *cmdutils.ConfigHelper) ds.Datastore {
-	stmgr, err := cmdutils.NewStateManager(cfgHelper.GetConsensus(), cfgHelper.Identity(), cfgHelper.Configs())
+	stmgr, err := cmdutils.NewStateManager(cfgHelper.GetConsensus(), cfgHelper.GetDatastore(), cfgHelper.Identity(), cfgHelper.Configs())
 	checkErr("creating state manager", err)
 	store, err := stmgr.GetStore()
 	checkErr("creating datastore", err)

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -224,10 +224,14 @@ func bootstrap(ctx context.Context, cluster *ipfscluster.Cluster, bootstraps []m
 }
 
 func setupDatastore(cfgHelper *cmdutils.ConfigHelper) ds.Datastore {
-	stmgr, err := cmdutils.NewStateManager(cfgHelper.GetConsensus(), cfgHelper.GetDatastore(), cfgHelper.Identity(), cfgHelper.Configs())
+	dsName := cfgHelper.GetDatastore()
+	stmgr, err := cmdutils.NewStateManager(cfgHelper.GetConsensus(), dsName, cfgHelper.Identity(), cfgHelper.Configs())
 	checkErr("creating state manager", err)
 	store, err := stmgr.GetStore()
 	checkErr("creating datastore", err)
+	if dsName != "" {
+		logger.Infof("Datastore backend: %s", dsName)
+	}
 	return store
 }
 

--- a/cmd/ipfs-cluster-service/lock.go
+++ b/cmd/ipfs-cluster-service/lock.go
@@ -29,7 +29,7 @@ func (l *lock) lock() {
 	}
 
 	// we should have a config folder whenever we try to lock
-	cfgHelper := cmdutils.NewConfigHelper(configPath, identityPath, "")
+	cfgHelper := cmdutils.NewConfigHelper(configPath, identityPath, "", "")
 	cfgHelper.MakeConfigFolder()
 
 	// set the lock file within this function

--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/consensus/crdt"
 	"github.com/ipfs/ipfs-cluster/consensus/raft"
 	"github.com/ipfs/ipfs-cluster/datastore/badger"
+	"github.com/ipfs/ipfs-cluster/datastore/leveldb"
 	"github.com/ipfs/ipfs-cluster/informer/disk"
 	"github.com/ipfs/ipfs-cluster/ipfsconn/ipfshttp"
 	"github.com/ipfs/ipfs-cluster/monitor/pubsubmon"
@@ -66,6 +67,12 @@ var testingBadgerCfg = []byte(`{
     "folder": "badgerFromTests",
     "badger_options": {
         "max_table_size": 1048576
+    }
+}`)
+
+var testingLevelDBCfg = []byte(`{
+    "folder": "leveldbFromTests",
+    "leveldb_options": {
     }
 }`)
 
@@ -129,8 +136,8 @@ var testingTracerCfg = []byte(`{
     "service_name": "cluster-daemon"
 }`)
 
-func testingConfigs() (*config.Identity, *Config, *rest.Config, *ipfsproxy.Config, *ipfshttp.Config, *badger.Config, *raft.Config, *crdt.Config, *stateless.Config, *pubsubmon.Config, *disk.Config, *observations.TracingConfig) {
-	identity, clusterCfg, apiCfg, proxyCfg, ipfsCfg, badgerCfg, raftCfg, crdtCfg, statelesstrkrCfg, pubsubmonCfg, diskInfCfg, tracingCfg := testingEmptyConfigs()
+func testingConfigs() (*config.Identity, *Config, *rest.Config, *ipfsproxy.Config, *ipfshttp.Config, *badger.Config, *leveldb.Config, *raft.Config, *crdt.Config, *stateless.Config, *pubsubmon.Config, *disk.Config, *observations.TracingConfig) {
+	identity, clusterCfg, apiCfg, proxyCfg, ipfsCfg, badgerCfg, levelDBCfg, raftCfg, crdtCfg, statelesstrkrCfg, pubsubmonCfg, diskInfCfg, tracingCfg := testingEmptyConfigs()
 	identity.LoadJSON(testingIdentity)
 	clusterCfg.LoadJSON(testingClusterCfg)
 	apiCfg.LoadJSON(testingAPICfg)
@@ -138,16 +145,17 @@ func testingConfigs() (*config.Identity, *Config, *rest.Config, *ipfsproxy.Confi
 	ipfsCfg.LoadJSON(testingIpfsCfg)
 	badgerCfg.LoadJSON(testingBadgerCfg)
 	raftCfg.LoadJSON(testingRaftCfg)
+	levelDBCfg.LoadJSON(testingLevelDBCfg)
 	crdtCfg.LoadJSON(testingCrdtCfg)
 	statelesstrkrCfg.LoadJSON(testingTrackerCfg)
 	pubsubmonCfg.LoadJSON(testingMonCfg)
 	diskInfCfg.LoadJSON(testingDiskInfCfg)
 	tracingCfg.LoadJSON(testingTracerCfg)
 
-	return identity, clusterCfg, apiCfg, proxyCfg, ipfsCfg, badgerCfg, raftCfg, crdtCfg, statelesstrkrCfg, pubsubmonCfg, diskInfCfg, tracingCfg
+	return identity, clusterCfg, apiCfg, proxyCfg, ipfsCfg, badgerCfg, levelDBCfg, raftCfg, crdtCfg, statelesstrkrCfg, pubsubmonCfg, diskInfCfg, tracingCfg
 }
 
-func testingEmptyConfigs() (*config.Identity, *Config, *rest.Config, *ipfsproxy.Config, *ipfshttp.Config, *badger.Config, *raft.Config, *crdt.Config, *stateless.Config, *pubsubmon.Config, *disk.Config, *observations.TracingConfig) {
+func testingEmptyConfigs() (*config.Identity, *Config, *rest.Config, *ipfsproxy.Config, *ipfshttp.Config, *badger.Config, *leveldb.Config, *raft.Config, *crdt.Config, *stateless.Config, *pubsubmon.Config, *disk.Config, *observations.TracingConfig) {
 	identity := &config.Identity{}
 	clusterCfg := &Config{}
 	apiCfg := &rest.Config{}
@@ -155,12 +163,13 @@ func testingEmptyConfigs() (*config.Identity, *Config, *rest.Config, *ipfsproxy.
 	ipfshttpCfg := &ipfshttp.Config{}
 	badgerCfg := &badger.Config{}
 	raftCfg := &raft.Config{}
+	levelDBCfg := &leveldb.Config{}
 	crdtCfg := &crdt.Config{}
 	statelessCfg := &stateless.Config{}
 	pubsubmonCfg := &pubsubmon.Config{}
 	diskInfCfg := &disk.Config{}
 	tracingCfg := &observations.TracingConfig{}
-	return identity, clusterCfg, apiCfg, proxyCfg, ipfshttpCfg, badgerCfg, raftCfg, crdtCfg, statelessCfg, pubsubmonCfg, diskInfCfg, tracingCfg
+	return identity, clusterCfg, apiCfg, proxyCfg, ipfshttpCfg, badgerCfg, levelDBCfg, raftCfg, crdtCfg, statelessCfg, pubsubmonCfg, diskInfCfg, tracingCfg
 }
 
 // func TestConfigDefault(t *testing.T) {

--- a/datastore/badger/config_test.go
+++ b/datastore/badger/config_test.go
@@ -12,7 +12,7 @@ var cfgJSON = []byte(`
     "folder": "test",
     "badger_options": {
          "max_levels": 4,
-		 "value_log_loading_mode": 0
+	 "value_log_loading_mode": 0
     }
 }
 `)

--- a/datastore/leveldb/config.go
+++ b/datastore/leveldb/config.go
@@ -1,0 +1,243 @@
+package leveldb
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+
+	"github.com/imdario/mergo"
+	"github.com/ipfs/ipfs-cluster/config"
+	"github.com/kelseyhightower/envconfig"
+	goleveldb "github.com/syndtr/goleveldb/leveldb/opt"
+)
+
+const configKey = "leveldb"
+const envConfigKey = "cluster_leveldb"
+
+// Default values for LevelDB Config
+const (
+	DefaultSubFolder = "leveldb"
+)
+
+var (
+	// DefaultLevelDBOptions carries default options. Values are customized during Init().
+	DefaultLevelDBOptions goleveldb.Options
+)
+
+func init() {
+	// go-ipfs uses defaults and only allows to configure compression, but
+	// otherwise stores a small amount of values in LevelDB.
+	// We leave defaults.
+	// Example:
+	DefaultLevelDBOptions.NoSync = false
+}
+
+// Config is used to initialize a LevelDB datastore. It implements the
+// ComponentConfig interface.
+type Config struct {
+	config.Saver
+
+	// The folder for this datastore. Non-absolute paths are relative to
+	// the base configuration folder.
+	Folder string
+
+	LevelDBOptions goleveldb.Options
+}
+
+// levelDBOptions allows json serialization in our configuration of the
+// goleveldb Options.
+type levelDBOptions struct {
+	BlockCacheCapacity                    int       `json:"block_cache_capacity"`
+	BlockCacheEvictRemoved                bool      `json:"block_cache_evict_removed"`
+	BlockRestartInterval                  int       `json:"block_restart_interval"`
+	BlockSize                             int       `json:"block_size"`
+	CompactionExpandLimitFactor           int       `json:"compaction_expand_limit_factor"`
+	CompactionGPOverlapsFactor            int       `json:"compaction_gp_overlaps_factor"`
+	CompactionL0Trigger                   int       `json:"compaction_l0_trigger"`
+	CompactionSourceLimitFactor           int       `json:"compaction_source_limit_factor"`
+	CompactionTableSize                   int       `json:"compaction_table_size"`
+	CompactionTableSizeMultiplier         float64   `json:"compaction_table_size_multiplier"`
+	CompactionTableSizeMultiplierPerLevel []float64 `json:"compaction_table_size_multiplier_per_level"`
+	CompactionTotalSize                   int       `json:"compaction_total_size"`
+	CompactionTotalSizeMultiplier         float64   `json:"compaction_total_size_multiplier"`
+	CompactionTotalSizeMultiplierPerLevel []float64 `json:"compaction_total_size_multiplier_per_level"`
+	Compression                           uint      `json:"compression"`
+	DisableBufferPool                     bool      `json:"disable_buffer_pool"`
+	DisableBlockCache                     bool      `json:"disable_block_cache"`
+	DisableCompactionBackoff              bool      `json:"disable_compaction_backoff"`
+	DisableLargeBatchTransaction          bool      `json:"disable_large_batch_transaction"`
+	IteratorSamplingRate                  int       `json:"iterator_sampling_rate"`
+	NoSync                                bool      `json:"no_sync"`
+	NoWriteMerge                          bool      `json:"no_write_merge"`
+	OpenFilesCacheCapacity                int       `json:"open_files_cache_capacity"`
+	ReadOnly                              bool      `json:"read_only"`
+	Strict                                uint      `json:"strict"`
+	WriteBuffer                           int       `json:"write_buffer"`
+	WriteL0PauseTrigger                   int       `json:"write_l0_pause_trigger"`
+	WriteL0SlowdownTrigger                int       `json:"write_l0_slowdown_trigger"`
+}
+
+func (ldbo *levelDBOptions) Unmarshal() *goleveldb.Options {
+	goldbo := &goleveldb.Options{}
+	goldbo.BlockCacheCapacity = ldbo.BlockCacheCapacity
+	goldbo.BlockCacheEvictRemoved = ldbo.BlockCacheEvictRemoved
+	goldbo.BlockRestartInterval = ldbo.BlockRestartInterval
+	goldbo.BlockSize = ldbo.BlockSize
+	goldbo.CompactionExpandLimitFactor = ldbo.CompactionExpandLimitFactor
+	goldbo.CompactionGPOverlapsFactor = ldbo.CompactionGPOverlapsFactor
+	goldbo.CompactionL0Trigger = ldbo.CompactionL0Trigger
+	goldbo.CompactionSourceLimitFactor = ldbo.CompactionSourceLimitFactor
+	goldbo.CompactionTableSize = ldbo.CompactionTableSize
+	goldbo.CompactionTableSizeMultiplier = ldbo.CompactionTableSizeMultiplier
+	goldbo.CompactionTableSizeMultiplierPerLevel = ldbo.CompactionTableSizeMultiplierPerLevel
+	goldbo.CompactionTotalSize = ldbo.CompactionTotalSize
+	goldbo.CompactionTotalSizeMultiplier = ldbo.CompactionTotalSizeMultiplier
+	goldbo.CompactionTotalSizeMultiplierPerLevel = ldbo.CompactionTotalSizeMultiplierPerLevel
+	goldbo.Compression = goleveldb.Compression(ldbo.Compression)
+	goldbo.DisableBufferPool = ldbo.DisableBufferPool
+	goldbo.DisableBlockCache = ldbo.DisableBlockCache
+	goldbo.DisableCompactionBackoff = ldbo.DisableCompactionBackoff
+	goldbo.DisableLargeBatchTransaction = ldbo.DisableLargeBatchTransaction
+	goldbo.IteratorSamplingRate = ldbo.IteratorSamplingRate
+	goldbo.NoSync = ldbo.NoSync
+	goldbo.NoWriteMerge = ldbo.NoWriteMerge
+	goldbo.OpenFilesCacheCapacity = ldbo.OpenFilesCacheCapacity
+	goldbo.ReadOnly = ldbo.ReadOnly
+	goldbo.Strict = goleveldb.Strict(ldbo.Strict)
+	goldbo.WriteBuffer = ldbo.WriteBuffer
+	goldbo.WriteL0PauseTrigger = ldbo.WriteL0PauseTrigger
+	goldbo.WriteL0SlowdownTrigger = ldbo.WriteL0SlowdownTrigger
+	return goldbo
+}
+
+func (ldbo *levelDBOptions) Marshal(goldbo *goleveldb.Options) {
+	ldbo.BlockCacheCapacity = goldbo.BlockCacheCapacity
+	ldbo.BlockCacheEvictRemoved = goldbo.BlockCacheEvictRemoved
+	ldbo.BlockRestartInterval = goldbo.BlockRestartInterval
+	ldbo.BlockSize = goldbo.BlockSize
+	ldbo.CompactionExpandLimitFactor = goldbo.CompactionExpandLimitFactor
+	ldbo.CompactionGPOverlapsFactor = goldbo.CompactionGPOverlapsFactor
+	ldbo.CompactionL0Trigger = goldbo.CompactionL0Trigger
+	ldbo.CompactionSourceLimitFactor = goldbo.CompactionSourceLimitFactor
+	ldbo.CompactionTableSize = goldbo.CompactionTableSize
+	ldbo.CompactionTableSizeMultiplier = goldbo.CompactionTableSizeMultiplier
+	ldbo.CompactionTableSizeMultiplierPerLevel = goldbo.CompactionTableSizeMultiplierPerLevel
+	ldbo.CompactionTotalSize = goldbo.CompactionTotalSize
+	ldbo.CompactionTotalSizeMultiplier = goldbo.CompactionTotalSizeMultiplier
+	ldbo.CompactionTotalSizeMultiplierPerLevel = goldbo.CompactionTotalSizeMultiplierPerLevel
+	ldbo.Compression = uint(goldbo.Compression)
+	ldbo.DisableBufferPool = goldbo.DisableBufferPool
+	ldbo.DisableBlockCache = goldbo.DisableBlockCache
+	ldbo.DisableCompactionBackoff = goldbo.DisableCompactionBackoff
+	ldbo.DisableLargeBatchTransaction = goldbo.DisableLargeBatchTransaction
+	ldbo.IteratorSamplingRate = goldbo.IteratorSamplingRate
+	ldbo.NoSync = goldbo.NoSync
+	ldbo.NoWriteMerge = goldbo.NoWriteMerge
+	ldbo.OpenFilesCacheCapacity = goldbo.OpenFilesCacheCapacity
+	ldbo.ReadOnly = goldbo.ReadOnly
+	ldbo.Strict = uint(goldbo.Strict)
+	ldbo.WriteBuffer = goldbo.WriteBuffer
+	ldbo.WriteL0PauseTrigger = goldbo.WriteL0PauseTrigger
+	ldbo.WriteL0SlowdownTrigger = goldbo.WriteL0SlowdownTrigger
+}
+
+type jsonConfig struct {
+	Folder         string         `json:"folder,omitempty"`
+	LevelDBOptions levelDBOptions `json:"leveldb_options,omitempty"`
+}
+
+// ConfigKey returns a human-friendly identifier for this type of Datastore.
+func (cfg *Config) ConfigKey() string {
+	return configKey
+}
+
+// Default initializes this Config with sensible values.
+func (cfg *Config) Default() error {
+	cfg.Folder = DefaultSubFolder
+	cfg.LevelDBOptions = DefaultLevelDBOptions
+	return nil
+}
+
+// ApplyEnvVars fills in any Config fields found as environment variables.
+func (cfg *Config) ApplyEnvVars() error {
+	jcfg := cfg.toJSONConfig()
+
+	err := envconfig.Process(envConfigKey, jcfg)
+	if err != nil {
+		return err
+	}
+
+	return cfg.applyJSONConfig(jcfg)
+}
+
+// Validate checks that the fields of this Config have working values,
+// at least in appearance.
+func (cfg *Config) Validate() error {
+	if cfg.Folder == "" {
+		return errors.New("folder is unset")
+	}
+
+	return nil
+}
+
+// LoadJSON reads the fields of this Config from a JSON byteslice as
+// generated by ToJSON.
+func (cfg *Config) LoadJSON(raw []byte) error {
+	jcfg := &jsonConfig{}
+	err := json.Unmarshal(raw, jcfg)
+	if err != nil {
+		return err
+	}
+	cfg.Default()
+
+	return cfg.applyJSONConfig(jcfg)
+}
+
+func (cfg *Config) applyJSONConfig(jcfg *jsonConfig) error {
+	config.SetIfNotDefault(jcfg.Folder, &cfg.Folder)
+
+	ldbOpts := jcfg.LevelDBOptions.Unmarshal()
+
+	if err := mergo.Merge(&cfg.LevelDBOptions, ldbOpts, mergo.WithOverride); err != nil {
+		return err
+	}
+
+	return cfg.Validate()
+}
+
+// ToJSON generates a JSON-formatted human-friendly representation of this
+// Config.
+func (cfg *Config) ToJSON() (raw []byte, err error) {
+	jcfg := cfg.toJSONConfig()
+
+	raw, err = config.DefaultJSONMarshal(jcfg)
+	return
+}
+
+func (cfg *Config) toJSONConfig() *jsonConfig {
+	jCfg := &jsonConfig{}
+
+	if cfg.Folder != DefaultSubFolder {
+		jCfg.Folder = cfg.Folder
+	}
+
+	bo := &levelDBOptions{}
+	bo.Marshal(&cfg.LevelDBOptions)
+	jCfg.LevelDBOptions = *bo
+
+	return jCfg
+}
+
+// GetFolder returns the LevelDB folder.
+func (cfg *Config) GetFolder() string {
+	if filepath.IsAbs(cfg.Folder) {
+		return cfg.Folder
+	}
+
+	return filepath.Join(cfg.BaseDir, cfg.Folder)
+}
+
+// ToDisplayJSON returns JSON config as a string.
+func (cfg *Config) ToDisplayJSON() ([]byte, error) {
+	return config.DisplayJSON(cfg.toJSONConfig())
+}

--- a/datastore/leveldb/config_test.go
+++ b/datastore/leveldb/config_test.go
@@ -1,0 +1,47 @@
+package leveldb
+
+import (
+	"testing"
+)
+
+var cfgJSON = []byte(`
+{
+    "folder": "test",
+    "leveldb_options": {
+         "no_sync": true,
+         "compaction_total_size_multiplier": 1.5
+    }
+}
+`)
+
+func TestLoadJSON(t *testing.T) {
+	cfg := &Config{}
+	err := cfg.LoadJSON(cfgJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToJSON(t *testing.T) {
+	cfg := &Config{}
+	cfg.LoadJSON(cfgJSON)
+
+	if !cfg.LevelDBOptions.NoSync {
+		t.Fatalf("NoSync should be true")
+	}
+
+	if cfg.LevelDBOptions.CompactionTotalSizeMultiplier != 1.5 {
+		t.Fatal("TotalSizeMultiplier should be 1.5")
+	}
+
+	newjson, err := cfg.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg = &Config{}
+	err = cfg.LoadJSON(newjson)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/datastore/leveldb/leveldb.go
+++ b/datastore/leveldb/leveldb.go
@@ -1,0 +1,32 @@
+// Package leveldb provides a configurable LevelDB go-datastore for use with
+// IPFS Cluster.
+package leveldb
+
+import (
+	"os"
+
+	ds "github.com/ipfs/go-datastore"
+	leveldbds "github.com/ipfs/go-ds-leveldb"
+	"github.com/pkg/errors"
+)
+
+// New returns a LevelDB datastore configured with the given
+// configuration.
+func New(cfg *Config) (ds.Datastore, error) {
+	folder := cfg.GetFolder()
+	err := os.MkdirAll(folder, 0700)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating leveldb folder")
+	}
+	return leveldbds.NewDatastore(folder, (*leveldbds.Options)(&cfg.LevelDBOptions))
+}
+
+// Cleanup deletes the leveldb datastore.
+func Cleanup(cfg *Config) error {
+	folder := cfg.GetFolder()
+	if _, err := os.Stat(folder); os.IsNotExist(err) {
+		return nil
+	}
+	return os.RemoveAll(cfg.GetFolder())
+
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.5
 	github.com/ipfs/go-ds-badger v0.2.6
 	github.com/ipfs/go-ds-crdt v0.1.20
+	github.com/ipfs/go-ds-leveldb v0.4.2
 	github.com/ipfs/go-fs-lock v0.0.6
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/ipfs/go-ipfs-chunker v0.0.5
@@ -65,6 +66,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/rs/cors v1.7.0
+	github.com/syndtr/goleveldb v1.0.0
 	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926
 	github.com/ugorji/go/codec v1.2.5
 	github.com/urfave/cli v1.22.5


### PR DESCRIPTION
Badger can take 1000x the amount of needed space if not GC'ed or compacted
(#1320), even for non heavy usage. Cluster has no provisions to run datastore
GC operations and while they could be added, they are not ensured to
help. Improvements on Badger v3 might help but would still need to GC
explicitally.

Cluster was however designed to support any go-datastore as backend.

This commit adds LevelDB support. LevelDB go-datastore wrapper is mature, does
not need GC and should work well for most cluster usecases, which are not
overly demanding.

A new `--datastore` flag has been added on init. The store backend is selected
based on the value in the configuration, similar to how raft/crdt is. The
default is set to leveldb. From now on it should be easier to add additional
backends, i.e. badgerv3.