### PR TITLE
Update go-ds-crdt and add RepairInterval option

### DIFF
--- a/consensus/crdt/config_test.go
+++ b/consensus/crdt/config_test.go
@@ -14,7 +14,8 @@ var cfgJSON = []byte(`
         "max_batch_size": 30,
         "max_batch_age": "5s",
         "max_queue_size": 150
-    }
+    },
+    "repair_interval": "1m"
 }
 `)
 
@@ -32,6 +33,9 @@ func TestLoadJSON(t *testing.T) {
 		cfg.Batching.MaxBatchAge != 5*time.Second ||
 		cfg.Batching.MaxQueueSize != 150 {
 		t.Error("Batching options were not parsed correctly")
+	}
+	if cfg.RepairInterval != time.Minute {
+		t.Error("repair interval not set")
 	}
 
 	cfg = &Config{}
@@ -118,6 +122,12 @@ func TestDefault(t *testing.T) {
 
 	cfg.Default()
 	cfg.Batching.MaxQueueSize = -3
+	if cfg.Validate() == nil {
+		t.Fatal("expected error validating")
+	}
+
+	cfg.Default()
+	cfg.RepairInterval = -3
 	if cfg.Validate() == nil {
 		t.Fatal("expected error validating")
 	}

--- a/consensus/crdt/consensus.go
+++ b/consensus/crdt/consensus.go
@@ -201,6 +201,7 @@ func (css *Consensus) setup() {
 	opts.RebroadcastInterval = css.config.RebroadcastInterval
 	opts.DAGSyncerTimeout = 2 * time.Minute
 	opts.Logger = logger
+	opts.RepairInterval = css.config.RepairInterval
 	opts.PutHook = func(k ds.Key, v []byte) {
 		ctx, span := trace.StartSpan(css.ctx, "crdt/PutHook")
 		defer span.End()

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-ds-badger v0.3.0
-	github.com/ipfs/go-ds-crdt v0.2.4
+	github.com/ipfs/go-ds-crdt v0.3.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-fs-lock v0.0.7
 	github.com/ipfs/go-ipfs-api v0.3.0
@@ -51,7 +51,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
 	github.com/libp2p/go-libp2p-noise v0.3.0
 	github.com/libp2p/go-libp2p-peerstore v0.6.0
-	github.com/libp2p/go-libp2p-pubsub v0.6.0
+	github.com/libp2p/go-libp2p-pubsub v0.6.1
 	github.com/libp2p/go-libp2p-quic-transport v0.15.2
 	github.com/libp2p/go-libp2p-raft v0.1.8
 	github.com/libp2p/go-libp2p-record v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,12 @@ github.com/ipfs/go-ds-badger v0.3.0 h1:xREL3V0EH9S219kFFueOYJJTcjgNSZ2HY1iSvN7U1
 github.com/ipfs/go-ds-badger v0.3.0/go.mod h1:1ke6mXNqeV8K3y5Ak2bAA0osoTfmxUdupVCGm4QUIek=
 github.com/ipfs/go-ds-crdt v0.2.4 h1:0MlPabDDQb+b+3XW3XmaqplzZ5mU9MzQqMA8fhmJM4E=
 github.com/ipfs/go-ds-crdt v0.2.4/go.mod h1:d/A3cgxuQP5JZiQHzVpmgi+qHhyVvrXocULV0C5bEDM=
+github.com/ipfs/go-ds-crdt v0.2.5-0.20220128235738-44ecbaba3b95 h1:1qnp+PNqtFGrZ2UCB3nHrVxrJee9nGK0j/eWKxrGTGo=
+github.com/ipfs/go-ds-crdt v0.2.5-0.20220128235738-44ecbaba3b95/go.mod h1:d/A3cgxuQP5JZiQHzVpmgi+qHhyVvrXocULV0C5bEDM=
+github.com/ipfs/go-ds-crdt v0.2.5-0.20220201001957-24cc4a1138a4 h1:hltEdjeGgbVL+RnFzRN1V+BKYnMk3myPJVMOazsS40A=
+github.com/ipfs/go-ds-crdt v0.2.5-0.20220201001957-24cc4a1138a4/go.mod h1:d/A3cgxuQP5JZiQHzVpmgi+qHhyVvrXocULV0C5bEDM=
+github.com/ipfs/go-ds-crdt v0.3.0 h1:S+0WEu5j3427OLzkEVS9+fzn0/SEwpoKJlBe1kfBMvo=
+github.com/ipfs/go-ds-crdt v0.3.0/go.mod h1:rcfJixHEd+hIWcu/8SecC/lVlNcAkhE6DNgRKPd1xgU=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
@@ -835,6 +841,8 @@ github.com/libp2p/go-libp2p-protocol v0.0.1/go.mod h1:Af9n4PiruirSDjHycM1QuiMi/1
 github.com/libp2p/go-libp2p-protocol v0.1.0/go.mod h1:KQPHpAabB57XQxGrXCNvbL6UEXfQqUgC/1adR2Xtflk=
 github.com/libp2p/go-libp2p-pubsub v0.6.0 h1:98+RXuEWW17U6cAijK1yaTf6mw/B+n5yPA421z+dlo0=
 github.com/libp2p/go-libp2p-pubsub v0.6.0/go.mod h1:nJv87QM2cU0w45KPR1rZicq+FmFIOD16zmT+ep1nOmg=
+github.com/libp2p/go-libp2p-pubsub v0.6.1 h1:wycbV+f4rreCoVY61Do6g/BUk0RIrbNRcYVbn+QkjGk=
+github.com/libp2p/go-libp2p-pubsub v0.6.1/go.mod h1:nJv87QM2cU0w45KPR1rZicq+FmFIOD16zmT+ep1nOmg=
 github.com/libp2p/go-libp2p-quic-transport v0.10.0/go.mod h1:RfJbZ8IqXIhxBRm5hqUEJqjiiY8xmEuq3HUDS993MkA=
 github.com/libp2p/go-libp2p-quic-transport v0.11.2/go.mod h1:wlanzKtIh6pHrq+0U3p3DY9PJfGqxMgPaGKaK5LifwQ=
 github.com/libp2p/go-libp2p-quic-transport v0.13.0/go.mod h1:39/ZWJ1TW/jx1iFkKzzUg00W6tDJh73FC0xYudjr7Hc=


### PR DESCRIPTION
The new version supports auto-repair of the datastore.

This adds a new `repair_interval` option in the crdt configuration.

Peers that upgrade will have it unset, which means 0, which disables repairs.

New peers will generate configurations with a default of 1 hour.

Fixes #1007 