### PR TITLE
pintracker: set status unexpectedly_unpinned correctly on Status()

### DIFF
--- a/pintracker/stateless/stateless.go
+++ b/pintracker/stateless/stateless.go
@@ -408,7 +408,7 @@ func (spt *Tracker) Status(ctx context.Context, c cid.Cid) *api.PinInfo {
 	case api.TrackerStatusUnpinned:
 		// The item is in the state but not in IPFS:
 		// PinError. Should be pinned.
-		pinInfo.Status = api.TrackerStatusPinError
+		pinInfo.Status = api.TrackerStatusUnexpectedlyUnpinned
 		pinInfo.Error = errUnexpectedlyUnpinned.Error()
 	default:
 		pinInfo.Status = ipfsStatus

--- a/pintracker/stateless/stateless_test.go
+++ b/pintracker/stateless/stateless_test.go
@@ -456,7 +456,7 @@ func TestStatus(t *testing.T) {
 	// Status needs to return:
 	// * For slowCid1: A slow CID pinning
 	// * For Cid1: pinned
-	// * For Cid4: pin error
+	// * For Cid4: unexpectedly_unpinned
 
 	st := spt.Status(ctx, test.Cid1)
 	if st.Status != api.TrackerStatusPinned {
@@ -464,8 +464,8 @@ func TestStatus(t *testing.T) {
 	}
 
 	st = spt.Status(ctx, test.Cid4)
-	if st.Status != api.TrackerStatusPinError {
-		t.Error("cid2 should be in pin_error status")
+	if st.Status != api.TrackerStatusUnexpectedlyUnpinned {
+		t.Error("cid2 should be in unexpectedly_unpinned status")
 	}
 
 	st = spt.Status(ctx, test.SlowCid1)


### PR DESCRIPTION
This must has been an oversight. We added a special unexpectedly_unpinned
status so that we could just return things from the operation tracker when
filtering by pin_error. unexpectedly_unpinned are things that we have no
operation for but are unpinned on ipfs.

Status however still returned a pin_error state for these, even though,
StatusAll would not show them when filtering with pin_error, and would show
them as unexpectedly_unpinned otherwise.

Since Recover correctly repins pin_error and unexpectedly_unpinned, this
change has no further consequences.