### PR TITLE
Remove warning message about informer metrics

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -357,7 +357,6 @@ func (c *Cluster) pushInformerMetrics(ctx context.Context, informer Informer) {
 		minTTL, err := c.sendInformerMetrics(ctx, informer)
 		if minTTL == 0 {
 			minTTL = 30 * time.Second
-			logger.Warningf("informer %s reported a min metric ttl of 0s.", informer.Name())
 		}
 		if err != nil {
 			if (retries % retryWarnMod) == 0 {


### PR DESCRIPTION
In happens when no tags are defined and I thought it was fixed.