### PR TITLE
Fix: tests: close datastore on cluster node shutdown.

### DIFF
--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -423,6 +423,7 @@ func shutdownCluster(t *testing.T, c *Cluster, m *test.IpfsMock) {
 	}
 	c.dht.Close()
 	c.host.Close()
+	c.datastore.Close()
 	m.Close()
 }
 


### PR DESCRIPTION
This resulted in too-many-files-open when running with leveldb.