### PR TITLE
Performance improvements to state List() and other minor things

### DIFF
--- a/api/common/api.go
+++ b/api/common/api.go
@@ -27,11 +27,10 @@ import (
 	"sync"
 	"time"
 
-	types "github.com/ipfs/ipfs-cluster/api"
-
 	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	gopath "github.com/ipfs/go-path"
+	types "github.com/ipfs/ipfs-cluster/api"
 	libp2p "github.com/libp2p/go-libp2p"
 	host "github.com/libp2p/go-libp2p-core/host"
 	peer "github.com/libp2p/go-libp2p-core/peer"

--- a/api/rest/client/request.go
+++ b/api/rest/client/request.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"go.opencensus.io/trace"
-
 	"github.com/ipfs/ipfs-cluster/api"
+
+	"go.opencensus.io/trace"
 )
 
 type responseDecoder func(d *json.Decoder) error

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-ds-badger v0.3.0
-	github.com/ipfs/go-ds-crdt v0.2.1
+	github.com/ipfs/go-ds-crdt v0.2.3
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-fs-lock v0.0.7
 	github.com/ipfs/go-ipfs-api v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,6 @@ github.com/hashicorp/raft-boltdb v0.0.0-20190605210249-ef2e128ed477 h1:bLsrEmB2N
 github.com/hashicorp/raft-boltdb v0.0.0-20190605210249-ef2e128ed477/go.mod h1:aUF6HQr8+t3FC/ZHAC+pZreUBhTaxumuu3L+d37uRxk=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hsanjuan/ipfs-lite v1.1.24-0.20211130050123-ef6b521edcf6 h1:0VDnVBRmVLy9h4pBrmbb3LhoGe1ET1ByfJGdJf9BSg8=
-github.com/hsanjuan/ipfs-lite v1.1.24-0.20211130050123-ef6b521edcf6/go.mod h1:GFTbYa5fyFV0Z/2IVc8W7/Uus31xwtfICGZQT7dDhRw=
 github.com/hsanjuan/ipfs-lite v1.2.0 h1:bV/GIbftDF9ecqi7Wa2yxgAUwX2yh7Zfz/h3eiXrwHU=
 github.com/hsanjuan/ipfs-lite v1.2.0/go.mod h1:KsCU8h2aBeSCNffdNIZ4mVkEWgPgW/9WYyty2wGxhv0=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
@@ -463,8 +461,8 @@ github.com/ipfs/go-ds-badger v0.2.6/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6
 github.com/ipfs/go-ds-badger v0.2.7/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
 github.com/ipfs/go-ds-badger v0.3.0 h1:xREL3V0EH9S219kFFueOYJJTcjgNSZ2HY1iSvN7U1Ro=
 github.com/ipfs/go-ds-badger v0.3.0/go.mod h1:1ke6mXNqeV8K3y5Ak2bAA0osoTfmxUdupVCGm4QUIek=
-github.com/ipfs/go-ds-crdt v0.2.1 h1:F5ru4Wr8BrQzq0LJjHe1ghHKVFHhLS3dfGZKTww8vtw=
-github.com/ipfs/go-ds-crdt v0.2.1/go.mod h1:iyNk2vbzhH/5oUtzS9Sf+6IOIGOFVUK3oMgB2NcMZQQ=
+github.com/ipfs/go-ds-crdt v0.2.3 h1:vRjMtEzh2lSuxLGjkLWkw51u4QmezJkeleXGcFX0I3s=
+github.com/ipfs/go-ds-crdt v0.2.3/go.mod h1:ZfBlHcA3Xc6el6MnLl1DS37nbj1ybvT3UOAtAw7L72o=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=

--- a/state/dsstate/datastore.go
+++ b/state/dsstate/datastore.go
@@ -140,6 +140,7 @@ func (st *State) List(ctx context.Context) ([]*api.Pin, error) {
 
 	var pins []*api.Pin
 
+	total := 0
 	for r := range results.Next() {
 		if r.Error != nil {
 			logger.Errorf("error in query result: %s", r.Error)
@@ -158,7 +159,14 @@ func (st *State) List(ctx context.Context) ([]*api.Pin, error) {
 			continue
 		}
 
+		if total > 0 && total%500000 == 0 {
+			logger.Infof("Full pinset listing in progress: %d pins so far", total)
+		}
+		total++
 		pins = append(pins, p)
+	}
+	if total >= 500000 {
+		logger.Infof("Full pinset listing finished: %d pins", total)
 	}
 	return pins, nil
 }


### PR DESCRIPTION
- Upgrades go-ds-crdt with a 3x performance improvement when doing a List. Current benchmark is 11k->36k pins per second listed.
- Adds logging when a List operation is ongoing and has more than 500k items (starts taking time). This can inform the user about the aliveness of the operation and total number of pins before they are actually delivered. It is very useful to be mindful of overly short recover-interval settings etc. It takes several minutes to list a state with 10M items now.
- Fixes a shutdown issue in the pintracker.

