### PR TITLE
Fix 1598: Include allocations in responses from /add

### DIFF
--- a/adder/adder_test.go
+++ b/adder/adder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/test"
 	"github.com/ipld/go-car"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 
 	cid "github.com/ipfs/go-cid"
 	files "github.com/ipfs/go-ipfs-files"
@@ -29,6 +30,10 @@ func newMockCDAGServ() *mockCDAGServ {
 // noop
 func (dag *mockCDAGServ) Finalize(ctx context.Context, root cid.Cid) (cid.Cid, error) {
 	return root, nil
+}
+
+func (dag *mockCDAGServ) Allocations() []peer.ID {
+	return nil
 }
 
 func TestAdder(t *testing.T) {

--- a/adder/sharding/shard.go
+++ b/adder/sharding/shard.go
@@ -71,6 +71,9 @@ func (sh *shard) AddLink(ctx context.Context, c cid.Cid, s uint64) {
 
 // Allocations returns the peer IDs on which blocks are put for this shard.
 func (sh *shard) Allocations() []peer.ID {
+	if len(sh.allocations) == 1 && sh.allocations[0] == "" {
+		return nil
+	}
 	return sh.allocations
 }
 

--- a/adder/single/dag_service.go
+++ b/adder/single/dag_service.go
@@ -98,9 +98,13 @@ func (dgs *DAGService) Finalize(ctx context.Context, root cid.Cid) (cid.Cid, err
 	// Cluster pin the result
 	rootPin := api.PinWithOpts(root, dgs.addParams.PinOptions)
 	rootPin.Allocations = dgs.dests
-	dgs.dests = nil
 
 	return root, adder.Pin(ctx, dgs.rpcClient, rootPin)
+}
+
+// Allocations returns the add destinations decided by the DAGService.
+func (dgs *DAGService) Allocations() []peer.ID {
+	return dgs.dests
 }
 
 // AddMany calls Add for every given node.

--- a/adder/single/dag_service.go
+++ b/adder/single/dag_service.go
@@ -54,29 +54,29 @@ func (dgs *DAGService) Add(ctx context.Context, node ipld.Node) error {
 			return err
 		}
 
+		hasLocal := false
+		localPid := dgs.rpcClient.ID()
+		for i, d := range dests {
+			if d == localPid || d == "" {
+				hasLocal = true
+				// ensure our allocs do not carry an empty peer
+				// mostly an issue with testing mocks
+				dests[i] = localPid
+			}
+		}
+
 		dgs.dests = dests
 
 		if dgs.local {
 			// If this is a local pin, make sure that the local
 			// peer is among the allocations..
 			// UNLESS user-allocations are defined!
-			localPid := dgs.rpcClient.ID()
-			hasLocal := false
-			for _, d := range dests {
-				if d == localPid {
-					hasLocal = true
-					break
-				}
-			}
-
-			if !hasLocal &&
-				localPid != "" &&
-				len(dgs.addParams.UserAllocations) == 0 {
+			if !hasLocal && localPid != "" && len(dgs.addParams.UserAllocations) == 0 {
 				// replace last allocation with local peer
 				dgs.dests[len(dgs.dests)-1] = localPid
 			}
 
-			dgs.ba = adder.NewBlockAdder(dgs.rpcClient, []peer.ID{""})
+			dgs.ba = adder.NewBlockAdder(dgs.rpcClient, []peer.ID{localPid})
 		} else {
 			dgs.ba = adder.NewBlockAdder(dgs.rpcClient, dgs.dests)
 		}
@@ -104,6 +104,11 @@ func (dgs *DAGService) Finalize(ctx context.Context, root cid.Cid) (cid.Cid, err
 
 // Allocations returns the add destinations decided by the DAGService.
 func (dgs *DAGService) Allocations() []peer.ID {
+	// using rpc clients without a host results in an empty peer
+	// which cannot be parsed to peer.ID on deserialization.
+	if len(dgs.dests) == 1 && dgs.dests[0] == "" {
+		return nil
+	}
 	return dgs.dests
 }
 

--- a/api/add.go
+++ b/api/add.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 // DefaultShardSize is the shard size for params objects created with DefaultParams().
@@ -15,10 +16,11 @@ var DefaultShardSize = uint64(100 * 1024 * 1024) // 100 MB
 // AddedOutput carries information for displaying the standard ipfs output
 // indicating a node of a file has been added.
 type AddedOutput struct {
-	Name  string  `json:"name" codec:"n,omitempty"`
-	Cid   cid.Cid `json:"cid" codec:"c"`
-	Bytes uint64  `json:"bytes,omitempty" codec:"b,omitempty"`
-	Size  uint64  `json:"size,omitempty" codec:"s,omitempty"`
+	Name        string    `json:"name" codec:"n,omitempty"`
+	Cid         cid.Cid   `json:"cid" codec:"c"`
+	Bytes       uint64    `json:"bytes,omitempty" codec:"b,omitempty"`
+	Size        uint64    `json:"size,omitempty" codec:"s,omitempty"`
+	Allocations []peer.ID `json:"allocations,omitempty" codec:"a,omitempty"`
 }
 
 // IPFSAddParams groups options specific to the ipfs-adder, which builds


### PR DESCRIPTION
This adds a new allocations field to add response objects which
provides the cluster peers to which the content has been allocated.

In the case of sharded dags, it provides peers for the current shard.

Fixes #1598 