### PR TITLE
Fix #1403: ctl: ssl errors when talking to https remote peers

### DIFF
--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -182,7 +182,16 @@ requires authorization. implies --https, which you can disable with --force-http
 				logger.Warn("Using libp2p-http for %s. The https flag will be ignored for this connection", addr)
 			}
 
-			cfgs, err := cfg.AsTemplateForResolvedAddress(ctx, multiaddr)
+			var cfgs []*client.Config
+
+			// We can auto round-robin on DNS records when using
+			// libp2p-http or not using SSL. When using SSL we
+			// cannot use the resolve-IPs directly.
+			if client.IsPeerAddress(multiaddr) || !cfg.SSL {
+				cfgs, err = cfg.AsTemplateForResolvedAddress(ctx, multiaddr)
+			} else {
+				cfgs = cfg.AsTemplateFor([]ma.Multiaddr{multiaddr})
+			}
 			checkErr("creating configs", err)
 			configs = append(configs, cfgs...)
 		}


### PR DESCRIPTION
When using SSL and not talking to libp2p-http endpoints, we should not
resolve the dns names in the multiaddresses as otherwise we cannot
verify the https certificates used by the remote endpoint.

Fixes #1403.