### PR TITLE
Fix state deserialization

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -566,16 +566,16 @@ func (pm PinMode) ToPinDepth() PinDepth {
 
 // PinOptions wraps user-defined options for Pins
 type PinOptions struct {
-	ReplicationFactorMin int                   `json:"replication_factor_min" codec:"rn,omitempty"`
-	ReplicationFactorMax int                   `json:"replication_factor_max" codec:"rx,omitempty"`
-	Name                 string                `json:"name" codec:"n,omitempty"`
-	Mode                 PinMode               `json:"mode" codec:"o,omitempty"`
-	ShardSize            uint64                `json:"shard_size" codec:"s,omitempty"`
-	UserAllocations      []peer.ID             `json:"user_allocations" codec:"ua,omitempty"`
-	ExpireAt             time.Time             `json:"expire_at" codec:"e,omitempty"`
-	Metadata             map[string]string     `json:"metadata" codec:"m,omitempty"`
-	PinUpdate            cid.Cid               `json:"pin_update,omitempty" codec:"pu,omitempty"`
-	Origins              []multiaddr.Multiaddr `json:"origins" codec:"g,omitempty"`
+	ReplicationFactorMin int               `json:"replication_factor_min" codec:"rn,omitempty"`
+	ReplicationFactorMax int               `json:"replication_factor_max" codec:"rx,omitempty"`
+	Name                 string            `json:"name" codec:"n,omitempty"`
+	Mode                 PinMode           `json:"mode" codec:"o,omitempty"`
+	ShardSize            uint64            `json:"shard_size" codec:"s,omitempty"`
+	UserAllocations      []peer.ID         `json:"user_allocations" codec:"ua,omitempty"`
+	ExpireAt             time.Time         `json:"expire_at" codec:"e,omitempty"`
+	Metadata             map[string]string `json:"metadata" codec:"m,omitempty"`
+	PinUpdate            cid.Cid           `json:"pin_update,omitempty" codec:"pu,omitempty"`
+	Origins              []Multiaddr       `json:"origins" codec:"g,omitempty"`
 }
 
 // Equals returns true if two PinOption objects are equivalent. po and po2 may
@@ -646,7 +646,7 @@ func (po *PinOptions) Equals(po2 *PinOptions) bool {
 	for _, o1 := range po.Origins {
 		found := false
 		for _, o2 := range po2.Origins {
-			if o1.Equal(o2) {
+			if o1.Value().Equal(o2.Value()) {
 				found = true
 			}
 		}
@@ -771,9 +771,9 @@ func (po *PinOptions) FromQuery(q url.Values) error {
 	originsStr := q.Get("origins")
 	if originsStr != "" {
 		origins := strings.Split(originsStr, ",")
-		maOrigins := make([]multiaddr.Multiaddr, len(origins))
+		maOrigins := make([]Multiaddr, len(origins))
 		for i, ostr := range origins {
-			maOrig, err := multiaddr.NewMultiaddr(ostr)
+			maOrig, err := NewMultiaddr(ostr)
 			if err != nil {
 				return fmt.Errorf("error decoding multiaddress: %w", err)
 			}
@@ -1015,13 +1015,13 @@ func (pin *Pin) ProtoUnmarshal(data []byte) error {
 	pin.Mode = pin.MaxDepth.ToPinMode()
 
 	pbOrigins := opts.GetOrigins()
-	origins := make([]multiaddr.Multiaddr, len(pbOrigins))
+	origins := make([]Multiaddr, len(pbOrigins))
 	for i, orig := range pbOrigins {
 		maOrig, err := multiaddr.NewMultiaddrBytes(orig)
 		if err != nil {
 			return err
 		}
-		origins[i] = maOrig
+		origins[i] = NewMultiaddrWithValue(maOrig)
 	}
 	pin.Origins = origins
 

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -174,9 +174,9 @@ func TestPinOptionsQuery(t *testing.T) {
 				"hello":  "bye",
 				"hello2": "bye2",
 			},
-			Origins: []multiaddr.Multiaddr{
-				multiaddr.StringCast("/ip4/1.2.3.4/tcp/1234/p2p/12D3KooWKewdAMAU3WjYHm8qkAJc5eW6KHbHWNigWraXXtE1UCng"),
-				multiaddr.StringCast("/ip4/2.3.3.4/tcp/1234/p2p/12D3KooWF6BgwX966ge5AVFs9Gd2wVTBmypxZVvaBR12eYnUmXkR"),
+			Origins: []Multiaddr{
+				NewMultiaddrWithValue(multiaddr.StringCast("/ip4/1.2.3.4/tcp/1234/p2p/12D3KooWKewdAMAU3WjYHm8qkAJc5eW6KHbHWNigWraXXtE1UCng")),
+				NewMultiaddrWithValue(multiaddr.StringCast("/ip4/2.3.3.4/tcp/1234/p2p/12D3KooWF6BgwX966ge5AVFs9Gd2wVTBmypxZVvaBR12eYnUmXkR")),
 			},
 		},
 		{

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -75,9 +75,9 @@ func TestPin(t *testing.T) {
 	defer ipfs.Shutdown(ctx)
 
 	pin := api.PinCid(test.Cid1)
-	pin.Origins = []ma.Multiaddr{
-		ma.StringCast("/ip4/1.2.3.4/tcp/1234/p2p/12D3KooWKewdAMAU3WjYHm8qkAJc5eW6KHbHWNigWraXXtE1UCng"),
-		ma.StringCast("/ip4/2.3.3.4/tcp/1234/p2p/12D3KooWF6BgwX966ge5AVFs9Gd2wVTBmypxZVvaBR12eYnUmXkR"),
+	pin.Origins = []api.Multiaddr{
+		api.NewMultiaddrWithValue(ma.StringCast("/ip4/1.2.3.4/tcp/1234/p2p/12D3KooWKewdAMAU3WjYHm8qkAJc5eW6KHbHWNigWraXXtE1UCng")),
+		api.NewMultiaddrWithValue(ma.StringCast("/ip4/2.3.3.4/tcp/1234/p2p/12D3KooWF6BgwX966ge5AVFs9Gd2wVTBmypxZVvaBR12eYnUmXkR")),
 	}
 	err := ipfs.Pin(ctx, pin)
 	if err != nil {


### PR DESCRIPTION
The pin objects now include an Origin field which was set to
multiaddr.Multiaddr.

This type is an interface and has no idea how to deserialize itself. As a
result, an state json export cannot be deseralized.

We had already added a wrapper Multiaddr type to handle these issues. I
believe this fix does not affect anything else other than fixing
UnmarshalJSON. PB types are deserialized by hand and it should not make a
difference.