### PR TITLE
ipfs-cluster-ctl: improve printing of health metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # IPFS Cluster Changelog
 
-### v0.14.2 - 2021-12-01
+### v0.14.2 - 2021-12-10
 
 This is a minor IPFS Cluster release focused on providing features for
 production Cluster deployments with very high pin ingestion rates.
@@ -48,6 +48,7 @@ configure these new features.
   * Refactor API to facilitate re-use of functionality | [ipfs/ipfs-cluster#1471](https://github.com/ipfs/ipfs-cluster/issues/1471)
   * Move testing to Github Actions | [ipfs/ipfs-cluster#1486](https://github.com/ipfs/ipfs-cluster/issues/1486)
   * Dependency upgrades (go-libp2p v0.16.0 etc.) | [ipfs/ipfs-cluster#1491](https://github.com/ipfs/ipfs-cluster/issues/1491) | [ipfs/ipfs-cluster#1501](https://github.com/ipfs/ipfs-cluster/issues/1501) | [ipfs/ipfs-cluster#1504](https://github.com/ipfs/ipfs-cluster/issues/1504)
+  * Improve `health metrics <metric>` output in ipfs-cluster-ctl | [ipfs/ipfs-cluster#1506](https://github.com/ipfs/ipfs-cluster/issues/1506)
 
 #### Upgrading notices
 

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -245,14 +244,12 @@ func textFormatPrintAddedOutputQuiet(obj *addedOutputQuiet) {
 }
 
 func textFormatPrintMetric(obj *api.Metric) {
-	if obj.Name == "freespace" {
-		u, err := strconv.ParseUint(obj.Value, 10, 64)
-		checkErr("parsing to uint64", err)
-		fmt.Printf("%s | freespace: %s | Expires in: %s\n", peer.Encode(obj.Peer), humanize.Bytes(u), humanize.Time(time.Unix(0, obj.Expire)))
-		return
+	v := obj.Value
+	if obj.Name == "freespace" && obj.Weight > 0 {
+		v = humanize.Bytes(uint64(obj.Weight))
 	}
 
-	fmt.Printf("%s | %s | Expires in: %s\n", peer.Encode(obj.Peer), obj.Name, humanize.Time(time.Unix(0, obj.Expire)))
+	fmt.Printf("%s | %s: %s | Expires in: %s\n", peer.Encode(obj.Peer), obj.Name, v, humanize.Time(time.Unix(0, obj.Expire)))
 }
 
 func textFormatPrintAlert(obj *api.Alert) {


### PR DESCRIPTION
Make sure we print the value in all cases. Use the weight for the free-space
metric, no need to parse the value anymore.