### PR TITLE
Adder: Add "no-pin" option.

### DIFF
--- a/adder/adder.go
+++ b/adder/adder.go
@@ -58,7 +58,7 @@ type Adder struct {
 
 	dgs ClusterDAGService
 
-	params *api.AddParams
+	params api.AddParams
 
 	// AddedOutput updates are placed on this channel
 	// whenever a block is processed. They contain information
@@ -71,7 +71,7 @@ type Adder struct {
 // channel to send updates during the adding process.
 //
 // An Adder may only be used once.
-func New(ds ClusterDAGService, p *api.AddParams, out chan *api.AddedOutput) *Adder {
+func New(ds ClusterDAGService, p api.AddParams, out chan *api.AddedOutput) *Adder {
 	// Discard all progress update output as the caller has not provided
 	// a channel for them to listen on.
 	if out == nil {
@@ -184,7 +184,7 @@ type ipfsAdder struct {
 	*ipfsadd.Adder
 }
 
-func newIpfsAdder(ctx context.Context, dgs ClusterDAGService, params *api.AddParams, out chan *api.AddedOutput) (*ipfsAdder, error) {
+func newIpfsAdder(ctx context.Context, dgs ClusterDAGService, params api.AddParams, out chan *api.AddedOutput) (*ipfsAdder, error) {
 	iadder, err := ipfsadd.NewAdder(ctx, dgs)
 	if err != nil {
 		logger.Error(err)
@@ -248,11 +248,11 @@ func (ia *ipfsAdder) Add(name string, f files.Node) (cid.Cid, error) {
 type carAdder struct {
 	ctx    context.Context
 	dgs    ClusterDAGService
-	params *api.AddParams
+	params api.AddParams
 	output chan *api.AddedOutput
 }
 
-func newCarAdder(ctx context.Context, dgs ClusterDAGService, params *api.AddParams, out chan *api.AddedOutput) (*carAdder, error) {
+func newCarAdder(ctx context.Context, dgs ClusterDAGService, params api.AddParams, out chan *api.AddedOutput) (*carAdder, error) {
 	return &carAdder{
 		ctx:    ctx,
 		dgs:    dgs,

--- a/adder/adderutils/adderutils.go
+++ b/adder/adderutils/adderutils.go
@@ -27,7 +27,7 @@ var logger = logging.Logger("adder")
 func AddMultipartHTTPHandler(
 	ctx context.Context,
 	rpc *rpc.Client,
-	params *api.AddParams,
+	params api.AddParams,
 	reader *multipart.Reader,
 	w http.ResponseWriter,
 	outputTransform func(*api.AddedOutput) interface{},
@@ -36,9 +36,9 @@ func AddMultipartHTTPHandler(
 	output := make(chan *api.AddedOutput, 200)
 
 	if params.Shard {
-		dags = sharding.New(rpc, params.PinOptions, output)
+		dags = sharding.New(rpc, params, output)
 	} else {
-		dags = single.New(rpc, params.PinOptions, params.Local)
+		dags = single.New(rpc, params, params.Local)
 	}
 
 	if outputTransform == nil {

--- a/adder/sharding/dag_service_test.go
+++ b/adder/sharding/dag_service_test.go
@@ -64,7 +64,7 @@ func (rpcs *testRPC) BlockGet(ctx context.Context, c cid.Cid) ([]byte, error) {
 	return bI.([]byte), nil
 }
 
-func makeAdder(t *testing.T, params *api.AddParams) (*adder.Adder, *testRPC) {
+func makeAdder(t *testing.T, params api.AddParams) (*adder.Adder, *testRPC) {
 	rpcObj := &testRPC{}
 	server := rpc.NewServer(nil, "mock")
 	err := server.RegisterName("Cluster", rpcObj)
@@ -79,7 +79,7 @@ func makeAdder(t *testing.T, params *api.AddParams) (*adder.Adder, *testRPC) {
 
 	out := make(chan *api.AddedOutput, 1)
 
-	dags := New(client, params.PinOptions, out)
+	dags := New(client, params, out)
 	add := adder.New(dags, params, out)
 
 	go func() {
@@ -190,13 +190,13 @@ func TestFromMultipart(t *testing.T) {
 func TestFromMultipart_Errors(t *testing.T) {
 	type testcase struct {
 		name   string
-		params *api.AddParams
+		params api.AddParams
 	}
 
 	tcs := []*testcase{
 		{
 			name: "bad chunker",
-			params: &api.AddParams{
+			params: api.AddParams{
 				Format: "",
 				IPFSAddParams: api.IPFSAddParams{
 					Chunker:   "aweee",
@@ -214,7 +214,7 @@ func TestFromMultipart_Errors(t *testing.T) {
 		},
 		{
 			name: "shard size too small",
-			params: &api.AddParams{
+			params: api.AddParams{
 				Format: "",
 				IPFSAddParams: api.IPFSAddParams{
 					Chunker:   "",
@@ -232,7 +232,7 @@ func TestFromMultipart_Errors(t *testing.T) {
 		},
 		{
 			name: "replication too high",
-			params: &api.AddParams{
+			params: api.AddParams{
 				Format: "",
 				IPFSAddParams: api.IPFSAddParams{
 					Chunker:   "",

--- a/adder/single/dag_service_test.go
+++ b/adder/single/dag_service_test.go
@@ -61,7 +61,7 @@ func TestAdd(t *testing.T) {
 		params := api.DefaultAddParams()
 		params.Wrap = true
 
-		dags := New(client, params.PinOptions, false)
+		dags := New(client, params, false)
 		add := adder.New(dags, params, nil)
 
 		sth := test.NewShardingTestHelper()
@@ -109,7 +109,7 @@ func TestAdd(t *testing.T) {
 		params := api.DefaultAddParams()
 		params.Layout = "trickle"
 
-		dags := New(client, params.PinOptions, false)
+		dags := New(client, params, false)
 		add := adder.New(dags, params, nil)
 
 		sth := test.NewShardingTestHelper()

--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -58,9 +58,9 @@ type Client interface {
 	PeerRm(ctx context.Context, pid peer.ID) error
 
 	// Add imports files to the cluster from the given paths.
-	Add(ctx context.Context, paths []string, params *api.AddParams, out chan<- *api.AddedOutput) error
+	Add(ctx context.Context, paths []string, params api.AddParams, out chan<- *api.AddedOutput) error
 	// AddMultiFile imports new files from a MultiFileReader.
-	AddMultiFile(ctx context.Context, multiFileR *files.MultiFileReader, params *api.AddParams, out chan<- *api.AddedOutput) error
+	AddMultiFile(ctx context.Context, multiFileR *files.MultiFileReader, params api.AddParams, out chan<- *api.AddedOutput) error
 
 	// Pin tracks a Cid with the given replication factor and a name for
 	// human-friendliness.

--- a/api/rest/client/lbclient.go
+++ b/api/rest/client/lbclient.go
@@ -393,7 +393,7 @@ func (lc *loadBalancingClient) RepoGC(ctx context.Context, local bool) (*api.Glo
 func (lc *loadBalancingClient) Add(
 	ctx context.Context,
 	paths []string,
-	params *api.AddParams,
+	params api.AddParams,
 	out chan<- *api.AddedOutput,
 ) error {
 	call := func(c Client) error {
@@ -407,7 +407,7 @@ func (lc *loadBalancingClient) Add(
 func (lc *loadBalancingClient) AddMultiFile(
 	ctx context.Context,
 	multiFileR *files.MultiFileReader,
-	params *api.AddParams,
+	params api.AddParams,
 	out chan<- *api.AddedOutput,
 ) error {
 	call := func(c Client) error {

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -513,7 +513,7 @@ func statusReached(target api.TrackerStatus, gblPinInfo *api.GlobalPinInfo, limi
 }
 
 // logic drawn from go-ipfs-cmds/cli/parse.go: appendFile
-func makeSerialFile(fpath string, params *api.AddParams) (string, files.Node, error) {
+func makeSerialFile(fpath string, params api.AddParams) (string, files.Node, error) {
 	if fpath == "." {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -553,7 +553,7 @@ func makeSerialFile(fpath string, params *api.AddParams) (string, files.Node, er
 func (c *defaultClient) Add(
 	ctx context.Context,
 	paths []string,
-	params *api.AddParams,
+	params api.AddParams,
 	out chan<- *api.AddedOutput,
 ) error {
 	ctx, span := trace.StartSpan(ctx, "client/Add")
@@ -596,7 +596,7 @@ func (c *defaultClient) Add(
 func (c *defaultClient) AddMultiFile(
 	ctx context.Context,
 	multiFileR *files.MultiFileReader,
-	params *api.AddParams,
+	params api.AddParams,
 	out chan<- *api.AddedOutput,
 ) error {
 	ctx, span := trace.StartSpan(ctx, "client/AddMultiFile")

--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -749,7 +749,7 @@ func TestAddMultiFile(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 
-		p := &types.AddParams{
+		p := types.AddParams{
 			PinOptions: types.PinOptions{
 				ReplicationFactorMin: -1,
 				ReplicationFactorMax: -1,

--- a/cluster.go
+++ b/cluster.go
@@ -1654,14 +1654,14 @@ func (c *Cluster) UnpinPath(ctx context.Context, path string) (*api.Pin, error) 
 // pipeline is used to DAGify the file.  Depending on input parameters this
 // DAG can be added locally to the calling cluster peer's ipfs repo, or
 // sharded across the entire cluster.
-func (c *Cluster) AddFile(reader *multipart.Reader, params *api.AddParams) (cid.Cid, error) {
+func (c *Cluster) AddFile(reader *multipart.Reader, params api.AddParams) (cid.Cid, error) {
 	// TODO: add context param and tracing
 
 	var dags adder.ClusterDAGService
 	if params.Shard {
-		dags = sharding.New(c.rpcClient, params.PinOptions, nil)
+		dags = sharding.New(c.rpcClient, params, nil)
 	} else {
-		dags = single.New(c.rpcClient, params.PinOptions, params.Local)
+		dags = single.New(c.rpcClient, params, params.Local)
 	}
 	add := adder.New(dags, params, nil)
 	return add.FromMultipart(c.ctx, reader)

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -344,6 +344,8 @@ func (rpcapi *ClusterRPCAPI) BlockAllocate(ctx context.Context, in *api.Pin, out
 		return errFollowerMode
 	}
 
+	// Allocating for a existing pin. Usually the adder calls this with
+	// cid.Undef.
 	existing, err := rpcapi.c.PinGet(ctx, in.Cid)
 	if err != nil && err != state.ErrNotFound {
 		return err


### PR DESCRIPTION
This does 3 things:

- Add a NoPin option to the adder. When set to true, the adding process does not
send a pin in the end.

- When user-allocations are set and local=true happens, we do not overwrite
  the allocations returned by the allocator to include the local peer
  anymore, as this could alter user-allocations.

- Some code improvement (remove pointers).