### PR TITLE
Fix #1360: Efficient pinset status with filters

### DIFF
--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -891,30 +891,6 @@ func (api *API) allocationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// filterGlobalPinInfos takes a GlobalPinInfo slice and discards
-// any item in it which does not carry a PinInfo matching the
-// filter (OR-wise).
-func filterGlobalPinInfos(globalPinInfos []*types.GlobalPinInfo, filter types.TrackerStatus) []*types.GlobalPinInfo {
-	if filter == types.TrackerStatusUndefined {
-		return globalPinInfos
-	}
-
-	var filteredGlobalPinInfos []*types.GlobalPinInfo
-
-	for _, globalPinInfo := range globalPinInfos {
-		for _, pinInfo := range globalPinInfo.PeerMap {
-			// silenced the error because we should have detected
-			// earlier if filters were invalid
-			if pinInfo.Status.Match(filter) {
-				filteredGlobalPinInfos = append(filteredGlobalPinInfos, globalPinInfo)
-				break
-			}
-		}
-	}
-
-	return filteredGlobalPinInfos
-}
-
 func (api *API) statusAllHandler(w http.ResponseWriter, r *http.Request) {
 	queryValues := r.URL.Query()
 	local := queryValues.Get("local")
@@ -936,7 +912,7 @@ func (api *API) statusAllHandler(w http.ResponseWriter, r *http.Request) {
 			"",
 			"Cluster",
 			"StatusAllLocal",
-			struct{}{},
+			filter,
 			&pinInfos,
 		)
 		if err != nil {
@@ -950,7 +926,7 @@ func (api *API) statusAllHandler(w http.ResponseWriter, r *http.Request) {
 			"",
 			"Cluster",
 			"StatusAll",
-			struct{}{},
+			filter,
 			&globalPinInfos,
 		)
 		if err != nil {
@@ -958,8 +934,6 @@ func (api *API) statusAllHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
-	globalPinInfos = filterGlobalPinInfos(globalPinInfos, filter)
 
 	api.sendResponse(w, autoStatus, nil, globalPinInfos)
 }

--- a/api/types.go
+++ b/api/types.go
@@ -77,6 +77,9 @@ const (
 	// The IPFS daemon is not pinning the item through this cid but it is
 	// tracked in a cluster dag
 	TrackerStatusSharded
+	// The item is in the state and should be pinned, but
+	// it is however not pinned and not queued/pinning.
+	TrackerStatusUnexpectedlyUnpinned
 )
 
 // Composite TrackerStatus.
@@ -89,19 +92,21 @@ const (
 type TrackerStatus int
 
 var trackerStatusString = map[TrackerStatus]string{
-	TrackerStatusUndefined:    "undefined",
-	TrackerStatusClusterError: "cluster_error",
-	TrackerStatusPinError:     "pin_error",
-	TrackerStatusUnpinError:   "unpin_error",
-	TrackerStatusError:        "error",
-	TrackerStatusPinned:       "pinned",
-	TrackerStatusPinning:      "pinning",
-	TrackerStatusUnpinning:    "unpinning",
-	TrackerStatusUnpinned:     "unpinned",
-	TrackerStatusRemote:       "remote",
-	TrackerStatusPinQueued:    "pin_queued",
-	TrackerStatusUnpinQueued:  "unpin_queued",
-	TrackerStatusQueued:       "queued",
+	TrackerStatusUndefined:            "undefined",
+	TrackerStatusClusterError:         "cluster_error",
+	TrackerStatusPinError:             "pin_error",
+	TrackerStatusUnpinError:           "unpin_error",
+	TrackerStatusError:                "error",
+	TrackerStatusPinned:               "pinned",
+	TrackerStatusPinning:              "pinning",
+	TrackerStatusUnpinning:            "unpinning",
+	TrackerStatusUnpinned:             "unpinned",
+	TrackerStatusRemote:               "remote",
+	TrackerStatusPinQueued:            "pin_queued",
+	TrackerStatusUnpinQueued:          "unpin_queued",
+	TrackerStatusQueued:               "queued",
+	TrackerStatusSharded:              "sharded",
+	TrackerStatusUnexpectedlyUnpinned: "unexpectedly_unpinned",
 }
 
 // values autofilled in init()
@@ -130,9 +135,11 @@ func (st TrackerStatus) String() string {
 
 // Match returns true if the tracker status matches the given filter.
 // For example TrackerStatusPinError will match TrackerStatusPinError
-// and TrackerStatusError
+// and TrackerStatusError.
 func (st TrackerStatus) Match(filter TrackerStatus) bool {
-	return filter == 0 || st&filter > 0
+	return filter == TrackerStatusUndefined ||
+		st == TrackerStatusUndefined ||
+		st&filter > 0
 }
 
 // MarshalJSON uses the string representation of TrackerStatus for JSON

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -119,8 +119,9 @@ type PinTracker interface {
 	// Untrack tells the tracker that a Cid is to be forgotten. The tracker
 	// may perform an IPFS unpin operation.
 	Untrack(context.Context, cid.Cid) error
-	// StatusAll returns the list of pins with their local status.
-	StatusAll(context.Context) []*api.PinInfo
+	// StatusAll returns the list of pins with their local status. Takes a
+	// filter to specify which statuses to report.
+	StatusAll(context.Context, api.TrackerStatus) []*api.PinInfo
 	// Status returns the local status of a given Cid.
 	Status(context.Context, cid.Cid) *api.PinInfo
 	// RecoverAll calls Recover() for all pins tracked.

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -655,7 +655,7 @@ func TestClustersPin(t *testing.T) {
 		delay()
 	}
 	fpinned := func(t *testing.T, c *Cluster) {
-		status := c.tracker.StatusAll(ctx)
+		status := c.tracker.StatusAll(ctx, api.TrackerStatusUndefined)
 		for _, v := range status {
 			if v.Status != api.TrackerStatusPinned {
 				t.Errorf("%s should have been pinned but it is %s", v.Cid, v.Status)
@@ -704,7 +704,7 @@ func TestClustersPin(t *testing.T) {
 	delay()
 
 	funpinned := func(t *testing.T, c *Cluster) {
-		status := c.tracker.StatusAll(ctx)
+		status := c.tracker.StatusAll(ctx, api.TrackerStatusUndefined)
 		for _, v := range status {
 			t.Errorf("%s should have been unpinned but it is %s", v.Cid, v.Status)
 		}
@@ -848,7 +848,7 @@ func TestClustersStatusAll(t *testing.T) {
 	pinDelay()
 	// Global status
 	f := func(t *testing.T, c *Cluster) {
-		statuses, err := c.StatusAll(ctx)
+		statuses, err := c.StatusAll(ctx, api.TrackerStatusUndefined)
 		if err != nil {
 			t.Error(err)
 		}
@@ -910,7 +910,7 @@ func TestClustersStatusAllWithErrors(t *testing.T) {
 			return
 		}
 
-		statuses, err := c.StatusAll(ctx)
+		statuses, err := c.StatusAll(ctx, api.TrackerStatusUndefined)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1194,7 +1194,7 @@ func TestClustersReplicationOverall(t *testing.T) {
 
 	f := func(t *testing.T, c *Cluster) {
 		// confirm that the pintracker state matches the current global state
-		pinfos := c.tracker.StatusAll(ctx)
+		pinfos := c.tracker.StatusAll(ctx, api.TrackerStatusUndefined)
 		if len(pinfos) != nClusters {
 			t.Error("Pinfos does not have the expected pins")
 		}

--- a/pintracker/pintracker_test.go
+++ b/pintracker/pintracker_test.go
@@ -204,7 +204,7 @@ func TestPinTracker_StatusAll(t *testing.T) {
 					// in state but not on IPFS
 					Cid: test.Cid4,
 					PinInfoShort: api.PinInfoShort{
-						Status: api.TrackerStatusPinError,
+						Status: api.TrackerStatusUnexpectedlyUnpinned,
 					},
 				},
 			},
@@ -216,7 +216,7 @@ func TestPinTracker_StatusAll(t *testing.T) {
 				t.Errorf("PinTracker.Track() error = %v", err)
 			}
 			time.Sleep(200 * time.Millisecond)
-			got := tt.args.tracker.StatusAll(context.Background())
+			got := tt.args.tracker.StatusAll(context.Background(), api.TrackerStatusUndefined)
 			if len(got) != len(tt.want) {
 				for _, pi := range got {
 					t.Logf("pinfo: %v", pi)
@@ -259,7 +259,7 @@ func BenchmarkPinTracker_StatusAll(b *testing.B) {
 		b.Run(tt.name, func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				tt.args.tracker.StatusAll(context.Background())
+				tt.args.tracker.StatusAll(context.Background(), api.TrackerStatusUndefined)
 			}
 		})
 	}

--- a/pintracker/stateless/stateless_test.go
+++ b/pintracker/stateless/stateless_test.go
@@ -397,7 +397,7 @@ func TestStatusAll(t *testing.T) {
 	// * A slow CID pinning
 	// * Cid1 is pinned
 	// * Cid4 should be in PinError (it's in the state but not on IPFS)
-	stAll := spt.StatusAll(ctx)
+	stAll := spt.StatusAll(ctx, api.TrackerStatusUndefined)
 	if len(stAll) != 3 {
 		t.Errorf("wrong status length. Expected 3, got: %d", len(stAll))
 	}
@@ -409,8 +409,8 @@ func TestStatusAll(t *testing.T) {
 				t.Error("cid1 should be pinned")
 			}
 		case test.Cid4:
-			if pi.Status != api.TrackerStatusPinError {
-				t.Error("cid2 should be in pin_error status")
+			if pi.Status != api.TrackerStatusUnexpectedlyUnpinned {
+				t.Error("cid2 should be in unexpectedly_unpinned status")
 			}
 		case test.SlowCid1:
 			if pi.Status != api.TrackerStatusPinning {
@@ -471,6 +471,6 @@ func BenchmarkTracker_localStatus(b *testing.B) {
 	ctx := context.Background()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tracker.localStatus(ctx, true)
+		tracker.localStatus(ctx, true, api.TrackerStatusUndefined)
 	}
 }

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -263,8 +263,8 @@ func (rpcapi *ClusterRPCAPI) Join(ctx context.Context, in api.Multiaddr, out *st
 }
 
 // StatusAll runs Cluster.StatusAll().
-func (rpcapi *ClusterRPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]*api.GlobalPinInfo) error {
-	pinfos, err := rpcapi.c.StatusAll(ctx)
+func (rpcapi *ClusterRPCAPI) StatusAll(ctx context.Context, in api.TrackerStatus, out *[]*api.GlobalPinInfo) error {
+	pinfos, err := rpcapi.c.StatusAll(ctx, in)
 	if err != nil {
 		return err
 	}
@@ -273,8 +273,8 @@ func (rpcapi *ClusterRPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]
 }
 
 // StatusAllLocal runs Cluster.StatusAllLocal().
-func (rpcapi *ClusterRPCAPI) StatusAllLocal(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
-	pinfos := rpcapi.c.StatusAllLocal(ctx)
+func (rpcapi *ClusterRPCAPI) StatusAllLocal(ctx context.Context, in api.TrackerStatus, out *[]*api.PinInfo) error {
+	pinfos := rpcapi.c.StatusAllLocal(ctx, in)
 	*out = pinfos
 	return nil
 }
@@ -452,10 +452,10 @@ func (rpcapi *PinTrackerRPCAPI) Untrack(ctx context.Context, in *api.Pin, out *s
 }
 
 // StatusAll runs PinTracker.StatusAll().
-func (rpcapi *PinTrackerRPCAPI) StatusAll(ctx context.Context, in struct{}, out *[]*api.PinInfo) error {
+func (rpcapi *PinTrackerRPCAPI) StatusAll(ctx context.Context, in api.TrackerStatus, out *[]*api.PinInfo) error {
 	ctx, span := trace.StartSpan(ctx, "rpc/tracker/StatusAll")
 	defer span.End()
-	*out = rpcapi.tracker.StatusAll(ctx)
+	*out = rpcapi.tracker.StatusAll(ctx, in)
 	return nil
 }
 


### PR DESCRIPTION
This commit modifies the pintracker StatusAll call to take a status filter.

This allows to skip a PinLs call to ipfs when checking status for items that
are queued, pinning, unpinning or in error. Those status come directly from
the operation tracker. This should result in a significant performance
increase for those calls, particularly in nodes with several hundred thousand
pins and more, where the call to IPFS is very expensive.

A new TrackerStatusUnexpectedlyUnpinned status has been introduce to
differentiate between pin errors (tracked by the operation tracker) and "lost"
items (which before were pin errors too). This new status is handled by the
Recover() operation as before.

Fixes #1360 .