### PR TITLE
Restapi: add "cids" query param to /pins

### DIFF
--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -513,7 +513,7 @@ func (wait *waitService) Status(ctx context.Context, in cid.Cid, out *types.Glob
 	if time.Now().After(wait.pinStart.Add(5 * time.Second)) { //pinned
 		*out = types.GlobalPinInfo{
 			Cid: in,
-			PeerMap: map[string]*types.PinInfoShort{
+			PeerMap: map[string]types.PinInfoShort{
 				peer.Encode(test.PeerID1): {
 					Status: types.TrackerStatusPinned,
 					TS:     wait.pinStart,
@@ -535,7 +535,7 @@ func (wait *waitService) Status(ctx context.Context, in cid.Cid, out *types.Glob
 	} else { // pinning
 		*out = types.GlobalPinInfo{
 			Cid: in,
-			PeerMap: map[string]*types.PinInfoShort{
+			PeerMap: map[string]types.PinInfoShort{
 				peer.Encode(test.PeerID1): {
 					Status: types.TrackerStatusPinning,
 					TS:     wait.pinStart,
@@ -585,7 +585,7 @@ func (wait *waitServiceUnpin) Status(ctx context.Context, in cid.Cid, out *types
 	if time.Now().After(wait.unpinStart.Add(5 * time.Second)) { //unpinned
 		*out = types.GlobalPinInfo{
 			Cid: in,
-			PeerMap: map[string]*types.PinInfoShort{
+			PeerMap: map[string]types.PinInfoShort{
 				peer.Encode(test.PeerID1): {
 					Status: types.TrackerStatusUnpinned,
 					TS:     wait.unpinStart,
@@ -599,7 +599,7 @@ func (wait *waitServiceUnpin) Status(ctx context.Context, in cid.Cid, out *types
 	} else { // pinning
 		*out = types.GlobalPinInfo{
 			Cid: in,
-			PeerMap: map[string]*types.PinInfoShort{
+			PeerMap: map[string]types.PinInfoShort{
 				peer.Encode(test.PeerID1): {
 					Status: types.TrackerStatusUnpinning,
 					TS:     wait.unpinStart,

--- a/api/types.go
+++ b/api/types.go
@@ -255,31 +255,31 @@ type GlobalPinInfo struct {
 	// https://github.com/golang/go/issues/28827
 	// Peer IDs are of string Kind(). We can't use peer IDs here
 	// as Go ignores TextMarshaler.
-	PeerMap map[string]*PinInfoShort `json:"peer_map" codec:"pm,omitempty"`
+	PeerMap map[string]PinInfoShort `json:"peer_map" codec:"pm,omitempty"`
 }
 
 // String returns the string representation of a GlobalPinInfo.
 func (gpi *GlobalPinInfo) String() string {
-	str := fmt.Sprintf("Cid: %v\n", gpi.Cid.String())
-	str = str + "Peer:\n"
-	for _, p := range gpi.PeerMap {
-		str = str + fmt.Sprintf("\t%+v\n", p)
+	str := fmt.Sprintf("Cid: %s\n", gpi.Cid)
+	str = str + "Peers:\n"
+	for pid, p := range gpi.PeerMap {
+		str = str + fmt.Sprintf("\t%s: %+v\n", pid, p)
 	}
 	return str
 }
 
 // Add adds a PinInfo object to a GlobalPinInfo
-func (gpi *GlobalPinInfo) Add(pi *PinInfo) {
+func (gpi *GlobalPinInfo) Add(pi PinInfo) {
 	if !gpi.Cid.Defined() {
 		gpi.Cid = pi.Cid
 		gpi.Name = pi.Name
 	}
 
 	if gpi.PeerMap == nil {
-		gpi.PeerMap = make(map[string]*PinInfoShort)
+		gpi.PeerMap = make(map[string]PinInfoShort)
 	}
 
-	gpi.PeerMap[peer.Encode(pi.Peer)] = &pi.PinInfoShort
+	gpi.PeerMap[peer.Encode(pi.Peer)] = pi.PinInfoShort
 }
 
 // PinInfoShort is a subset of PinInfo which is embedded in GlobalPinInfo
@@ -306,10 +306,10 @@ type PinInfo struct {
 
 // ToGlobal converts a PinInfo object to a GlobalPinInfo with
 // a single peer corresponding to the given PinInfo.
-func (pi *PinInfo) ToGlobal() *GlobalPinInfo {
-	gpi := GlobalPinInfo{}
+func (pi PinInfo) ToGlobal() GlobalPinInfo {
+	gpi := &GlobalPinInfo{}
 	gpi.Add(pi)
-	return &gpi
+	return *gpi
 }
 
 // Version holds version information

--- a/cluster.go
+++ b/cluster.go
@@ -1751,7 +1751,7 @@ func (c *Cluster) setTrackerStatus(gpin *api.GlobalPinInfo, h cid.Cid, peers []p
 		if peerName == "" {
 			peerName = p.String()
 		}
-		gpin.Add(&api.PinInfo{
+		gpin.Add(api.PinInfo{
 			Cid:  h,
 			Name: name,
 			Peer: p,
@@ -1862,7 +1862,7 @@ func (c *Cluster) globalPinInfoCid(ctx context.Context, comp, method string, h c
 
 		// No error. Parse and continue
 		if e == nil {
-			gpin.Add(r)
+			gpin.Add(*r)
 			continue
 		}
 
@@ -1879,7 +1879,7 @@ func (c *Cluster) globalPinInfoCid(ctx context.Context, comp, method string, h c
 		if peerName == "" {
 			peerName = dests[i].String()
 		}
-		gpin.Add(&api.PinInfo{
+		gpin.Add(api.PinInfo{
 			Cid:  h,
 			Name: pin.Name,
 			Peer: dests[i],
@@ -1946,7 +1946,7 @@ func (c *Cluster) globalPinInfoSlice(ctx context.Context, comp, method string, a
 			info = &api.GlobalPinInfo{}
 			fullMap[p.Cid] = info
 		}
-		info.Add(p)
+		info.Add(*p)
 	}
 
 	erroredPeers := make(map[peer.ID]string)

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -224,7 +224,7 @@ func (mock *mockCluster) StatusAll(ctx context.Context, in api.TrackerStatus, ou
 	gPinInfos := []*api.GlobalPinInfo{
 		{
 			Cid: Cid1,
-			PeerMap: map[string]*api.PinInfoShort{
+			PeerMap: map[string]api.PinInfoShort{
 				pid: {
 					Status: api.TrackerStatusPinned,
 					TS:     time.Now(),
@@ -233,7 +233,7 @@ func (mock *mockCluster) StatusAll(ctx context.Context, in api.TrackerStatus, ou
 		},
 		{
 			Cid: Cid2,
-			PeerMap: map[string]*api.PinInfoShort{
+			PeerMap: map[string]api.PinInfoShort{
 				pid: {
 					Status: api.TrackerStatusPinning,
 					TS:     time.Now(),
@@ -242,7 +242,7 @@ func (mock *mockCluster) StatusAll(ctx context.Context, in api.TrackerStatus, ou
 		},
 		{
 			Cid: Cid3,
-			PeerMap: map[string]*api.PinInfoShort{
+			PeerMap: map[string]api.PinInfoShort{
 				pid: {
 					Status: api.TrackerStatusPinError,
 					TS:     time.Now(),
@@ -281,7 +281,7 @@ func (mock *mockCluster) Status(ctx context.Context, in cid.Cid, out *api.Global
 	}
 	*out = api.GlobalPinInfo{
 		Cid: in,
-		PeerMap: map[string]*api.PinInfoShort{
+		PeerMap: map[string]api.PinInfoShort{
 			peer.Encode(PeerID1): {
 				Status: api.TrackerStatusPinned,
 				TS:     time.Now(),


### PR DESCRIPTION
This allows to specifically request status for several CIDs as
provided in the "cids" query parameter, instead of request status for
all CIDs.

In this case, the filter is ignored.