### PR TITLE
Support querying status for multiple CIDs in clients

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -84,6 +84,8 @@ type Client interface {
 	// the information affects only the current peer, otherwise the information
 	// is fetched from all cluster peers.
 	Status(ctx context.Context, ci cid.Cid, local bool) (*api.GlobalPinInfo, error)
+	// StatusCids status information for the requested CIDs.
+	StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]*api.GlobalPinInfo, error)
 	// StatusAll gathers Status() for all tracked items.
 	StatusAll(ctx context.Context, filter api.TrackerStatus, local bool) ([]*api.GlobalPinInfo, error)
 

--- a/api/rest/client/lbclient.go
+++ b/api/rest/client/lbclient.go
@@ -253,6 +253,21 @@ func (lc *loadBalancingClient) Status(ctx context.Context, ci cid.Cid, local boo
 	return pinInfo, err
 }
 
+// StatusCids returns Status() information for the given Cids. If local is
+// true, the information affects only the current peer, otherwise the
+// information is fetched from all cluster peers.
+func (lc *loadBalancingClient) StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]*api.GlobalPinInfo, error) {
+	var pinInfos []*api.GlobalPinInfo
+	call := func(c Client) error {
+		var err error
+		pinInfos, err = c.StatusCids(ctx, cids, local)
+		return err
+	}
+
+	err := lc.retry(0, call)
+	return pinInfos, err
+}
+
 // StatusAll gathers Status() for all tracked items. If a filter is
 // provided, only entries matching the given filter statuses
 // will be returned. A filter can be built by merging TrackerStatuses with

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -250,9 +250,9 @@ func (c *defaultClient) statusAllWithCids(ctx context.Context, filter api.Tracke
 		}
 	}
 
-	var cidsStr []string
-	for _, c := range cids {
-		cidsStr = append(cidsStr, c.String())
+	cidsStr := make([]string, len(cids))
+	for i, c := range cids {
+		cidsStr[i] = c.String()
 	}
 
 	err := c.do(

--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -327,6 +327,27 @@ func TestStatus(t *testing.T) {
 	testClients(t, api, testF)
 }
 
+func TestStatusCids(t *testing.T) {
+	ctx := context.Background()
+	api := testAPI(t)
+	defer shutdown(api)
+
+	testF := func(t *testing.T, c Client) {
+		pins, err := c.StatusCids(ctx, []cid.Cid{test.Cid1}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(pins) != 1 {
+			t.Fatal("wrong number of pins returned")
+		}
+		if !pins[0].Cid.Equals(test.Cid1) {
+			t.Error("should be same pin")
+		}
+	}
+
+	testClients(t, api, testF)
+}
+
 func TestStatusAll(t *testing.T) {
 	ctx := context.Background()
 	api := testAPI(t)

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -860,8 +860,8 @@ The filter only takes effect when listing all pins. The possible values are:
 			Description: `
 This command retrieves the status of the CIDs tracked by IPFS
 Cluster, including which member is pinning them and any errors.
-If a CID is provided, the status will be only fetched for a single
-item.  Metadata CIDs are included in the status response
+If one of several CIDs are provided, the status will be only fetched 
+for a single item.  Metadata CIDs are included in the status response.
 
 When the --local flag is passed, it will only fetch the status from the
 contacted cluster peer. By default, status will be fetched from all peers.
@@ -871,7 +871,7 @@ where status of the pin matches at least one of the filter values (a comma
 separated list). The following are valid status values:
 
 ` + trackerStatusAllString(),
-			ArgsUsage: "[CID]",
+			ArgsUsage: "[CID1] [CID2]...",
 			Flags: []cli.Flag{
 				localFlag(),
 				cli.StringFlag{
@@ -880,11 +880,18 @@ separated list). The following are valid status values:
 				},
 			},
 			Action: func(c *cli.Context) error {
-				cidStr := c.Args().First()
-				if cidStr != "" {
-					ci, err := cid.Decode(cidStr)
+				cidsStr := c.Args()
+				cids := make([]cid.Cid, len(cidsStr))
+				for i, cStr := range cidsStr {
+					ci, err := cid.Decode(cStr)
 					checkErr("parsing cid", err)
-					resp, cerr := globalClient.Status(ctx, ci, c.Bool("local"))
+					cids[i] = ci
+				}
+				if len(cids) == 1 {
+					resp, cerr := globalClient.Status(ctx, cids[0], c.Bool("local"))
+					formatResponse(c, resp, cerr)
+				} else if len(cids) > 1 {
+					resp, cerr := globalClient.StatusCids(ctx, cids, c.Bool("local"))
 					formatResponse(c, resp, cerr)
 				} else {
 					filterFlag := c.String("filter")


### PR DESCRIPTION
Adds support for this in the Go RESTAPI client and the ipfs-cluster-ctl command.

Fixes #1564 .