### PR TITLE
allocator: Filter out metrics from non-trusted peers when configured

### DIFF
--- a/cluster_config_test.go
+++ b/cluster_config_test.go
@@ -28,6 +28,7 @@ var ccfgTestJSON = []byte(`
         "replication_factor_min": 5,
         "replication_factor_max": 5,
         "monitor_ping_interval": "2s",
+        "pin_only_on_trusted_peers": true,
         "disable_repinning": true,
         "peer_addresses": [ "/ip4/127.0.0.1/tcp/1234/p2p/QmXZrtE5jQwXNqCJMfHUTQkvhQ4ZAnqMnmzFMJfLewuabc" ]
 }
@@ -69,6 +70,13 @@ func TestLoadJSON(t *testing.T) {
 		cfg := loadJSON(t)
 		if !cfg.DisableRepinning {
 			t.Error("expected disable_repinning to be true")
+		}
+	})
+
+	t.Run("expected pin_only_on_trusted_peers", func(t *testing.T) {
+		cfg := loadJSON(t)
+		if !cfg.PinOnlyOnTrustedPeers {
+			t.Error("expected pin_only_on_trusted_peers to be true")
 		}
 	})
 

--- a/config_test.go
+++ b/config_test.go
@@ -37,6 +37,7 @@ var testingClusterCfg = []byte(`{
     "replication_factor": -1,
     "monitor_ping_interval": "250ms",
     "peer_watch_interval": "1s",
+    "pin_only_on_trusted_peers": true,
     "disable_repinning": false,
     "mdns_interval": "0s"
 }`)


### PR DESCRIPTION
Adds pin_only_on_cluster_peers configuration option

Fixes #1585 .