### PR TITLE
Pintracker: support prioritary pinning for recent pins with small number of retries

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -285,11 +285,12 @@ func (gpi *GlobalPinInfo) Add(pi *PinInfo) {
 // PinInfoShort is a subset of PinInfo which is embedded in GlobalPinInfo
 // objects and does not carry redundant information as PinInfo would.
 type PinInfoShort struct {
-	PeerName   string        `json:"peername" codec:"pn,omitempty"`
-	Status     TrackerStatus `json:"status" codec:"st,omitempty"`
-	TS         time.Time     `json:"timestamp" codec:"ts,omitempty"`
-	Error      string        `json:"error" codec:"e,omitempty"`
-	RetryCount int           `json:"retry_count" codec:"r,omitempty"`
+	PeerName     string        `json:"peername" codec:"pn,omitempty"`
+	Status       TrackerStatus `json:"status" codec:"st,omitempty"`
+	TS           time.Time     `json:"timestamp" codec:"ts,omitempty"`
+	Error        string        `json:"error" codec:"e,omitempty"`
+	AttemptCount int           `json:"attempt_count" codec:"a,omitempty"`
+	PriorityPin  bool          `json:"priority_pin" codec:"y,omitempty"`
 }
 
 // PinInfo holds information about local pins. This is used by the Pin

--- a/api/types.go
+++ b/api/types.go
@@ -285,10 +285,11 @@ func (gpi *GlobalPinInfo) Add(pi *PinInfo) {
 // PinInfoShort is a subset of PinInfo which is embedded in GlobalPinInfo
 // objects and does not carry redundant information as PinInfo would.
 type PinInfoShort struct {
-	PeerName string        `json:"peername" codec:"pn,omitempty"`
-	Status   TrackerStatus `json:"status" codec:"st,omitempty"`
-	TS       time.Time     `json:"timestamp" codec:"ts,omitempty"`
-	Error    string        `json:"error" codec:"e,omitempty"`
+	PeerName   string        `json:"peername" codec:"pn,omitempty"`
+	Status     TrackerStatus `json:"status" codec:"st,omitempty"`
+	TS         time.Time     `json:"timestamp" codec:"ts,omitempty"`
+	Error      string        `json:"error" codec:"e,omitempty"`
+	RetryCount int           `json:"retry_count" codec:"r,omitempty"`
 }
 
 // PinInfo holds information about local pins. This is used by the Pin

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -173,10 +173,8 @@ func textFormatPrintGPInfo(obj *api.GlobalPinInfo) {
 		}
 		txt, _ := v.TS.MarshalText()
 		fmt.Fprintf(&b, " | %s", txt)
-
-		if retries := v.RetryCount; retries > 0 {
-			fmt.Fprintf(&b, " | Retries: %d", retries)
-		}
+		fmt.Fprintf(&b, " | Attempts: %d", v.AttemptCount)
+		fmt.Fprintf(&b, " | Priority: %t", v.PriorityPin)
 		fmt.Fprintf(&b, "\n")
 	}
 	fmt.Print(b.String())

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -172,7 +172,12 @@ func textFormatPrintGPInfo(obj *api.GlobalPinInfo) {
 			fmt.Fprintf(&b, ": %s", v.Error)
 		}
 		txt, _ := v.TS.MarshalText()
-		fmt.Fprintf(&b, " | %s\n", txt)
+		fmt.Fprintf(&b, " | %s", txt)
+
+		if retries := v.RetryCount; retries > 0 {
+			fmt.Fprintf(&b, " | Retries: %d", retries)
+		}
+		fmt.Fprintf(&b, "\n")
 	}
 	fmt.Print(b.String())
 }

--- a/pintracker/optracker/operationtracker.go
+++ b/pintracker/optracker/operationtracker.go
@@ -141,10 +141,11 @@ func (opt *OperationTracker) unsafePinInfo(ctx context.Context, op *Operation) a
 			Cid:  cid.Undef,
 			Peer: opt.pid,
 			PinInfoShort: api.PinInfoShort{
-				PeerName: opt.peerName,
-				Status:   api.TrackerStatusUnpinned,
-				TS:       time.Now(),
-				Error:    "",
+				PeerName:   opt.peerName,
+				Status:     api.TrackerStatusUnpinned,
+				TS:         time.Now(),
+				RetryCount: 0,
+				Error:      "",
 			},
 		}
 	}
@@ -152,10 +153,11 @@ func (opt *OperationTracker) unsafePinInfo(ctx context.Context, op *Operation) a
 		Cid:  op.Cid(),
 		Peer: opt.pid,
 		PinInfoShort: api.PinInfoShort{
-			PeerName: opt.peerName,
-			Status:   op.ToTrackerStatus(),
-			TS:       op.Timestamp(),
-			Error:    op.Error(),
+			PeerName:   opt.peerName,
+			Status:     op.ToTrackerStatus(),
+			TS:         op.Timestamp(),
+			RetryCount: op.RetryCount(),
+			Error:      op.Error(),
 		},
 	}
 }

--- a/pintracker/optracker/operationtracker.go
+++ b/pintracker/optracker/operationtracker.go
@@ -83,8 +83,9 @@ func (opt *OperationTracker) TrackNewOperation(ctx context.Context, pin *api.Pin
 	}
 
 	op2 := NewOperation(ctx, pin, typ, ph)
-	if ok { // Carry over the attempt count.
-		// The old operation exists and was cancelled.
+	if ok && op.Type() == typ {
+		// Carry over the attempt count when doing an operation of the
+		// same type.  The old operation exists and was cancelled.
 		op2.attemptCount = op.AttemptCount() // carry the count
 	}
 	logger.Debugf("'%s' on cid '%s' has been created with phase '%s'", typ, pin.Cid, ph)

--- a/pintracker/stateless/stateless.go
+++ b/pintracker/stateless/stateless.go
@@ -196,7 +196,12 @@ func (spt *Tracker) enqueue(ctx context.Context, c *api.Pin, typ optracker.Opera
 
 	switch typ {
 	case optracker.OperationPin:
-		ch = spt.pinCh
+		if time.Now().Before(c.Timestamp.Add(spt.config.PriorityPinMaxAge)) &&
+			op.RetryCount() <= spt.config.PriorityPinMaxRetries {
+			ch = spt.priorityPinCh
+		} else {
+			ch = spt.pinCh
+		}
 	case optracker.OperationUnpin:
 		ch = spt.unpinCh
 	}


### PR DESCRIPTION
Fixes #1469 

This PR improves the stateless pintracker component in multiple ways:
  * The operation manager tracks retry counts for operations. These are shown as part of the pin status. Retry counts are not stored on disk. They are reset on restart.
  * The pinning queue is doubled into a priority queue and a normal queue. Items on the priority queue get to be processed first.
  * The pintracker decides which pins end up in the priority queue based on two configurations settings:
    * The number of retries that a pin has on it.
    * The age of the pin.

In practical terms: a cluster may ingest many thousands of pins, not all of which end up pinned (low quality providers etc). Those that fail to pin multiple times (retries) or potentially become old (i.e. they were added more than a day ago and are not pinned) will move into the no-priority queue. They will not get in the way of pinning new content that arrives to the cluster and which will be attempted first.

This alleviates practical use-cases like web3.storage clusters, which have many thousands of pins in error state which get regurlarly requeued. When that happens, they hinder the pinning of new items which are constantly arriving and are well provided.