### PR TITLE
restapi: allocationsHandler: skip filtering pins when not needed.

### DIFF
--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -862,11 +862,18 @@ func (api *API) allocationsHandler(w http.ResponseWriter, r *http.Request) {
 		struct{}{},
 		&pins,
 	)
-	outPins := make([]*types.Pin, 0)
-	for _, pin := range pins {
-		if filter&pin.Type > 0 {
-			// add this pin to output
-			outPins = append(outPins, pin)
+
+	var outPins []*types.Pin
+
+	if filter == types.AllType {
+		outPins = pins
+	} else {
+		outPins = make([]*types.Pin, 0, len(pins))
+		for _, pin := range pins {
+			if filter&pin.Type > 0 {
+				// add this pin to output
+				outPins = append(outPins, pin)
+			}
 		}
 	}
 	api.sendResponse(w, autoStatus, err, outPins)

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -795,7 +795,7 @@ merely represents the list of pins which are part of the shared state of
 the cluster. For IPFS-status information about the pins, use "status".
 
 The filter only takes effect when listing all pins. The possible values are:
-  - all
+  - all (default)
   - pin (normal pins, recursive or direct)
   - meta-pin (sharded pins)
   - clusterdag-pin (sharding-dag root pins)
@@ -806,7 +806,7 @@ The filter only takes effect when listing all pins. The possible values are:
 						cli.StringFlag{
 							Name:  "filter",
 							Usage: "Comma separated list of pin types. See help above.",
-							Value: "pin",
+							Value: "all",
 						},
 					},
 					Action: func(c *cli.Context) error {


### PR DESCRIPTION
The restapi component supports filters for the pinset. This was done to keep
expected output when sharding was fully supported by filtering out "internal"
pins.

However this filter requires looping on the full pinset and re-allocating  and
usually does nothing. The useless copy is significant for really big pinsets.

Additionally, ipfs-cluster-ctl set the filter by default to "pins". By setting
it to "all" instead we can skip the whole filtering step and, in practice, get the
same results.