### PR TITLE
pintracker: RecoverAll should only return status for recovered items

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1198,6 +1198,8 @@ func (c *Cluster) RecoverAll(ctx context.Context) ([]*api.GlobalPinInfo, error) 
 // is faster than calling Pin on the same CID as it avoids committing an
 // identical pin to the consensus layer.
 //
+// It returns the list of pins that were re-queued for pinning.
+//
 // RecoverAllLocal is called automatically every PinRecoverInterval.
 func (c *Cluster) RecoverAllLocal(ctx context.Context) ([]*api.PinInfo, error) {
 	_, span := trace.StartSpan(ctx, "cluster/RecoverAllLocal")

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -124,7 +124,8 @@ type PinTracker interface {
 	StatusAll(context.Context, api.TrackerStatus) []*api.PinInfo
 	// Status returns the local status of a given Cid.
 	Status(context.Context, cid.Cid) *api.PinInfo
-	// RecoverAll calls Recover() for all pins tracked.
+	// RecoverAll calls Recover() for all pins tracked. Returns only
+	// informations for retriggered pins.
 	RecoverAll(context.Context) ([]*api.PinInfo, error)
 	// Recover retriggers a Pin/Unpin operation in a Cids with error status.
 	Recover(context.Context, cid.Cid) (*api.PinInfo, error)

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -1109,8 +1109,8 @@ func TestClustersRecoverAll(t *testing.T) {
 	}
 	delay()
 
-	if len(gInfos) != 2 {
-		t.Error("expected two items")
+	if len(gInfos) != 1 {
+		t.Error("expected one items")
 	}
 
 	for _, gInfo := range gInfos {

--- a/pintracker/pintracker_test.go
+++ b/pintracker/pintracker_test.go
@@ -332,25 +332,8 @@ func TestPinTracker_RecoverAll(t *testing.T) {
 			args{
 				testStatelessPinTracker(t),
 			},
+			// The only CID to recover is test.Cid4 which is in error.
 			[]*api.PinInfo{
-				{
-					Cid: test.Cid1,
-					PinInfoShort: api.PinInfoShort{
-						Status: api.TrackerStatusPinned,
-					},
-				},
-				{
-					Cid: test.Cid2,
-					PinInfoShort: api.PinInfoShort{
-						Status: api.TrackerStatusRemote,
-					},
-				},
-				{
-					Cid: test.Cid3,
-					PinInfoShort: api.PinInfoShort{
-						Status: api.TrackerStatusRemote,
-					},
-				},
 				{
 					// This will recover and status
 					// is ignored as it could come back as


### PR DESCRIPTION
We call RecoverAll regularly and I noticed it was way slower than it should be.

After all, it should just loop the pinset and enqueued items that are
unexpectedly unpinned or in pin error.

However, at some point we decided that RecoverAll would return information for
all pins, regardless of whether they were recovered or not. This ends up
resulting in a separate Status call for every pin that is already pinned, and
this call hits IPFS. This is pretty bad with big pinsets.

This commit fixes that, we return no state information for pins that are not
touched.