### PR TITLE
Fix #1320: Add automatic GC to Badger datastore

### DIFF
--- a/config/util.go
+++ b/config/util.go
@@ -77,6 +77,11 @@ func SetIfNotDefault(src interface{}, dest interface{}) {
 		if n != 0 {
 			*dest.(*int) = n
 		}
+	case float64:
+		n := src.(float64)
+		if n != 0 {
+			*dest.(*float64) = n
+		}
 	case bool:
 		b := src.(bool)
 		if b {

--- a/config_test.go
+++ b/config_test.go
@@ -65,6 +65,8 @@ var testingCrdtCfg = []byte(`{
 
 var testingBadgerCfg = []byte(`{
     "folder": "badgerFromTests",
+    "gc_interval": "0m",
+    "gc_sleep": "0m",
     "badger_options": {
         "max_table_size": 1048576
     }

--- a/datastore/badger/badger.go
+++ b/datastore/badger/badger.go
@@ -18,7 +18,12 @@ func New(cfg *Config) (ds.Datastore, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating badger folder")
 	}
-	opts := badgerds.Options{Options: cfg.BadgerOptions}
+	opts := badgerds.Options{
+		GcDiscardRatio: cfg.GCDiscardRatio,
+		GcInterval:     cfg.GCInterval,
+		GcSleep:        cfg.GCSleep,
+		Options:        cfg.BadgerOptions,
+	}
 	return badgerds.NewDatastore(folder, &opts)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5
-	github.com/ipfs/go-ds-badger v0.2.6
+	github.com/ipfs/go-ds-badger v0.2.7
 	github.com/ipfs/go-ds-crdt v0.1.20
 	github.com/ipfs/go-ds-leveldb v0.4.2
 	github.com/ipfs/go-fs-lock v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/ipfs/go-ds-badger v0.2.1/go.mod h1:Tx7l3aTph3FMFrRS838dcSJh+jjA7cX9Dr
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
 github.com/ipfs/go-ds-badger v0.2.6 h1:Hy8jw4rifxtRDrqpvC1yh36oIyE37KDzsUzlHUPOFiU=
 github.com/ipfs/go-ds-badger v0.2.6/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
+github.com/ipfs/go-ds-badger v0.2.7 h1:ju5REfIm+v+wgVnQ19xGLYPHYHbYLR6qJfmMbCDSK1I=
+github.com/ipfs/go-ds-badger v0.2.7/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
 github.com/ipfs/go-ds-crdt v0.1.20 h1:4iJPmZSXq4/2gLOq0fVH3ROYDjw39vgdCyJF7akkdvE=
 github.com/ipfs/go-ds-crdt v0.1.20/go.mod h1:1LiDiHfnunQ6UfilPCkgtlWTX8vWP9hiQt4Q5GK+jaE=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=


### PR DESCRIPTION
This takes advantage of go-ds-badger "auto-gc" feature.

It will run a GC cycle made of multiple GC rounds (until it cannot GC more)
automatically. The behaviour is enabled by default in the configuration and
can be disabled by setting "gc_interval" to "0m". Hopefully this prevents
badger datastores from growing crazy.