### PR TITLE
Fix: improve log level handling

### DIFF
--- a/cmd/ipfs-cluster-follow/commands.go
+++ b/cmd/ipfs-cluster-follow/commands.go
@@ -55,6 +55,10 @@ func setLogLevels(lvl string) {
 	for f := range ipfscluster.LoggingFacilities {
 		ipfscluster.SetFacilityLogLevel(f, lvl)
 	}
+
+	for f := range ipfscluster.LoggingFacilitiesExtra {
+		ipfscluster.SetFacilityLogLevel(f, lvl)
+	}
 }
 
 // returns whether the config folder exists

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -640,13 +640,26 @@ func setupLogLevel(debug bool, l string) error {
 	ipfscluster.SetFacilityLogLevel("service", logLevel)
 
 	logfacs := make(map[string]string)
-	for key := range ipfscluster.LoggingFacilities {
-		logfacs[key] = logLevel
-	}
 
 	// fill component-wise log levels
 	for identifier, level := range compLogFacs {
 		logfacs[identifier] = level
+	}
+
+	// Set the values for things not set by the user or for
+	// things set by "all".
+	for key := range ipfscluster.LoggingFacilities {
+		if _, ok := logfacs[key]; !ok {
+			logfacs[key] = logLevel
+		}
+	}
+
+	// For Extra facilities, set the defaults per logging.go unless
+	// manually set
+	for key, defaultLvl := range ipfscluster.LoggingFacilitiesExtra {
+		if _, ok := logfacs[key]; !ok {
+			logfacs[key] = defaultLvl
+		}
 	}
 
 	for identifier, level := range logfacs {

--- a/logging.go
+++ b/logging.go
@@ -39,6 +39,7 @@ var LoggingFacilitiesExtra = map[string]string{
 	"swarm2":      "ERROR",
 	"libp2p-raft": "CRITICAL",
 	"raftlib":     "ERROR",
+	"badger":      "INFO",
 }
 
 // SetFacilityLogLevel sets the log level for a given module


### PR DESCRIPTION
We have default log levels for things like swarm and go-rpc but we were ignoring them. Among the effects, the go-rpc library pollutes logs a lot with things like "context timeout" and 0 useful information. These errors will be logged by other components when relevant.