### PR TITLE
Pinset streaming and method type revamp

### DIFF
--- a/add_test.go
+++ b/add_test.go
@@ -4,7 +4,6 @@ package ipfscluster
 
 import (
 	"context"
-	"fmt"
 	"mime/multipart"
 	"sync"
 	"testing"
@@ -85,7 +84,6 @@ func TestAdd(t *testing.T) {
 			if pin.Error != "" {
 				t.Error(pin.Error)
 			}
-			fmt.Println(pin)
 			switch c.id {
 			case clusters[2].id:
 				if pin.Status != api.TrackerStatusPinned {

--- a/adder/sharding/dag_service_test.go
+++ b/adder/sharding/dag_service_test.go
@@ -27,18 +27,18 @@ type testRPC struct {
 	pins   sync.Map
 }
 
-func (rpcs *testRPC) BlockPut(ctx context.Context, in *api.NodeWithMeta, out *struct{}) error {
+func (rpcs *testRPC) BlockPut(ctx context.Context, in api.NodeWithMeta, out *struct{}) error {
 	rpcs.blocks.Store(in.Cid.String(), in.Data)
 	return nil
 }
 
-func (rpcs *testRPC) Pin(ctx context.Context, in *api.Pin, out *api.Pin) error {
+func (rpcs *testRPC) Pin(ctx context.Context, in api.Pin, out *api.Pin) error {
 	rpcs.pins.Store(in.Cid.String(), in)
-	*out = *in
+	*out = in
 	return nil
 }
 
-func (rpcs *testRPC) BlockAllocate(ctx context.Context, in *api.Pin, out *[]peer.ID) error {
+func (rpcs *testRPC) BlockAllocate(ctx context.Context, in api.Pin, out *[]peer.ID) error {
 	if in.ReplicationFactorMin > 1 {
 		return errors.New("we can only replicate to 1 peer")
 	}
@@ -48,12 +48,12 @@ func (rpcs *testRPC) BlockAllocate(ctx context.Context, in *api.Pin, out *[]peer
 	return nil
 }
 
-func (rpcs *testRPC) PinGet(ctx context.Context, c cid.Cid) (*api.Pin, error) {
+func (rpcs *testRPC) PinGet(ctx context.Context, c cid.Cid) (api.Pin, error) {
 	pI, ok := rpcs.pins.Load(c.String())
 	if !ok {
-		return nil, errors.New("not found")
+		return api.Pin{}, errors.New("not found")
 	}
-	return pI.(*api.Pin), nil
+	return pI.(api.Pin), nil
 }
 
 func (rpcs *testRPC) BlockGet(ctx context.Context, c cid.Cid) ([]byte, error) {

--- a/adder/sharding/verify.go
+++ b/adder/sharding/verify.go
@@ -14,7 +14,7 @@ import (
 // MockPinStore is used in VerifyShards
 type MockPinStore interface {
 	// Gets a pin
-	PinGet(context.Context, cid.Cid) (*api.Pin, error)
+	PinGet(context.Context, cid.Cid) (api.Pin, error)
 }
 
 // MockBlockStore is used in VerifyShards

--- a/adder/single/dag_service_test.go
+++ b/adder/single/dag_service_test.go
@@ -23,18 +23,18 @@ type testClusterRPC struct {
 	pins sync.Map
 }
 
-func (rpcs *testIPFSRPC) BlockPut(ctx context.Context, in *api.NodeWithMeta, out *struct{}) error {
+func (rpcs *testIPFSRPC) BlockPut(ctx context.Context, in api.NodeWithMeta, out *struct{}) error {
 	rpcs.blocks.Store(in.Cid.String(), in)
 	return nil
 }
 
-func (rpcs *testClusterRPC) Pin(ctx context.Context, in *api.Pin, out *api.Pin) error {
+func (rpcs *testClusterRPC) Pin(ctx context.Context, in api.Pin, out *api.Pin) error {
 	rpcs.pins.Store(in.Cid.String(), in)
-	*out = *in
+	*out = in
 	return nil
 }
 
-func (rpcs *testClusterRPC) BlockAllocate(ctx context.Context, in *api.Pin, out *[]peer.ID) error {
+func (rpcs *testClusterRPC) BlockAllocate(ctx context.Context, in api.Pin, out *[]peer.ID) error {
 	if in.ReplicationFactorMin > 1 {
 		return errors.New("we can only replicate to 1 peer")
 	}

--- a/adder/util.go
+++ b/adder/util.go
@@ -93,13 +93,13 @@ func (ba *BlockAdder) AddMany(ctx context.Context, nodes []ipld.Node) error {
 }
 
 // ipldNodeToNodeSerial converts an ipld.Node to NodeWithMeta.
-func ipldNodeToNodeWithMeta(n ipld.Node) *api.NodeWithMeta {
+func ipldNodeToNodeWithMeta(n ipld.Node) api.NodeWithMeta {
 	size, err := n.Size()
 	if err != nil {
 		logger.Warn(err)
 	}
 
-	return &api.NodeWithMeta{
+	return api.NodeWithMeta{
 		Cid:     n.Cid(),
 		Data:    n.RawData(),
 		CumSize: size,
@@ -122,7 +122,7 @@ func BlockAllocate(ctx context.Context, rpc *rpc.Client, pinOpts api.PinOptions)
 }
 
 // Pin helps sending local RPC pin requests.
-func Pin(ctx context.Context, rpc *rpc.Client, pin *api.Pin) error {
+func Pin(ctx context.Context, rpc *rpc.Client, pin api.Pin) error {
 	if pin.ReplicationFactorMin < 0 {
 		pin.Allocations = []peer.ID{}
 	}

--- a/allocate.go
+++ b/allocate.go
@@ -57,7 +57,7 @@ type classifiedMetrics struct {
 // into account if the given CID was previously in a "pin everywhere" mode,
 // and will consider such Pins as currently unallocated ones, providing
 // new allocations as available.
-func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, currentPin *api.Pin, rplMin, rplMax int, blacklist []peer.ID, priorityList []peer.ID) ([]peer.ID, error) {
+func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, currentPin api.Pin, rplMin, rplMax int, blacklist []peer.ID, priorityList []peer.ID) ([]peer.ID, error) {
 	ctx, span := trace.StartSpan(ctx, "cluster/allocate")
 	defer span.End()
 
@@ -71,7 +71,7 @@ func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, currentPin *api.Pi
 
 	// Figure out who is holding the CID
 	var currentAllocs []peer.ID
-	if currentPin != nil {
+	if currentPin.Defined() {
 		currentAllocs = currentPin.Allocations
 	}
 
@@ -120,9 +120,9 @@ func (c *Cluster) allocate(ctx context.Context, hash cid.Cid, currentPin *api.Pi
 // For a metric/peer to be included in a group, it is necessary that it has
 // metrics for all informers.
 func (c *Cluster) filterMetrics(ctx context.Context, mSet api.MetricsSet, numMetrics int, currentAllocs, priorityList, blacklist []peer.ID) classifiedMetrics {
-	curPeersMap := make(map[peer.ID][]*api.Metric)
-	candPeersMap := make(map[peer.ID][]*api.Metric)
-	prioPeersMap := make(map[peer.ID][]*api.Metric)
+	curPeersMap := make(map[peer.ID][]api.Metric)
+	candPeersMap := make(map[peer.ID][]api.Metric)
+	prioPeersMap := make(map[peer.ID][]api.Metric)
 
 	// Divide the metric by current/candidate/prio and by peer
 	for _, metrics := range mSet {
@@ -145,7 +145,7 @@ func (c *Cluster) filterMetrics(ctx context.Context, mSet api.MetricsSet, numMet
 		}
 	}
 
-	fillMetricsSet := func(peersMap map[peer.ID][]*api.Metric) (api.MetricsSet, []peer.ID) {
+	fillMetricsSet := func(peersMap map[peer.ID][]api.Metric) (api.MetricsSet, []peer.ID) {
 		mSet := make(api.MetricsSet)
 		peers := make([]peer.ID, 0, len(peersMap))
 

--- a/allocator/balanced/balanced.go
+++ b/allocator/balanced/balanced.go
@@ -119,7 +119,7 @@ func partitionMetrics(set api.MetricsSet, by []string) *partitionedMetric {
 	return pnedMetric
 }
 
-func partitionValues(metrics []*api.Metric) []*partition {
+func partitionValues(metrics []api.Metric) []*partition {
 	partitions := []*partition{}
 
 	if len(metrics) <= 0 {

--- a/allocator/balanced/balanced_test.go
+++ b/allocator/balanced/balanced_test.go
@@ -10,8 +10,8 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-func makeMetric(name, value string, weight int64, peer peer.ID, partitionable bool) *api.Metric {
-	return &api.Metric{
+func makeMetric(name, value string, weight int64, peer peer.ID, partitionable bool) api.Metric {
+	return api.Metric{
 		Name:          name,
 		Value:         value,
 		Weight:        weight,
@@ -35,11 +35,11 @@ func TestAllocate(t *testing.T) {
 	}
 
 	candidates := api.MetricsSet{
-		"abc": []*api.Metric{ // don't want anything in results
+		"abc": []api.Metric{ // don't want anything in results
 			makeMetric("abc", "a", 0, test.PeerID1, true),
 			makeMetric("abc", "b", 0, test.PeerID2, true),
 		},
-		"region": []*api.Metric{
+		"region": []api.Metric{
 			makeMetric("region", "a-us", 0, test.PeerID1, true),
 			makeMetric("region", "a-us", 0, test.PeerID2, true),
 
@@ -51,7 +51,7 @@ func TestAllocate(t *testing.T) {
 			makeMetric("region", "c-au", 0, test.PeerID7, true),
 			makeMetric("region", "c-au", 0, test.PeerID8, true), // I don't want to see this in results
 		},
-		"az": []*api.Metric{
+		"az": []api.Metric{
 			makeMetric("az", "us1", 0, test.PeerID1, true),
 			makeMetric("az", "us2", 0, test.PeerID2, true),
 
@@ -62,7 +62,7 @@ func TestAllocate(t *testing.T) {
 			makeMetric("az", "au1", 0, test.PeerID6, true),
 			makeMetric("az", "au1", 0, test.PeerID7, true),
 		},
-		"freespace": []*api.Metric{
+		"freespace": []api.Metric{
 			makeMetric("freespace", "100", 100, test.PeerID1, false),
 			makeMetric("freespace", "500", 500, test.PeerID2, false),
 

--- a/api/add.go
+++ b/api/add.go
@@ -243,7 +243,7 @@ func (p AddParams) ToQueryString() (string, error) {
 
 // Equals checks if p equals p2.
 func (p AddParams) Equals(p2 AddParams) bool {
-	return p.PinOptions.Equals(&p2.PinOptions) &&
+	return p.PinOptions.Equals(p2.PinOptions) &&
 		p.Local == p2.Local &&
 		p.Recursive == p2.Recursive &&
 		p.Shard == p2.Shard &&

--- a/api/pinsvcapi/pinsvc/pinsvc.go
+++ b/api/pinsvcapi/pinsvc/pinsvc.go
@@ -60,6 +60,11 @@ type Pin struct {
 	Meta    map[string]string `json:"meta"`
 }
 
+// Defined returns if the pinis empty (Cid not set).
+func (p Pin) Defined() bool {
+	return p.Cid != ""
+}
+
 // MatchesName returns in a pin status matches a name option with a given
 // match strategy.
 func (p Pin) MatchesName(nameOpt string, strategy MatchingStrategy) bool {

--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -48,73 +48,73 @@ var logger = logging.Logger(loggingFacility)
 // metrics and tracing of requests through the API.
 type Client interface {
 	// ID returns information about the cluster Peer.
-	ID(context.Context) (*api.ID, error)
+	ID(context.Context) (api.ID, error)
 
 	// Peers requests ID information for all cluster peers.
-	Peers(context.Context) ([]*api.ID, error)
+	Peers(context.Context) ([]api.ID, error)
 	// PeerAdd adds a new peer to the cluster.
-	PeerAdd(ctx context.Context, pid peer.ID) (*api.ID, error)
+	PeerAdd(ctx context.Context, pid peer.ID) (api.ID, error)
 	// PeerRm removes a current peer from the cluster
 	PeerRm(ctx context.Context, pid peer.ID) error
 
 	// Add imports files to the cluster from the given paths.
-	Add(ctx context.Context, paths []string, params api.AddParams, out chan<- *api.AddedOutput) error
+	Add(ctx context.Context, paths []string, params api.AddParams, out chan<- api.AddedOutput) error
 	// AddMultiFile imports new files from a MultiFileReader.
-	AddMultiFile(ctx context.Context, multiFileR *files.MultiFileReader, params api.AddParams, out chan<- *api.AddedOutput) error
+	AddMultiFile(ctx context.Context, multiFileR *files.MultiFileReader, params api.AddParams, out chan<- api.AddedOutput) error
 
 	// Pin tracks a Cid with the given replication factor and a name for
 	// human-friendliness.
-	Pin(ctx context.Context, ci cid.Cid, opts api.PinOptions) (*api.Pin, error)
+	Pin(ctx context.Context, ci cid.Cid, opts api.PinOptions) (api.Pin, error)
 	// Unpin untracks a Cid from cluster.
-	Unpin(ctx context.Context, ci cid.Cid) (*api.Pin, error)
+	Unpin(ctx context.Context, ci cid.Cid) (api.Pin, error)
 
 	// PinPath resolves given path into a cid and performs the pin operation.
-	PinPath(ctx context.Context, path string, opts api.PinOptions) (*api.Pin, error)
+	PinPath(ctx context.Context, path string, opts api.PinOptions) (api.Pin, error)
 	// UnpinPath resolves given path into a cid and performs the unpin operation.
 	// It returns api.Pin of the given cid before it is unpinned.
-	UnpinPath(ctx context.Context, path string) (*api.Pin, error)
+	UnpinPath(ctx context.Context, path string) (api.Pin, error)
 
 	// Allocations returns the consensus state listing all tracked items
 	// and the peers that should be pinning them.
-	Allocations(ctx context.Context, filter api.PinType) ([]*api.Pin, error)
+	Allocations(ctx context.Context, filter api.PinType, out chan<- api.Pin) error
 	// Allocation returns the current allocations for a given Cid.
-	Allocation(ctx context.Context, ci cid.Cid) (*api.Pin, error)
+	Allocation(ctx context.Context, ci cid.Cid) (api.Pin, error)
 
 	// Status returns the current ipfs state for a given Cid. If local is true,
 	// the information affects only the current peer, otherwise the information
 	// is fetched from all cluster peers.
-	Status(ctx context.Context, ci cid.Cid, local bool) (*api.GlobalPinInfo, error)
+	Status(ctx context.Context, ci cid.Cid, local bool) (api.GlobalPinInfo, error)
 	// StatusCids status information for the requested CIDs.
-	StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]*api.GlobalPinInfo, error)
+	StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]api.GlobalPinInfo, error)
 	// StatusAll gathers Status() for all tracked items.
-	StatusAll(ctx context.Context, filter api.TrackerStatus, local bool) ([]*api.GlobalPinInfo, error)
+	StatusAll(ctx context.Context, filter api.TrackerStatus, local bool) ([]api.GlobalPinInfo, error)
 
 	// Recover retriggers pin or unpin ipfs operations for a Cid in error
 	// state.  If local is true, the operation is limited to the current
 	// peer, otherwise it happens on every cluster peer.
-	Recover(ctx context.Context, ci cid.Cid, local bool) (*api.GlobalPinInfo, error)
+	Recover(ctx context.Context, ci cid.Cid, local bool) (api.GlobalPinInfo, error)
 	// RecoverAll triggers Recover() operations on all tracked items. If
 	// local is true, the operation is limited to the current peer.
 	// Otherwise, it happens everywhere.
-	RecoverAll(ctx context.Context, local bool) ([]*api.GlobalPinInfo, error)
+	RecoverAll(ctx context.Context, local bool) ([]api.GlobalPinInfo, error)
 
 	// Alerts returns information health events in the cluster (expired
 	// metrics etc.).
-	Alerts(ctx context.Context) ([]*api.Alert, error)
+	Alerts(ctx context.Context) ([]api.Alert, error)
 
 	// Version returns the ipfs-cluster peer's version.
-	Version(context.Context) (*api.Version, error)
+	Version(context.Context) (api.Version, error)
 
 	// IPFS returns an instance of go-ipfs-api's Shell, pointing to a
 	// Cluster's IPFS proxy endpoint.
 	IPFS(context.Context) *shell.Shell
 
 	// GetConnectGraph returns an ipfs-cluster connection graph.
-	GetConnectGraph(context.Context) (*api.ConnectGraph, error)
+	GetConnectGraph(context.Context) (api.ConnectGraph, error)
 
 	// Metrics returns a map with the latest metrics of matching name
 	// for the current cluster peers.
-	Metrics(ctx context.Context, name string) ([]*api.Metric, error)
+	Metrics(ctx context.Context, name string) ([]api.Metric, error)
 
 	// MetricNames returns the list of metric types.
 	MetricNames(ctx context.Context) ([]string, error)
@@ -122,7 +122,7 @@ type Client interface {
 	// RepoGC runs garbage collection on IPFS daemons of cluster peers and
 	// returns collected CIDs. If local is true, it would garbage collect
 	// only on contacted peer, otherwise on all peers' IPFS daemons.
-	RepoGC(ctx context.Context, local bool) (*api.GlobalRepoGC, error)
+	RepoGC(ctx context.Context, local bool) (api.GlobalRepoGC, error)
 }
 
 // Config allows to configure the parameters to connect

--- a/api/rest/client/lbclient.go
+++ b/api/rest/client/lbclient.go
@@ -91,7 +91,7 @@ func (lc *loadBalancingClient) retry(count int, call func(Client) error) error {
 
 	// It is a safety check. This error should never occur.
 	// All errors returned by client methods are of type `api.Error`.
-	apiErr, ok := err.(*api.Error)
+	apiErr, ok := err.(api.Error)
 	if !ok {
 		logger.Error("could not cast error into api.Error")
 		return err
@@ -110,8 +110,8 @@ func (lc *loadBalancingClient) retry(count int, call func(Client) error) error {
 }
 
 // ID returns information about the cluster Peer.
-func (lc *loadBalancingClient) ID(ctx context.Context) (*api.ID, error) {
-	var id *api.ID
+func (lc *loadBalancingClient) ID(ctx context.Context) (api.ID, error) {
+	var id api.ID
 	call := func(c Client) error {
 		var err error
 		id, err = c.ID(ctx)
@@ -123,8 +123,8 @@ func (lc *loadBalancingClient) ID(ctx context.Context) (*api.ID, error) {
 }
 
 // Peers requests ID information for all cluster peers.
-func (lc *loadBalancingClient) Peers(ctx context.Context) ([]*api.ID, error) {
-	var peers []*api.ID
+func (lc *loadBalancingClient) Peers(ctx context.Context) ([]api.ID, error) {
+	var peers []api.ID
 	call := func(c Client) error {
 		var err error
 		peers, err = c.Peers(ctx)
@@ -136,8 +136,8 @@ func (lc *loadBalancingClient) Peers(ctx context.Context) ([]*api.ID, error) {
 }
 
 // PeerAdd adds a new peer to the cluster.
-func (lc *loadBalancingClient) PeerAdd(ctx context.Context, pid peer.ID) (*api.ID, error) {
-	var id *api.ID
+func (lc *loadBalancingClient) PeerAdd(ctx context.Context, pid peer.ID) (api.ID, error) {
+	var id api.ID
 	call := func(c Client) error {
 		var err error
 		id, err = c.PeerAdd(ctx, pid)
@@ -159,8 +159,8 @@ func (lc *loadBalancingClient) PeerRm(ctx context.Context, id peer.ID) error {
 
 // Pin tracks a Cid with the given replication factor and a name for
 // human-friendliness.
-func (lc *loadBalancingClient) Pin(ctx context.Context, ci cid.Cid, opts api.PinOptions) (*api.Pin, error) {
-	var pin *api.Pin
+func (lc *loadBalancingClient) Pin(ctx context.Context, ci cid.Cid, opts api.PinOptions) (api.Pin, error) {
+	var pin api.Pin
 	call := func(c Client) error {
 		var err error
 		pin, err = c.Pin(ctx, ci, opts)
@@ -172,8 +172,8 @@ func (lc *loadBalancingClient) Pin(ctx context.Context, ci cid.Cid, opts api.Pin
 }
 
 // Unpin untracks a Cid from cluster.
-func (lc *loadBalancingClient) Unpin(ctx context.Context, ci cid.Cid) (*api.Pin, error) {
-	var pin *api.Pin
+func (lc *loadBalancingClient) Unpin(ctx context.Context, ci cid.Cid) (api.Pin, error) {
+	var pin api.Pin
 	call := func(c Client) error {
 		var err error
 		pin, err = c.Unpin(ctx, ci)
@@ -185,8 +185,8 @@ func (lc *loadBalancingClient) Unpin(ctx context.Context, ci cid.Cid) (*api.Pin,
 }
 
 // PinPath allows to pin an element by the given IPFS path.
-func (lc *loadBalancingClient) PinPath(ctx context.Context, path string, opts api.PinOptions) (*api.Pin, error) {
-	var pin *api.Pin
+func (lc *loadBalancingClient) PinPath(ctx context.Context, path string, opts api.PinOptions) (api.Pin, error) {
+	var pin api.Pin
 	call := func(c Client) error {
 		var err error
 		pin, err = c.PinPath(ctx, path, opts)
@@ -199,8 +199,8 @@ func (lc *loadBalancingClient) PinPath(ctx context.Context, path string, opts ap
 
 // UnpinPath allows to unpin an item by providing its IPFS path.
 // It returns the unpinned api.Pin information of the resolved Cid.
-func (lc *loadBalancingClient) UnpinPath(ctx context.Context, p string) (*api.Pin, error) {
-	var pin *api.Pin
+func (lc *loadBalancingClient) UnpinPath(ctx context.Context, p string) (api.Pin, error) {
+	var pin api.Pin
 	call := func(c Client) error {
 		var err error
 		pin, err = c.UnpinPath(ctx, p)
@@ -213,21 +213,18 @@ func (lc *loadBalancingClient) UnpinPath(ctx context.Context, p string) (*api.Pi
 
 // Allocations returns the consensus state listing all tracked items and
 // the peers that should be pinning them.
-func (lc *loadBalancingClient) Allocations(ctx context.Context, filter api.PinType) ([]*api.Pin, error) {
-	var pins []*api.Pin
+func (lc *loadBalancingClient) Allocations(ctx context.Context, filter api.PinType, out chan<- api.Pin) error {
 	call := func(c Client) error {
-		var err error
-		pins, err = c.Allocations(ctx, filter)
-		return err
+		return c.Allocations(ctx, filter, out)
 	}
 
 	err := lc.retry(0, call)
-	return pins, err
+	return err
 }
 
 // Allocation returns the current allocations for a given Cid.
-func (lc *loadBalancingClient) Allocation(ctx context.Context, ci cid.Cid) (*api.Pin, error) {
-	var pin *api.Pin
+func (lc *loadBalancingClient) Allocation(ctx context.Context, ci cid.Cid) (api.Pin, error) {
+	var pin api.Pin
 	call := func(c Client) error {
 		var err error
 		pin, err = c.Allocation(ctx, ci)
@@ -241,8 +238,8 @@ func (lc *loadBalancingClient) Allocation(ctx context.Context, ci cid.Cid) (*api
 // Status returns the current ipfs state for a given Cid. If local is true,
 // the information affects only the current peer, otherwise the information
 // is fetched from all cluster peers.
-func (lc *loadBalancingClient) Status(ctx context.Context, ci cid.Cid, local bool) (*api.GlobalPinInfo, error) {
-	var pinInfo *api.GlobalPinInfo
+func (lc *loadBalancingClient) Status(ctx context.Context, ci cid.Cid, local bool) (api.GlobalPinInfo, error) {
+	var pinInfo api.GlobalPinInfo
 	call := func(c Client) error {
 		var err error
 		pinInfo, err = c.Status(ctx, ci, local)
@@ -256,8 +253,8 @@ func (lc *loadBalancingClient) Status(ctx context.Context, ci cid.Cid, local boo
 // StatusCids returns Status() information for the given Cids. If local is
 // true, the information affects only the current peer, otherwise the
 // information is fetched from all cluster peers.
-func (lc *loadBalancingClient) StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]*api.GlobalPinInfo, error) {
-	var pinInfos []*api.GlobalPinInfo
+func (lc *loadBalancingClient) StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]api.GlobalPinInfo, error) {
+	var pinInfos []api.GlobalPinInfo
 	call := func(c Client) error {
 		var err error
 		pinInfos, err = c.StatusCids(ctx, cids, local)
@@ -273,8 +270,8 @@ func (lc *loadBalancingClient) StatusCids(ctx context.Context, cids []cid.Cid, l
 // will be returned. A filter can be built by merging TrackerStatuses with
 // a bitwise OR operation (st1 | st2 | ...). A "0" filter value (or
 // api.TrackerStatusUndefined), means all.
-func (lc *loadBalancingClient) StatusAll(ctx context.Context, filter api.TrackerStatus, local bool) ([]*api.GlobalPinInfo, error) {
-	var pinInfos []*api.GlobalPinInfo
+func (lc *loadBalancingClient) StatusAll(ctx context.Context, filter api.TrackerStatus, local bool) ([]api.GlobalPinInfo, error) {
+	var pinInfos []api.GlobalPinInfo
 	call := func(c Client) error {
 		var err error
 		pinInfos, err = c.StatusAll(ctx, filter, local)
@@ -288,8 +285,8 @@ func (lc *loadBalancingClient) StatusAll(ctx context.Context, filter api.Tracker
 // Recover retriggers pin or unpin ipfs operations for a Cid in error state.
 // If local is true, the operation is limited to the current peer, otherwise
 // it happens on every cluster peer.
-func (lc *loadBalancingClient) Recover(ctx context.Context, ci cid.Cid, local bool) (*api.GlobalPinInfo, error) {
-	var pinInfo *api.GlobalPinInfo
+func (lc *loadBalancingClient) Recover(ctx context.Context, ci cid.Cid, local bool) (api.GlobalPinInfo, error) {
+	var pinInfo api.GlobalPinInfo
 	call := func(c Client) error {
 		var err error
 		pinInfo, err = c.Recover(ctx, ci, local)
@@ -303,8 +300,8 @@ func (lc *loadBalancingClient) Recover(ctx context.Context, ci cid.Cid, local bo
 // RecoverAll triggers Recover() operations on all tracked items. If local is
 // true, the operation is limited to the current peer. Otherwise, it happens
 // everywhere.
-func (lc *loadBalancingClient) RecoverAll(ctx context.Context, local bool) ([]*api.GlobalPinInfo, error) {
-	var pinInfos []*api.GlobalPinInfo
+func (lc *loadBalancingClient) RecoverAll(ctx context.Context, local bool) ([]api.GlobalPinInfo, error) {
+	var pinInfos []api.GlobalPinInfo
 	call := func(c Client) error {
 		var err error
 		pinInfos, err = c.RecoverAll(ctx, local)
@@ -316,8 +313,8 @@ func (lc *loadBalancingClient) RecoverAll(ctx context.Context, local bool) ([]*a
 }
 
 // Alerts returns things that are wrong with cluster.
-func (lc *loadBalancingClient) Alerts(ctx context.Context) ([]*api.Alert, error) {
-	var alerts []*api.Alert
+func (lc *loadBalancingClient) Alerts(ctx context.Context) ([]api.Alert, error) {
+	var alerts []api.Alert
 	call := func(c Client) error {
 		var err error
 		alerts, err = c.Alerts(ctx)
@@ -329,8 +326,8 @@ func (lc *loadBalancingClient) Alerts(ctx context.Context) ([]*api.Alert, error)
 }
 
 // Version returns the ipfs-cluster peer's version.
-func (lc *loadBalancingClient) Version(ctx context.Context) (*api.Version, error) {
-	var v *api.Version
+func (lc *loadBalancingClient) Version(ctx context.Context) (api.Version, error) {
+	var v api.Version
 	call := func(c Client) error {
 		var err error
 		v, err = c.Version(ctx)
@@ -342,8 +339,8 @@ func (lc *loadBalancingClient) Version(ctx context.Context) (*api.Version, error
 
 // GetConnectGraph returns an ipfs-cluster connection graph.
 // The serialized version, strings instead of pids, is returned.
-func (lc *loadBalancingClient) GetConnectGraph(ctx context.Context) (*api.ConnectGraph, error) {
-	var graph *api.ConnectGraph
+func (lc *loadBalancingClient) GetConnectGraph(ctx context.Context) (api.ConnectGraph, error) {
+	var graph api.ConnectGraph
 	call := func(c Client) error {
 		var err error
 		graph, err = c.GetConnectGraph(ctx)
@@ -356,8 +353,8 @@ func (lc *loadBalancingClient) GetConnectGraph(ctx context.Context) (*api.Connec
 
 // Metrics returns a map with the latest valid metrics of the given name
 // for the current cluster peers.
-func (lc *loadBalancingClient) Metrics(ctx context.Context, name string) ([]*api.Metric, error) {
-	var metrics []*api.Metric
+func (lc *loadBalancingClient) Metrics(ctx context.Context, name string) ([]api.Metric, error) {
+	var metrics []api.Metric
 	call := func(c Client) error {
 		var err error
 		metrics, err = c.Metrics(ctx, name)
@@ -385,8 +382,8 @@ func (lc *loadBalancingClient) MetricNames(ctx context.Context) ([]string, error
 // RepoGC runs garbage collection on IPFS daemons of cluster peers and
 // returns collected CIDs. If local is true, it would garbage collect
 // only on contacted peer, otherwise on all peers' IPFS daemons.
-func (lc *loadBalancingClient) RepoGC(ctx context.Context, local bool) (*api.GlobalRepoGC, error) {
-	var repoGC *api.GlobalRepoGC
+func (lc *loadBalancingClient) RepoGC(ctx context.Context, local bool) (api.GlobalRepoGC, error) {
+	var repoGC api.GlobalRepoGC
 
 	call := func(c Client) error {
 		var err error
@@ -409,7 +406,7 @@ func (lc *loadBalancingClient) Add(
 	ctx context.Context,
 	paths []string,
 	params api.AddParams,
-	out chan<- *api.AddedOutput,
+	out chan<- api.AddedOutput,
 ) error {
 	call := func(c Client) error {
 		return c.Add(ctx, paths, params, out)
@@ -423,7 +420,7 @@ func (lc *loadBalancingClient) AddMultiFile(
 	ctx context.Context,
 	multiFileR *files.MultiFileReader,
 	params api.AddParams,
-	out chan<- *api.AddedOutput,
+	out chan<- api.AddedOutput,
 ) error {
 	call := func(c Client) error {
 		return c.AddMultiFile(ctx, multiFileR, params, out)

--- a/api/rest/client/lbclient_test.go
+++ b/api/rest/client/lbclient_test.go
@@ -47,8 +47,8 @@ type dummyClient struct {
 }
 
 // ID returns dummy client's serial number.
-func (d *dummyClient) ID(ctx context.Context) (*api.ID, error) {
-	return &api.ID{
+func (d *dummyClient) ID(ctx context.Context) (api.ID, error) {
+	return api.ID{
 		Peername: fmt.Sprintf("%d", d.i),
 	}, nil
 }

--- a/api/rest/client/request.go
+++ b/api/rest/client/request.go
@@ -131,10 +131,10 @@ func (c *defaultClient) handleStreamResponse(resp *http.Response, handler respon
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		return api.Error{
 			Code:    resp.StatusCode,
-			Message: "expected streaming response with code 200",
+			Message: "expected streaming response with code 200/204",
 		}
 	}
 

--- a/api/rest/client/request.go
+++ b/api/rest/client/request.go
@@ -25,7 +25,7 @@ func (c *defaultClient) do(
 
 	resp, err := c.doRequest(ctx, method, path, headers, body)
 	if err != nil {
-		return &api.Error{Code: 0, Message: err.Error()}
+		return api.Error{Code: 0, Message: err.Error()}
 	}
 	return c.handleResponse(resp, obj)
 }
@@ -40,7 +40,7 @@ func (c *defaultClient) doStream(
 
 	resp, err := c.doRequest(ctx, method, path, headers, body)
 	if err != nil {
-		return &api.Error{Code: 0, Message: err.Error()}
+		return api.Error{Code: 0, Message: err.Error()}
 	}
 	return c.handleStreamResponse(resp, outHandler)
 }
@@ -91,7 +91,7 @@ func (c *defaultClient) handleResponse(resp *http.Response, obj interface{}) err
 	resp.Body.Close()
 
 	if err != nil {
-		return &api.Error{Code: resp.StatusCode, Message: err.Error()}
+		return api.Error{Code: resp.StatusCode, Message: err.Error()}
 	}
 	logger.Debugf("Response body: %s", body)
 
@@ -106,16 +106,16 @@ func (c *defaultClient) handleResponse(resp *http.Response, obj interface{}) err
 			err = json.Unmarshal(body, &apiErr)
 			if err != nil {
 				// not json. 404s etc.
-				return &api.Error{
+				return api.Error{
 					Code:    resp.StatusCode,
 					Message: string(body),
 				}
 			}
-			return &apiErr
+			return apiErr
 		}
 		err = json.Unmarshal(body, obj)
 		if err != nil {
-			return &api.Error{
+			return api.Error{
 				Code:    resp.StatusCode,
 				Message: err.Error(),
 			}
@@ -132,7 +132,7 @@ func (c *defaultClient) handleStreamResponse(resp *http.Response, handler respon
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return &api.Error{
+		return api.Error{
 			Code:    resp.StatusCode,
 			Message: "expected streaming response with code 200",
 		}
@@ -153,7 +153,7 @@ func (c *defaultClient) handleStreamResponse(resp *http.Response, handler respon
 
 	errTrailer := resp.Trailer.Get("X-Stream-Error")
 	if errTrailer != "" {
-		return &api.Error{
+		return api.Error{
 			Code:    500,
 			Message: errTrailer,
 		}

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -506,15 +506,15 @@ func TestAPIAllocationsEndpoint(t *testing.T) {
 	defer rest.Shutdown(ctx)
 
 	tf := func(t *testing.T, url test.URLFunc) {
-		var resp []*api.Pin
-		test.MakeGet(t, rest, url(rest)+"/allocations?filter=pin,meta-pin", &resp)
+		var resp []api.Pin
+		test.MakeStreamingGet(t, rest, url(rest)+"/allocations?filter=pin,meta-pin", &resp)
 		if len(resp) != 3 ||
 			!resp[0].Cid.Equals(clustertest.Cid1) || !resp[1].Cid.Equals(clustertest.Cid2) ||
 			!resp[2].Cid.Equals(clustertest.Cid3) {
 			t.Error("unexpected pin list: ", resp)
 		}
 
-		test.MakeGet(t, rest, url(rest)+"/allocations", &resp)
+		test.MakeStreamingGet(t, rest, url(rest)+"/allocations", &resp)
 		if len(resp) != 3 ||
 			!resp[0].Cid.Equals(clustertest.Cid1) || !resp[1].Cid.Equals(clustertest.Cid2) ||
 			!resp[2].Cid.Equals(clustertest.Cid3) {
@@ -522,7 +522,7 @@ func TestAPIAllocationsEndpoint(t *testing.T) {
 		}
 
 		errResp := api.Error{}
-		test.MakeGet(t, rest, url(rest)+"/allocations?filter=invalid", &errResp)
+		test.MakeStreamingGet(t, rest, url(rest)+"/allocations?filter=invalid", &errResp)
 		if errResp.Code != http.StatusBadRequest {
 			t.Error("an invalid filter value should 400")
 		}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -208,7 +208,7 @@ func TestPinOptionsQuery(t *testing.T) {
 		if err != nil {
 			t.Error("error parsing query", err)
 		}
-		po2 := &PinOptions{}
+		po2 := PinOptions{}
 		err = po2.FromQuery(q)
 		if err != nil {
 			t.Fatal("error parsing options", err)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -54,13 +54,13 @@ type mockConnector struct {
 	blocks sync.Map
 }
 
-func (ipfs *mockConnector) ID(ctx context.Context) (*api.IPFSID, error) {
-	return &api.IPFSID{
+func (ipfs *mockConnector) ID(ctx context.Context) (api.IPFSID, error) {
+	return api.IPFSID{
 		ID: test.PeerID1,
 	}, nil
 }
 
-func (ipfs *mockConnector) Pin(ctx context.Context, pin *api.Pin) error {
+func (ipfs *mockConnector) Pin(ctx context.Context, pin api.Pin) error {
 	if pin.Cid == test.ErrorCid {
 		return errors.New("trying to pin ErrorCid")
 	}
@@ -73,7 +73,7 @@ func (ipfs *mockConnector) Unpin(ctx context.Context, c cid.Cid) error {
 	return nil
 }
 
-func (ipfs *mockConnector) PinLsCid(ctx context.Context, pin *api.Pin) (api.IPFSPinStatus, error) {
+func (ipfs *mockConnector) PinLsCid(ctx context.Context, pin api.Pin) (api.IPFSPinStatus, error) {
 	dI, ok := ipfs.pins.Load(pin.Cid.String())
 	if !ok {
 		return api.IPFSPinStatusUnpinned, nil
@@ -107,12 +107,12 @@ func (ipfs *mockConnector) SwarmPeers(ctx context.Context) ([]peer.ID, error) {
 	return []peer.ID{test.PeerID4, test.PeerID5}, nil
 }
 
-func (ipfs *mockConnector) RepoStat(ctx context.Context) (*api.IPFSRepoStat, error) {
-	return &api.IPFSRepoStat{RepoSize: 100, StorageMax: 1000}, nil
+func (ipfs *mockConnector) RepoStat(ctx context.Context) (api.IPFSRepoStat, error) {
+	return api.IPFSRepoStat{RepoSize: 100, StorageMax: 1000}, nil
 }
 
-func (ipfs *mockConnector) RepoGC(ctx context.Context) (*api.RepoGC, error) {
-	return &api.RepoGC{
+func (ipfs *mockConnector) RepoGC(ctx context.Context) (api.RepoGC, error) {
+	return api.RepoGC{
 		Keys: []api.IPFSRepoGC{
 			{
 				Key: test.Cid1,
@@ -132,7 +132,7 @@ func (ipfs *mockConnector) Resolve(ctx context.Context, path string) (cid.Cid, e
 func (ipfs *mockConnector) ConnectSwarms(ctx context.Context) error       { return nil }
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
 
-func (ipfs *mockConnector) BlockPut(ctx context.Context, nwm *api.NodeWithMeta) error {
+func (ipfs *mockConnector) BlockPut(ctx context.Context, nwm api.NodeWithMeta) error {
 	ipfs.blocks.Store(nwm.Cid.String(), nwm.Data)
 	return nil
 }
@@ -990,7 +990,7 @@ func TestClusterRepoGCLocal(t *testing.T) {
 	testRepoGC(t, repoGC)
 }
 
-func testRepoGC(t *testing.T, repoGC *api.RepoGC) {
+func testRepoGC(t *testing.T, repoGC api.RepoGC) {
 	if repoGC.Peer == "" {
 		t.Error("expected a cluster ID")
 	}

--- a/cmd/ipfs-cluster-ctl/graph.go
+++ b/cmd/ipfs-cluster-ctl/graph.go
@@ -40,7 +40,7 @@ const (
 
 var errUnknownNodeType = errors.New("unsupported node type. Expected cluster or ipfs")
 
-func makeDot(cg *api.ConnectGraph, w io.Writer, allIpfs bool) error {
+func makeDot(cg api.ConnectGraph, w io.Writer, allIpfs bool) error {
 	ipfsEdges := make(map[string][]peer.ID)
 	for k, v := range cg.IPFSLinks {
 		ipfsEdges[k] = make([]peer.ID, 0)

--- a/cmd/ipfs-cluster-ctl/graph_test.go
+++ b/cmd/ipfs-cluster-ctl/graph_test.go
@@ -117,7 +117,7 @@ func TestSimpleIpfsGraphs(t *testing.T) {
 		},
 	}
 	buf := new(bytes.Buffer)
-	err := makeDot(&cg, buf, false)
+	err := makeDot(cg, buf, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestIpfsAllGraphs(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	err := makeDot(&cg, buf, true)
+	err := makeDot(cg, buf, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ipfs-cluster-follow/commands.go
+++ b/cmd/ipfs-cluster-follow/commands.go
@@ -532,7 +532,7 @@ func printStatusOffline(cfgHelper *cmdutils.ConfigHelper) error {
 	if err != nil {
 		return err
 	}
-	for _, pin := range pins {
+	for pin := range pins {
 		printPin(pin.Cid, "offline", pin.Name, "")
 	}
 	return nil

--- a/cmdutils/state.go
+++ b/cmdutils/state.go
@@ -213,7 +213,7 @@ func importState(r io.Reader, st state.State, opts api.PinOptions) error {
 			pin.Allocations = opts.UserAllocations
 		}
 
-		err = st.Add(ctx, &pin)
+		err = st.Add(ctx, pin)
 		if err != nil {
 			return err
 		}
@@ -227,7 +227,7 @@ func exportState(w io.Writer, st state.State) error {
 		return err
 	}
 	enc := json.NewEncoder(w)
-	for _, pin := range pins {
+	for pin := range pins {
 		err := enc.Encode(pin)
 		if err != nil {
 			return err

--- a/connect_graph.go
+++ b/connect_graph.go
@@ -33,7 +33,7 @@ func (c *Cluster) ConnectGraph() (api.ConnectGraph, error) {
 		cg.ClusterTrustLinks[peer.Encode(member)] = c.consensus.IsTrustedPeer(ctx, member)
 	}
 
-	peers := make([][]*api.ID, len(members))
+	peers := make([][]api.ID, len(members))
 
 	ctxs, cancels := rpcutil.CtxsWithCancel(ctx, len(members))
 	defer rpcutil.MultiCancel(cancels)
@@ -68,9 +68,9 @@ func (c *Cluster) ConnectGraph() (api.ConnectGraph, error) {
 	return cg, nil
 }
 
-func (c *Cluster) recordClusterLinks(cg *api.ConnectGraph, p string, peers []*api.ID) (bool, *api.ID) {
+func (c *Cluster) recordClusterLinks(cg *api.ConnectGraph, p string, peers []api.ID) (bool, api.ID) {
 	selfConnection := false
-	var pID *api.ID
+	var pID api.ID
 	for _, id := range peers {
 		if id.Error != "" {
 			logger.Debugf("Peer %s errored connecting to its peer %s", p, id.ID.Pretty())
@@ -86,7 +86,7 @@ func (c *Cluster) recordClusterLinks(cg *api.ConnectGraph, p string, peers []*ap
 	return selfConnection, pID
 }
 
-func (c *Cluster) recordIPFSLinks(cg *api.ConnectGraph, pID *api.ID) {
+func (c *Cluster) recordIPFSLinks(cg *api.ConnectGraph, pID api.ID) {
 	ipfsID := pID.IPFS.ID
 	if pID.IPFS.Error != "" { // Only setting ipfs connections when no error occurs
 		logger.Warnf("ipfs id: %s has error: %s. Skipping swarm connections", ipfsID.Pretty(), pID.IPFS.Error)

--- a/consensus/crdt/consensus.go
+++ b/consensus/crdt/consensus.go
@@ -50,7 +50,7 @@ var (
 type batchItem struct {
 	ctx   context.Context
 	isPin bool // pin or unpin
-	pin   *api.Pin
+	pin   api.Pin
 }
 
 // Consensus implement ipfscluster.Consensus and provides the facility to add
@@ -208,7 +208,7 @@ func (css *Consensus) setup() {
 		ctx, span := trace.StartSpan(css.ctx, "crdt/PutHook")
 		defer span.End()
 
-		pin := &api.Pin{}
+		pin := api.Pin{}
 		err := pin.ProtoUnmarshal(v)
 		if err != nil {
 			logger.Error(err)
@@ -406,7 +406,7 @@ func (css *Consensus) Distrust(ctx context.Context, pid peer.ID) error {
 }
 
 // LogPin adds a new pin to the shared state.
-func (css *Consensus) LogPin(ctx context.Context, pin *api.Pin) error {
+func (css *Consensus) LogPin(ctx context.Context, pin api.Pin) error {
 	ctx, span := trace.StartSpan(ctx, "consensus/LogPin")
 	defer span.End()
 
@@ -427,7 +427,7 @@ func (css *Consensus) LogPin(ctx context.Context, pin *api.Pin) error {
 }
 
 // LogUnpin removes a pin from the shared state.
-func (css *Consensus) LogUnpin(ctx context.Context, pin *api.Pin) error {
+func (css *Consensus) LogUnpin(ctx context.Context, pin api.Pin) error {
 	ctx, span := trace.StartSpan(ctx, "consensus/LogUnpin")
 	defer span.End()
 
@@ -521,7 +521,7 @@ func (css *Consensus) Peers(ctx context.Context) ([]peer.ID, error) {
 	ctx, span := trace.StartSpan(ctx, "consensus/Peers")
 	defer span.End()
 
-	var metrics []*api.Metric
+	var metrics []api.Metric
 
 	err := css.rpcClient.CallContext(
 		ctx,

--- a/consensus/crdt/consensus_test.go
+++ b/consensus/crdt/consensus_test.go
@@ -87,7 +87,7 @@ func clean(t *testing.T, cc *Consensus) {
 	}
 }
 
-func testPin(c cid.Cid) *api.Pin {
+func testPin(c cid.Cid) api.Pin {
 	p := api.PinCid(c)
 	p.ReplicationFactorMin = -1
 	p.ReplicationFactorMax = -1
@@ -125,10 +125,17 @@ func TestConsensusPin(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
 		t.Error("the added pin should be in the state")
 	}
@@ -164,7 +171,7 @@ func TestConsensusUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Update pin
 	pin.Reference = &test.Cid2
@@ -173,18 +180,25 @@ func TestConsensusUpdate(t *testing.T) {
 		t.Error(err)
 	}
 
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	st, err := cc.State(ctx)
 	if err != nil {
 		t.Fatal("error getting state:", err)
 	}
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
-		t.Error("the added pin should be in the state")
+		t.Fatal("the added pin should be in the state")
 	}
 	if !pins[0].Reference.Equals(test.Cid2) {
 		t.Error("pin updated incorrectly")
@@ -223,16 +237,23 @@ func TestConsensusAddRmPeer(t *testing.T) {
 		t.Error(err)
 	}
 
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	st, err := cc2.State(ctx)
 	if err != nil {
 		t.Fatal("error getting state:", err)
 	}
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
 		t.Error("the added pin should be in the state")
 	}
@@ -289,10 +310,17 @@ func TestConsensusDistrustPeer(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
 		t.Error("only first pin should be in the state")
 	}
@@ -344,10 +372,17 @@ func TestOfflineState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pins, err := offlineState.List(ctx)
+	ch, err := offlineState.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 2 {
 		t.Error("there should be two pins in the state")
 	}
@@ -377,10 +412,17 @@ func TestBatching(t *testing.T) {
 
 	time.Sleep(250 * time.Millisecond)
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 0 {
 		t.Error("pin should not be pinned yet as it is being batched")
 	}
@@ -388,10 +430,17 @@ func TestBatching(t *testing.T) {
 	// Trigger batch auto-commit by time
 	time.Sleep(time.Second)
 
-	pins, err = st.List(ctx)
+	ch, err = st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	pins = nil
+
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
 		t.Error("the added pin should be in the state")
 	}
@@ -407,20 +456,31 @@ func TestBatching(t *testing.T) {
 	// Give a chance for things to persist
 	time.Sleep(250 * time.Millisecond)
 
-	pins, err = st.List(ctx)
+	ch, err = st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	pins = nil
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 4 {
 		t.Error("expected 4 items pinned")
 	}
 
 	// wait for the last pin
 	time.Sleep(time.Second)
-	pins, err = st.List(ctx)
+	ch, err = st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+	pins = nil
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 5 {
 		t.Error("expected 5 items pinned")
 	}

--- a/consensus/raft/consensus.go
+++ b/consensus/raft/consensus.go
@@ -239,7 +239,7 @@ func (cc *Consensus) Trust(ctx context.Context, pid peer.ID) error { return nil 
 // Distrust is a no-op.
 func (cc *Consensus) Distrust(ctx context.Context, pid peer.ID) error { return nil }
 
-func (cc *Consensus) op(ctx context.Context, pin *api.Pin, t LogOpType) *LogOp {
+func (cc *Consensus) op(ctx context.Context, pin api.Pin, t LogOpType) *LogOp {
 	return &LogOp{
 		Cid:  pin,
 		Type: t,
@@ -365,7 +365,7 @@ func (cc *Consensus) commit(ctx context.Context, op *LogOp, rpcOp string, redire
 
 // LogPin submits a Cid to the shared state of the cluster. It will forward
 // the operation to the leader if this is not it.
-func (cc *Consensus) LogPin(ctx context.Context, pin *api.Pin) error {
+func (cc *Consensus) LogPin(ctx context.Context, pin api.Pin) error {
 	ctx, span := trace.StartSpan(ctx, "consensus/LogPin")
 	defer span.End()
 
@@ -378,7 +378,7 @@ func (cc *Consensus) LogPin(ctx context.Context, pin *api.Pin) error {
 }
 
 // LogUnpin removes a Cid from the shared state of the cluster.
-func (cc *Consensus) LogUnpin(ctx context.Context, pin *api.Pin) error {
+func (cc *Consensus) LogUnpin(ctx context.Context, pin api.Pin) error {
 	ctx, span := trace.StartSpan(ctx, "consensus/LogUnpin")
 	defer span.End()
 

--- a/consensus/raft/consensus_test.go
+++ b/consensus/raft/consensus_test.go
@@ -22,7 +22,7 @@ func cleanRaft(idn int) {
 	os.RemoveAll(fmt.Sprintf("raftFolderFromTests-%d", idn))
 }
 
-func testPin(c cid.Cid) *api.Pin {
+func testPin(c cid.Cid) api.Pin {
 	p := api.PinCid(c)
 	p.ReplicationFactorMin = -1
 	p.ReplicationFactorMax = -1
@@ -99,10 +99,16 @@ func TestConsensusPin(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
 		t.Error("the added pin should be in the state")
 	}
@@ -148,10 +154,16 @@ func TestConsensusUpdate(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
 		t.Error("the added pin should be in the state")
 	}
@@ -318,10 +330,16 @@ func TestRaftLatestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal("Snapshot bytes returned could not restore to state: ", err)
 	}
-	pins, err := snapState.List(ctx)
+	ch, err := snapState.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 3 {
 		t.Fatal("Latest snapshot not read")
 	}

--- a/consensus/raft/log_op.go
+++ b/consensus/raft/log_op.go
@@ -28,7 +28,7 @@ type LogOpType int
 type LogOp struct {
 	SpanCtx   trace.SpanContext `codec:"s,omitempty"`
 	TagCtx    []byte            `codec:"t,omitempty"`
-	Cid       *api.Pin          `codec:"c,omitempty"`
+	Cid       api.Pin           `codec:"c,omitempty"`
 	Type      LogOpType         `codec:"p,omitempty"`
 	consensus *Consensus        `codec:"-"`
 	tracing   bool              `codec:"-"`
@@ -56,11 +56,6 @@ func (op *LogOp) ApplyTo(cstate consensus.State) (consensus.State, error) {
 	}
 
 	pin := op.Cid
-	// We are about to pass "pin" it to go-routines that will make things
-	// with it (read its fields). However, as soon as ApplyTo is done, the
-	// next operation will be deserealized on top of "op". We nullify it
-	// to make sure no data races occur.
-	op.Cid = nil
 
 	switch op.Type {
 	case LogOpPin:

--- a/consensus/raft/log_op_test.go
+++ b/consensus/raft/log_op_test.go
@@ -27,10 +27,16 @@ func TestApplyToPin(t *testing.T) {
 	}
 	op.ApplyTo(st)
 
-	pins, err := st.List(ctx)
+	ch, err := st.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var pins []api.Pin
+	for p := range ch {
+		pins = append(pins, p)
+	}
+
 	if len(pins) != 1 || !pins[0].Cid.Equals(test.Cid1) {
 		t.Error("the state was not modified correctly")
 	}

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.3.1
 	github.com/libp2p/go-libp2p-consensus v0.0.1
 	github.com/libp2p/go-libp2p-core v0.13.0
-	github.com/libp2p/go-libp2p-gorpc v0.2.1
+	github.com/libp2p/go-libp2p-gorpc v0.3.0
 	github.com/libp2p/go-libp2p-gostream v0.3.1
 	github.com/libp2p/go-libp2p-http v0.2.1
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.3.1
 	github.com/libp2p/go-libp2p-consensus v0.0.1
 	github.com/libp2p/go-libp2p-core v0.13.0
-	github.com/libp2p/go-libp2p-gorpc v0.1.4
+	github.com/libp2p/go-libp2p-gorpc v0.2.1
 	github.com/libp2p/go-libp2p-gostream v0.3.1
 	github.com/libp2p/go-libp2p-http v0.2.1
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -774,12 +774,8 @@ github.com/libp2p/go-libp2p-discovery v0.5.0/go.mod h1:+srtPIU9gDaBNu//UHvcdliKB
 github.com/libp2p/go-libp2p-discovery v0.6.0 h1:1XdPmhMJr8Tmj/yUfkJMIi8mgwWrLUsCB3bMxdT+DSo=
 github.com/libp2p/go-libp2p-discovery v0.6.0/go.mod h1:/u1voHt0tKIe5oIA1RHBKQLVCWPna2dXmPNHc2zR9S8=
 github.com/libp2p/go-libp2p-gorpc v0.1.0/go.mod h1:DrswTLnu7qjLgbqe4fekX4ISoPiHUqtA45thTsJdE1w=
-github.com/libp2p/go-libp2p-gorpc v0.1.4 h1:ynW5w+zas3G8cmHzpzRXePxQRnj9JIaS7znhB3Xuzek=
-github.com/libp2p/go-libp2p-gorpc v0.1.4/go.mod h1:KUWY/bb0GYV7PyGoqcTtq4vgT3lXJIg3iLLmX1FQUbU=
-github.com/libp2p/go-libp2p-gorpc v0.2.0 h1:Ttt61OedoiFe/SsspHl2AyAkf8ED3WWRN7Y5wlHj/iE=
-github.com/libp2p/go-libp2p-gorpc v0.2.0/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
-github.com/libp2p/go-libp2p-gorpc v0.2.1 h1:Grd75tnI6pEdW1H2oZR2p+e+h4XPWgdKQRXV+mJHYlM=
-github.com/libp2p/go-libp2p-gorpc v0.2.1/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
+github.com/libp2p/go-libp2p-gorpc v0.3.0 h1:1ww39zPEclHh8p1Exk882Xhy3CK2gW+JZYd+6NZp+q0=
+github.com/libp2p/go-libp2p-gorpc v0.3.0/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
 github.com/libp2p/go-libp2p-gostream v0.3.0/go.mod h1:pLBQu8db7vBMNINGsAwLL/ZCE8wng5V1FThoaE5rNjc=
 github.com/libp2p/go-libp2p-gostream v0.3.1 h1:XlwohsPn6uopGluEWs1Csv1QCEjrTXf2ZQagzZ5paAg=
 github.com/libp2p/go-libp2p-gostream v0.3.1/go.mod h1:1V3b+u4Zhaq407UUY9JLCpboaeufAeVQbnvAt12LRsI=

--- a/go.sum
+++ b/go.sum
@@ -776,6 +776,10 @@ github.com/libp2p/go-libp2p-discovery v0.6.0/go.mod h1:/u1voHt0tKIe5oIA1RHBKQLVC
 github.com/libp2p/go-libp2p-gorpc v0.1.0/go.mod h1:DrswTLnu7qjLgbqe4fekX4ISoPiHUqtA45thTsJdE1w=
 github.com/libp2p/go-libp2p-gorpc v0.1.4 h1:ynW5w+zas3G8cmHzpzRXePxQRnj9JIaS7znhB3Xuzek=
 github.com/libp2p/go-libp2p-gorpc v0.1.4/go.mod h1:KUWY/bb0GYV7PyGoqcTtq4vgT3lXJIg3iLLmX1FQUbU=
+github.com/libp2p/go-libp2p-gorpc v0.2.0 h1:Ttt61OedoiFe/SsspHl2AyAkf8ED3WWRN7Y5wlHj/iE=
+github.com/libp2p/go-libp2p-gorpc v0.2.0/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
+github.com/libp2p/go-libp2p-gorpc v0.2.1 h1:Grd75tnI6pEdW1H2oZR2p+e+h4XPWgdKQRXV+mJHYlM=
+github.com/libp2p/go-libp2p-gorpc v0.2.1/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
 github.com/libp2p/go-libp2p-gostream v0.3.0/go.mod h1:pLBQu8db7vBMNINGsAwLL/ZCE8wng5V1FThoaE5rNjc=
 github.com/libp2p/go-libp2p-gostream v0.3.1 h1:XlwohsPn6uopGluEWs1Csv1QCEjrTXf2ZQagzZ5paAg=
 github.com/libp2p/go-libp2p-gostream v0.3.1/go.mod h1:1V3b+u4Zhaq407UUY9JLCpboaeufAeVQbnvAt12LRsI=

--- a/informer/disk/disk.go
+++ b/informer/disk/disk.go
@@ -87,7 +87,7 @@ func (disk *Informer) Shutdown(ctx context.Context) error {
 
 // GetMetrics returns the metric obtained by this Informer. It must always
 // return at least one metric.
-func (disk *Informer) GetMetrics(ctx context.Context) []*api.Metric {
+func (disk *Informer) GetMetrics(ctx context.Context) []api.Metric {
 	ctx, span := trace.StartSpan(ctx, "informer/disk/GetMetric")
 	defer span.End()
 
@@ -96,10 +96,12 @@ func (disk *Informer) GetMetrics(ctx context.Context) []*api.Metric {
 	disk.mu.Unlock()
 
 	if rpcClient == nil {
-		return []*api.Metric{&api.Metric{
-			Name:  disk.Name(),
-			Valid: false,
-		}}
+		return []api.Metric{
+			{
+				Name:  disk.Name(),
+				Valid: false,
+			},
+		}
 	}
 
 	var repoStat api.IPFSRepoStat
@@ -133,7 +135,7 @@ func (disk *Informer) GetMetrics(ctx context.Context) []*api.Metric {
 		}
 	}
 
-	m := &api.Metric{
+	m := api.Metric{
 		Name:          disk.Name(),
 		Value:         fmt.Sprintf("%d", metric),
 		Valid:         valid,
@@ -142,5 +144,5 @@ func (disk *Informer) GetMetrics(ctx context.Context) []*api.Metric {
 	}
 
 	m.SetTTL(disk.config.MetricTTL)
-	return []*api.Metric{m}
+	return []api.Metric{m}
 }

--- a/informer/disk/disk_test.go
+++ b/informer/disk/disk_test.go
@@ -29,7 +29,7 @@ func (mock *badRPCService) RepoStat(ctx context.Context, in struct{}, out *api.I
 }
 
 // Returns the first metric
-func getMetrics(t *testing.T, inf *Informer) *api.Metric {
+func getMetrics(t *testing.T, inf *Informer) api.Metric {
 	t.Helper()
 	metrics := inf.GetMetrics(context.Background())
 	if len(metrics) != 1 {

--- a/informer/numpin/numpin.go
+++ b/informer/numpin/numpin.go
@@ -59,14 +59,16 @@ func (npi *Informer) Name() string {
 // GetMetrics contacts the IPFSConnector component and requests the `pin ls`
 // command. We return the number of pins in IPFS. It must always return at
 // least one metric.
-func (npi *Informer) GetMetrics(ctx context.Context) []*api.Metric {
+func (npi *Informer) GetMetrics(ctx context.Context) []api.Metric {
 	ctx, span := trace.StartSpan(ctx, "informer/numpin/GetMetric")
 	defer span.End()
 
 	if npi.rpcClient == nil {
-		return []*api.Metric{&api.Metric{
-			Valid: false,
-		}}
+		return []api.Metric{
+			{
+				Valid: false,
+			},
+		}
 	}
 
 	pinMap := make(map[string]api.IPFSPinStatus)
@@ -84,7 +86,7 @@ func (npi *Informer) GetMetrics(ctx context.Context) []*api.Metric {
 
 	valid := err == nil
 
-	m := &api.Metric{
+	m := api.Metric{
 		Name:          MetricName,
 		Value:         fmt.Sprintf("%d", len(pinMap)),
 		Valid:         valid,
@@ -92,5 +94,5 @@ func (npi *Informer) GetMetrics(ctx context.Context) []*api.Metric {
 	}
 
 	m.SetTTL(npi.config.MetricTTL)
-	return []*api.Metric{m}
+	return []api.Metric{m}
 }

--- a/informer/tags/tags.go
+++ b/informer/tags/tags.go
@@ -65,26 +65,26 @@ func (tags *Informer) Shutdown(ctx context.Context) error {
 // GetMetrics returns one metric for each tag defined in the configuration.
 // The metric name is set as "tags:<tag_name>". When no tags are defined,
 // a single invalid metric is returned.
-func (tags *Informer) GetMetrics(ctx context.Context) []*api.Metric {
+func (tags *Informer) GetMetrics(ctx context.Context) []api.Metric {
 	// Note we could potentially extend the tag:value syntax to include manual weights
 	// ie: { "region": "us:100", ... }
 	// This would potentially allow to always give priority to peers of a certain group
 
 	if len(tags.config.Tags) == 0 {
 		logger.Debug("no tags defined in tags informer")
-		m := &api.Metric{
+		m := api.Metric{
 			Name:          "tag:none",
 			Value:         "",
 			Valid:         false,
 			Partitionable: true,
 		}
 		m.SetTTL(tags.config.MetricTTL)
-		return []*api.Metric{m}
+		return []api.Metric{m}
 	}
 
-	metrics := make([]*api.Metric, 0, len(tags.config.Tags))
+	metrics := make([]api.Metric, 0, len(tags.config.Tags))
 	for n, v := range tags.config.Tags {
-		m := &api.Metric{
+		m := api.Metric{
 			Name:          "tag:" + n,
 			Value:         v,
 			Valid:         true,

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -37,9 +37,9 @@ type Consensus interface {
 	// allowing the main component to wait for it during start.
 	Ready(context.Context) <-chan struct{}
 	// Logs a pin operation.
-	LogPin(context.Context, *api.Pin) error
+	LogPin(context.Context, api.Pin) error
 	// Logs an unpin operation.
-	LogUnpin(context.Context, *api.Pin) error
+	LogUnpin(context.Context, api.Pin) error
 	AddPeer(context.Context, peer.ID) error
 	RmPeer(context.Context, peer.ID) error
 	State(context.Context) (state.ReadOnly, error)
@@ -74,10 +74,10 @@ type API interface {
 // an IPFS daemon. This is a base component.
 type IPFSConnector interface {
 	Component
-	ID(context.Context) (*api.IPFSID, error)
-	Pin(context.Context, *api.Pin) error
+	ID(context.Context) (api.IPFSID, error)
+	Pin(context.Context, api.Pin) error
 	Unpin(context.Context, cid.Cid) error
-	PinLsCid(context.Context, *api.Pin) (api.IPFSPinStatus, error)
+	PinLsCid(context.Context, api.Pin) (api.IPFSPinStatus, error)
 	PinLs(ctx context.Context, typeFilter string) (map[string]api.IPFSPinStatus, error)
 	// ConnectSwarms make sure this peer's IPFS daemon is connected to
 	// other peers IPFS daemons.
@@ -89,13 +89,13 @@ type IPFSConnector interface {
 	ConfigKey(keypath string) (interface{}, error)
 	// RepoStat returns the current repository size and max limit as
 	// provided by "repo stat".
-	RepoStat(context.Context) (*api.IPFSRepoStat, error)
+	RepoStat(context.Context) (api.IPFSRepoStat, error)
 	// RepoGC performs garbage collection sweep on the IPFS repo.
-	RepoGC(context.Context) (*api.RepoGC, error)
+	RepoGC(context.Context) (api.RepoGC, error)
 	// Resolve returns a cid given a path.
 	Resolve(context.Context, string) (cid.Cid, error)
 	// BlockPut directly adds a block of data to the IPFS repo.
-	BlockPut(context.Context, *api.NodeWithMeta) error
+	BlockPut(context.Context, api.NodeWithMeta) error
 	// BlockGet retrieves the raw data of an IPFS block.
 	BlockGet(context.Context, cid.Cid) ([]byte, error)
 }
@@ -115,20 +115,20 @@ type PinTracker interface {
 	Component
 	// Track tells the tracker that a Cid is now under its supervision
 	// The tracker may decide to perform an IPFS pin.
-	Track(context.Context, *api.Pin) error
+	Track(context.Context, api.Pin) error
 	// Untrack tells the tracker that a Cid is to be forgotten. The tracker
 	// may perform an IPFS unpin operation.
 	Untrack(context.Context, cid.Cid) error
 	// StatusAll returns the list of pins with their local status. Takes a
 	// filter to specify which statuses to report.
-	StatusAll(context.Context, api.TrackerStatus) []*api.PinInfo
+	StatusAll(context.Context, api.TrackerStatus) []api.PinInfo
 	// Status returns the local status of a given Cid.
-	Status(context.Context, cid.Cid) *api.PinInfo
+	Status(context.Context, cid.Cid) api.PinInfo
 	// RecoverAll calls Recover() for all pins tracked. Returns only
 	// informations for retriggered pins.
-	RecoverAll(context.Context) ([]*api.PinInfo, error)
+	RecoverAll(context.Context) ([]api.PinInfo, error)
 	// Recover retriggers a Pin/Unpin operation in a Cids with error status.
-	Recover(context.Context, cid.Cid) (*api.PinInfo, error)
+	Recover(context.Context, cid.Cid) (api.PinInfo, error)
 }
 
 // Informer provides Metric information from a peer. The metrics produced by
@@ -140,7 +140,7 @@ type Informer interface {
 	Name() string
 	// GetMetrics returns the metrics obtained by this Informer.  It must
 	// always return at least one metric.
-	GetMetrics(context.Context) []*api.Metric
+	GetMetrics(context.Context) []api.Metric
 }
 
 // PinAllocator decides where to pin certain content. In order to make such
@@ -171,22 +171,22 @@ type PeerMonitor interface {
 	Component
 	// LogMetric stores a metric. It can be used to manually inject
 	// a metric to a monitor.
-	LogMetric(context.Context, *api.Metric) error
+	LogMetric(context.Context, api.Metric) error
 	// PublishMetric sends a metric to the rest of the peers.
 	// How to send it, and to who, is to be decided by the implementation.
-	PublishMetric(context.Context, *api.Metric) error
+	PublishMetric(context.Context, api.Metric) error
 	// LatestMetrics returns a map with the latest valid metrics of matching
 	// name for the current cluster peers. The result should only contain
 	// one metric per peer at most.
-	LatestMetrics(ctx context.Context, name string) []*api.Metric
+	LatestMetrics(ctx context.Context, name string) []api.Metric
 	// Returns the latest metric received from a peer. It may be expired.
-	LatestForPeer(ctx context.Context, name string, pid peer.ID) *api.Metric
+	LatestForPeer(ctx context.Context, name string, pid peer.ID) api.Metric
 	// MetricNames returns a list of metric names.
 	MetricNames(ctx context.Context) []string
 	// Alerts delivers alerts generated when this peer monitor detects
 	// a problem (i.e. metrics not arriving as expected). Alerts can be used
 	// to trigger self-healing measures or re-pinnings of content.
-	Alerts() <-chan *api.Alert
+	Alerts() <-chan api.Alert
 }
 
 // Tracer implements Component as a way

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -570,8 +570,8 @@ func TestClustersPeers(t *testing.T) {
 		t.Fatal("expected as many peers as clusters")
 	}
 
-	clusterIDMap := make(map[peer.ID]*api.ID)
-	peerIDMap := make(map[peer.ID]*api.ID)
+	clusterIDMap := make(map[peer.ID]api.ID)
+	peerIDMap := make(map[peer.ID]api.ID)
 
 	for _, c := range clusters {
 		id := c.ID(ctx)

--- a/ipfsconn/ipfshttp/ipfshttp_test.go
+++ b/ipfsconn/ipfshttp/ipfshttp_test.go
@@ -17,6 +17,7 @@ import (
 
 func init() {
 	_ = logging.Logger
+	//logging.SetLogLevel("*", "DEBUG")
 }
 
 func testIPFSConnector(t *testing.T) (*Connector, *test.IpfsMock) {
@@ -295,7 +296,7 @@ func TestBlockPut(t *testing.T) {
 	defer ipfs.Shutdown(ctx)
 
 	// CidV1
-	err := ipfs.BlockPut(ctx, &api.NodeWithMeta{
+	err := ipfs.BlockPut(ctx, api.NodeWithMeta{
 		Data: []byte(test.Cid4Data),
 		Cid:  test.Cid4,
 	})
@@ -304,7 +305,7 @@ func TestBlockPut(t *testing.T) {
 	}
 
 	// CidV0
-	err = ipfs.BlockPut(ctx, &api.NodeWithMeta{
+	err = ipfs.BlockPut(ctx, api.NodeWithMeta{
 		Data: []byte(test.Cid5Data),
 		Cid:  test.Cid5,
 	})
@@ -327,7 +328,7 @@ func TestBlockGet(t *testing.T) {
 	}
 
 	// Put and then successfully get
-	err = ipfs.BlockPut(ctx, &api.NodeWithMeta{
+	err = ipfs.BlockPut(ctx, api.NodeWithMeta{
 		Data: test.ShardData,
 		Cid:  test.ShardCid,
 	})

--- a/monitor/metrics/checker_test.go
+++ b/monitor/metrics/checker_test.go
@@ -16,7 +16,7 @@ func TestChecker_CheckPeers(t *testing.T) {
 		metrics := NewStore()
 		checker := NewChecker(context.Background(), metrics)
 
-		metr := &api.Metric{
+		metr := api.Metric{
 			Name:  "ping",
 			Peer:  test.PeerID1,
 			Value: "1",
@@ -59,7 +59,7 @@ func TestChecker_CheckAll(t *testing.T) {
 		metrics := NewStore()
 		checker := NewChecker(context.Background(), metrics)
 
-		metr := &api.Metric{
+		metr := api.Metric{
 			Name:  "ping",
 			Peer:  test.PeerID1,
 			Value: "1",
@@ -104,7 +104,7 @@ func TestChecker_Watch(t *testing.T) {
 	metrics := NewStore()
 	checker := NewChecker(context.Background(), metrics)
 
-	metr := &api.Metric{
+	metr := api.Metric{
 		Name:  "ping",
 		Peer:  test.PeerID1,
 		Value: "1",
@@ -154,7 +154,7 @@ func TestChecker_alert(t *testing.T) {
 		metrics := NewStore()
 		checker := NewChecker(ctx, metrics)
 
-		metr := &api.Metric{
+		metr := api.Metric{
 			Name:  "ping",
 			Peer:  test.PeerID1,
 			Value: "1",
@@ -188,8 +188,8 @@ func TestChecker_alert(t *testing.T) {
 	})
 }
 
-func makePeerMetric(pid peer.ID, value string, ttl time.Duration) *api.Metric {
-	metr := &api.Metric{
+func makePeerMetric(pid peer.ID, value string, ttl time.Duration) api.Metric {
+	metr := api.Metric{
 		Name:  "ping",
 		Peer:  pid,
 		Value: value,

--- a/monitor/metrics/store.go
+++ b/monitor/metrics/store.go
@@ -26,7 +26,7 @@ func NewStore() *Store {
 }
 
 // Add inserts a new metric in Metrics.
-func (mtrs *Store) Add(m *api.Metric) {
+func (mtrs *Store) Add(m api.Metric) {
 	mtrs.mux.Lock()
 	defer mtrs.mux.Unlock()
 
@@ -67,16 +67,16 @@ func (mtrs *Store) RemovePeerMetrics(pid peer.ID, name string) {
 
 // LatestValid returns all the last known valid metrics of a given type. A metric
 // is valid if it has not expired.
-func (mtrs *Store) LatestValid(name string) []*api.Metric {
+func (mtrs *Store) LatestValid(name string) []api.Metric {
 	mtrs.mux.RLock()
 	defer mtrs.mux.RUnlock()
 
 	byPeer, ok := mtrs.byName[name]
 	if !ok {
-		return []*api.Metric{}
+		return []api.Metric{}
 	}
 
-	metrics := make([]*api.Metric, 0, len(byPeer))
+	metrics := make([]api.Metric, 0, len(byPeer))
 	for _, window := range byPeer {
 		m, err := window.Latest()
 		// TODO(ajl): for accrual, does it matter if a ping has expired?
@@ -93,11 +93,11 @@ func (mtrs *Store) LatestValid(name string) []*api.Metric {
 
 // AllMetrics returns the latest metrics for all peers and metrics types.  It
 // may return expired metrics.
-func (mtrs *Store) AllMetrics() []*api.Metric {
+func (mtrs *Store) AllMetrics() []api.Metric {
 	mtrs.mux.RLock()
 	defer mtrs.mux.RUnlock()
 
-	result := make([]*api.Metric, 0)
+	result := make([]api.Metric, 0)
 
 	for _, byPeer := range mtrs.byName {
 		for _, window := range byPeer {
@@ -113,11 +113,11 @@ func (mtrs *Store) AllMetrics() []*api.Metric {
 
 // PeerMetrics returns the latest metrics for a given peer ID for
 // all known metrics types. It may return expired metrics.
-func (mtrs *Store) PeerMetrics(pid peer.ID) []*api.Metric {
+func (mtrs *Store) PeerMetrics(pid peer.ID) []api.Metric {
 	mtrs.mux.RLock()
 	defer mtrs.mux.RUnlock()
 
-	result := make([]*api.Metric, 0)
+	result := make([]api.Metric, 0)
 
 	for _, byPeer := range mtrs.byName {
 		window, ok := byPeer[pid]
@@ -135,7 +135,7 @@ func (mtrs *Store) PeerMetrics(pid peer.ID) []*api.Metric {
 
 // PeerMetricAll returns all of a particular metrics for a
 // particular peer.
-func (mtrs *Store) PeerMetricAll(name string, pid peer.ID) []*api.Metric {
+func (mtrs *Store) PeerMetricAll(name string, pid peer.ID) []api.Metric {
 	mtrs.mux.RLock()
 	defer mtrs.mux.RUnlock()
 
@@ -154,23 +154,23 @@ func (mtrs *Store) PeerMetricAll(name string, pid peer.ID) []*api.Metric {
 
 // PeerLatest returns the latest of a particular metric for a
 // particular peer. It may return an expired metric.
-func (mtrs *Store) PeerLatest(name string, pid peer.ID) *api.Metric {
+func (mtrs *Store) PeerLatest(name string, pid peer.ID) api.Metric {
 	mtrs.mux.RLock()
 	defer mtrs.mux.RUnlock()
 
 	byPeer, ok := mtrs.byName[name]
 	if !ok {
-		return nil
+		return api.Metric{}
 	}
 
 	window, ok := byPeer[pid]
 	if !ok {
-		return nil
+		return api.Metric{}
 	}
 	m, err := window.Latest()
 	if err != nil {
 		// ignoring error, as nil metric is indicative enough
-		return nil
+		return api.Metric{}
 	}
 	return m
 }

--- a/monitor/metrics/store_test.go
+++ b/monitor/metrics/store_test.go
@@ -11,7 +11,7 @@ import (
 func TestStoreLatest(t *testing.T) {
 	store := NewStore()
 
-	metr := &api.Metric{
+	metr := api.Metric{
 		Name:  "test",
 		Peer:  test.PeerID1,
 		Value: "1",
@@ -36,7 +36,7 @@ func TestStoreLatest(t *testing.T) {
 func TestRemovePeer(t *testing.T) {
 	store := NewStore()
 
-	metr := &api.Metric{
+	metr := api.Metric{
 		Name:  "test",
 		Peer:  test.PeerID1,
 		Value: "1",

--- a/monitor/metrics/util.go
+++ b/monitor/metrics/util.go
@@ -8,13 +8,13 @@ import (
 
 // PeersetFilter removes all metrics not belonging to the given
 // peerset
-func PeersetFilter(metrics []*api.Metric, peerset []peer.ID) []*api.Metric {
+func PeersetFilter(metrics []api.Metric, peerset []peer.ID) []api.Metric {
 	peerMap := make(map[peer.ID]struct{})
 	for _, pid := range peerset {
 		peerMap[pid] = struct{}{}
 	}
 
-	filtered := make([]*api.Metric, 0, len(metrics))
+	filtered := make([]api.Metric, 0, len(metrics))
 
 	for _, metric := range metrics {
 		_, ok := peerMap[metric.Peer]

--- a/monitor/metrics/window_test.go
+++ b/monitor/metrics/window_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ipfs/ipfs-cluster/api"
 )
 
-func makeMetric(value string) *api.Metric {
-	metr := &api.Metric{
+func makeMetric(value string) api.Metric {
+	metr := api.Metric{
 		Name:  "test",
 		Peer:  "peer1",
 		Value: value,
@@ -105,11 +105,15 @@ func TestWindow_Add(t *testing.T) {
 
 		mw.wMu.RLock()
 		prevRing := mw.window.Prev()
-		got, ok := prevRing.Value.(*api.Metric)
+		got, ok := prevRing.Value.(api.Metric)
 		mw.wMu.RUnlock()
 		if !ok {
-			t.Error("value in window isn't an *api.Metric")
+			t.Error("value in window isn't an api.Metric")
 		}
+
+		// We need to do this for metrics to be equal since ReceivedAt
+		// is added by the window.
+		want.ReceivedAt = got.ReceivedAt
 
 		if got != want {
 			t.Errorf("got = %v, want = %v", got, want)

--- a/monitor/pubsubmon/pubsubmon.go
+++ b/monitor/pubsubmon/pubsubmon.go
@@ -158,9 +158,9 @@ func (mon *Monitor) logFromPubsub() {
 				}
 			}
 
-			debug("recieved", &metric)
+			debug("recieved", metric)
 
-			err = mon.LogMetric(ctx, &metric)
+			err = mon.LogMetric(ctx, metric)
 			if err != nil {
 				logger.Error(err)
 				continue
@@ -200,7 +200,7 @@ func (mon *Monitor) Shutdown(ctx context.Context) error {
 }
 
 // LogMetric stores a metric so it can later be retrieved.
-func (mon *Monitor) LogMetric(ctx context.Context, m *api.Metric) error {
+func (mon *Monitor) LogMetric(ctx context.Context, m api.Metric) error {
 	_, span := trace.StartSpan(ctx, "monitor/pubsub/LogMetric")
 	defer span.End()
 
@@ -213,7 +213,7 @@ func (mon *Monitor) LogMetric(ctx context.Context, m *api.Metric) error {
 }
 
 // PublishMetric broadcasts a metric to all current cluster peers.
-func (mon *Monitor) PublishMetric(ctx context.Context, m *api.Metric) error {
+func (mon *Monitor) PublishMetric(ctx context.Context, m api.Metric) error {
 	ctx, span := trace.StartSpan(ctx, "monitor/pubsub/PublishMetric")
 	defer span.End()
 
@@ -244,7 +244,7 @@ func (mon *Monitor) PublishMetric(ctx context.Context, m *api.Metric) error {
 
 // LatestMetrics returns last known VALID metrics of a given type. A metric
 // is only valid if it has not expired and belongs to a current cluster peer.
-func (mon *Monitor) LatestMetrics(ctx context.Context, name string) []*api.Metric {
+func (mon *Monitor) LatestMetrics(ctx context.Context, name string) []api.Metric {
 	ctx, span := trace.StartSpan(ctx, "monitor/pubsub/LatestMetrics")
 	defer span.End()
 
@@ -258,7 +258,7 @@ func (mon *Monitor) LatestMetrics(ctx context.Context, name string) []*api.Metri
 	// a peerset provider.
 	peers, err := mon.peers(ctx)
 	if err != nil {
-		return []*api.Metric{}
+		return []api.Metric{}
 	}
 
 	return metrics.PeersetFilter(latest, peers)
@@ -266,13 +266,13 @@ func (mon *Monitor) LatestMetrics(ctx context.Context, name string) []*api.Metri
 
 // LatestForPeer returns the latest metric received for a peer (it may have
 // expired). It returns nil if no metric exists.
-func (mon *Monitor) LatestForPeer(ctx context.Context, name string, pid peer.ID) *api.Metric {
+func (mon *Monitor) LatestForPeer(ctx context.Context, name string, pid peer.ID) api.Metric {
 	return mon.metrics.PeerLatest(name, pid)
 }
 
 // Alerts returns a channel on which alerts are sent when the
 // monitor detects a failure.
-func (mon *Monitor) Alerts() <-chan *api.Alert {
+func (mon *Monitor) Alerts() <-chan api.Alert {
 	return mon.checker.Alerts()
 }
 
@@ -284,7 +284,7 @@ func (mon *Monitor) MetricNames(ctx context.Context) []string {
 	return mon.metrics.MetricNames()
 }
 
-func debug(event string, m *api.Metric) {
+func debug(event string, m api.Metric) {
 	logger.Debugf(
 		"%s metric: '%s' - '%s' - '%s' - '%s'",
 		event,

--- a/monitor/pubsubmon/pubsubmon_test.go
+++ b/monitor/pubsubmon/pubsubmon_test.go
@@ -35,10 +35,10 @@ func newMetricFactory() *metricFactory {
 	}
 }
 
-func (mf *metricFactory) newMetric(n string, p peer.ID) *api.Metric {
+func (mf *metricFactory) newMetric(n string, p peer.ID) api.Metric {
 	mf.l.Lock()
 	defer mf.l.Unlock()
-	m := &api.Metric{
+	m := api.Metric{
 		Name:  n,
 		Peer:  p,
 		Value: fmt.Sprintf("%d", mf.counter),
@@ -125,7 +125,7 @@ func TestLogMetricConcurrent(t *testing.T) {
 	f := func() {
 		defer wg.Done()
 		for i := 0; i < 25; i++ {
-			mt := &api.Metric{
+			mt := api.Metric{
 				Name:  "test",
 				Peer:  test.PeerID1,
 				Value: fmt.Sprintf("%d", time.Now().UnixNano()),

--- a/pintracker/optracker/operation.go
+++ b/pintracker/optracker/operation.go
@@ -58,7 +58,7 @@ type Operation struct {
 
 	// RO fields
 	opType OperationType
-	pin    *api.Pin
+	pin    api.Pin
 
 	// RW fields
 	mu           sync.RWMutex
@@ -70,7 +70,7 @@ type Operation struct {
 }
 
 // NewOperation creates a new Operation.
-func NewOperation(ctx context.Context, pin *api.Pin, typ OperationType, ph Phase) *Operation {
+func NewOperation(ctx context.Context, pin api.Pin, typ OperationType, ph Phase) *Operation {
 	ctx, span := trace.StartSpan(ctx, "optracker/NewOperation")
 	defer span.End()
 
@@ -212,7 +212,7 @@ func (op *Operation) Type() OperationType {
 }
 
 // Pin returns the Pin object associated to the operation.
-func (op *Operation) Pin() *api.Pin {
+func (op *Operation) Pin() api.Pin {
 	return op.pin
 }
 

--- a/pintracker/optracker/operationtracker.go
+++ b/pintracker/optracker/operationtracker.go
@@ -66,7 +66,7 @@ func NewOperationTracker(ctx context.Context, pid peer.ID, peerName string) *Ope
 //
 // If an operation exists it is of different type, it is
 // cancelled and the new one replaces it in the tracker.
-func (opt *OperationTracker) TrackNewOperation(ctx context.Context, pin *api.Pin, typ OperationType, ph Phase) *Operation {
+func (opt *OperationTracker) TrackNewOperation(ctx context.Context, pin api.Pin, typ OperationType, ph Phase) *Operation {
 	ctx = trace.NewContext(opt.ctx, trace.FromContext(ctx))
 	ctx, span := trace.StartSpan(ctx, "optracker/TrackNewOperation")
 	defer span.End()
@@ -174,7 +174,7 @@ func (opt *OperationTracker) unsafePinInfo(ctx context.Context, op *Operation) a
 }
 
 // Get returns a PinInfo object for Cid.
-func (opt *OperationTracker) Get(ctx context.Context, c cid.Cid) *api.PinInfo {
+func (opt *OperationTracker) Get(ctx context.Context, c cid.Cid) api.PinInfo {
 	ctx, span := trace.StartSpan(ctx, "optracker/GetAll")
 	defer span.End()
 
@@ -185,12 +185,12 @@ func (opt *OperationTracker) Get(ctx context.Context, c cid.Cid) *api.PinInfo {
 	if pInfo.Cid == cid.Undef {
 		pInfo.Cid = c
 	}
-	return &pInfo
+	return pInfo
 }
 
 // GetExists returns a PinInfo object for a Cid only if there exists
 // an associated Operation.
-func (opt *OperationTracker) GetExists(ctx context.Context, c cid.Cid) (*api.PinInfo, bool) {
+func (opt *OperationTracker) GetExists(ctx context.Context, c cid.Cid) (api.PinInfo, bool) {
 	ctx, span := trace.StartSpan(ctx, "optracker/GetExists")
 	defer span.End()
 
@@ -198,23 +198,23 @@ func (opt *OperationTracker) GetExists(ctx context.Context, c cid.Cid) (*api.Pin
 	defer opt.mu.RUnlock()
 	op, ok := opt.operations[c]
 	if !ok {
-		return nil, false
+		return api.PinInfo{}, false
 	}
 	pInfo := opt.unsafePinInfo(ctx, op)
-	return &pInfo, true
+	return pInfo, true
 }
 
 // GetAll returns PinInfo objects for all known operations.
-func (opt *OperationTracker) GetAll(ctx context.Context) []*api.PinInfo {
+func (opt *OperationTracker) GetAll(ctx context.Context) []api.PinInfo {
 	ctx, span := trace.StartSpan(ctx, "optracker/GetAll")
 	defer span.End()
 
-	var pinfos []*api.PinInfo
+	var pinfos []api.PinInfo
 	opt.mu.RLock()
 	defer opt.mu.RUnlock()
 	for _, op := range opt.operations {
 		pinfo := opt.unsafePinInfo(ctx, op)
-		pinfos = append(pinfos, &pinfo)
+		pinfos = append(pinfos, pinfo)
 	}
 	return pinfos
 }
@@ -245,14 +245,14 @@ func (opt *OperationTracker) OpContext(ctx context.Context, c cid.Cid) context.C
 // Operations that matched the provided filter. Note, only supports
 // filters of type OperationType or Phase, any other type
 // will result in a nil slice being returned.
-func (opt *OperationTracker) Filter(ctx context.Context, filters ...interface{}) []*api.PinInfo {
-	var pinfos []*api.PinInfo
+func (opt *OperationTracker) Filter(ctx context.Context, filters ...interface{}) []api.PinInfo {
+	var pinfos []api.PinInfo
 	opt.mu.RLock()
 	defer opt.mu.RUnlock()
 	ops := filterOpsMap(ctx, opt.operations, filters)
 	for _, op := range ops {
 		pinfo := opt.unsafePinInfo(ctx, op)
-		pinfos = append(pinfos, &pinfo)
+		pinfos = append(pinfos, pinfo)
 	}
 	return pinfos
 }

--- a/pintracker/pintracker_test.go
+++ b/pintracker/pintracker_test.go
@@ -30,7 +30,7 @@ var (
 	}
 )
 
-var sortPinInfoByCid = func(p []*api.PinInfo) {
+var sortPinInfoByCid = func(p []api.PinInfo) {
 	sort.Slice(p, func(i, j int) bool {
 		return p[i].Cid.String() < p[j].Cid.String()
 	})
@@ -53,7 +53,7 @@ func prefilledState(context.Context) (state.ReadOnly, error) {
 	})
 	remote.Allocations = []peer.ID{test.PeerID2}
 
-	pins := []*api.Pin{
+	pins := []api.Pin{
 		api.PinWithOpts(test.Cid1, pinOpts),
 		api.PinCid(test.Cid2),
 		remote,
@@ -82,7 +82,7 @@ func testStatelessPinTracker(t testing.TB) *stateless.Tracker {
 
 func TestPinTracker_Track(t *testing.T) {
 	type args struct {
-		c       *api.Pin
+		c       api.Pin
 		tracker ipfscluster.PinTracker
 	}
 	tests := []struct {
@@ -110,7 +110,7 @@ func TestPinTracker_Track(t *testing.T) {
 
 func BenchmarkPinTracker_Track(b *testing.B) {
 	type args struct {
-		c       *api.Pin
+		c       api.Pin
 		tracker ipfscluster.PinTracker
 	}
 	tests := []struct {
@@ -167,13 +167,13 @@ func TestPinTracker_Untrack(t *testing.T) {
 
 func TestPinTracker_StatusAll(t *testing.T) {
 	type args struct {
-		c       *api.Pin
+		c       api.Pin
 		tracker ipfscluster.PinTracker
 	}
 	tests := []struct {
 		name string
 		args args
-		want []*api.PinInfo
+		want []api.PinInfo
 	}{
 		{
 			"basic stateless statusall",
@@ -181,7 +181,7 @@ func TestPinTracker_StatusAll(t *testing.T) {
 				api.PinWithOpts(test.Cid1, pinOpts),
 				testStatelessPinTracker(t),
 			},
-			[]*api.PinInfo{
+			[]api.PinInfo{
 				{
 					Cid: test.Cid1,
 					PinInfoShort: api.PinInfoShort{
@@ -324,7 +324,7 @@ func TestPinTracker_RecoverAll(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []*api.PinInfo
+		want    []api.PinInfo
 		wantErr bool
 	}{
 		{
@@ -333,7 +333,7 @@ func TestPinTracker_RecoverAll(t *testing.T) {
 				testStatelessPinTracker(t),
 			},
 			// The only CID to recover is test.Cid4 which is in error.
-			[]*api.PinInfo{
+			[]api.PinInfo{
 				{
 					// This will recover and status
 					// is ignored as it could come back as

--- a/pintracker/stateless/stateless.go
+++ b/pintracker/stateless/stateless.go
@@ -457,6 +457,7 @@ func (spt *Tracker) RecoverAll(ctx context.Context) ([]api.PinInfo, error) {
 	ctx, span := trace.StartSpan(ctx, "tracker/stateless/RecoverAll")
 	defer span.End()
 
+	// FIXME: make sure this returns a channel.
 	statuses := spt.StatusAll(ctx, api.TrackerStatusUndefined)
 	resp := make([]api.PinInfo, 0)
 	for _, st := range statuses {

--- a/pintracker/stateless/stateless_test.go
+++ b/pintracker/stateless/stateless_test.go
@@ -39,7 +39,7 @@ var (
 // special errors when unwanted operations have been triggered.
 type mockIPFS struct{}
 
-func (mock *mockIPFS) Pin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (mock *mockIPFS) Pin(ctx context.Context, in api.Pin, out *struct{}) error {
 	switch in.Cid {
 	case pinCancelCid:
 		return errPinCancelCid
@@ -51,7 +51,7 @@ func (mock *mockIPFS) Pin(ctx context.Context, in *api.Pin, out *struct{}) error
 	return nil
 }
 
-func (mock *mockIPFS) Unpin(ctx context.Context, in *api.Pin, out *struct{}) error {
+func (mock *mockIPFS) Unpin(ctx context.Context, in api.Pin, out *struct{}) error {
 	switch in.Cid {
 	case unpinCancelCid:
 		return errUnpinCancelCid
@@ -74,7 +74,7 @@ func (mock *mockIPFS) PinLs(ctx context.Context, in string, out *map[string]api.
 	return nil
 }
 
-func (mock *mockIPFS) PinLsCid(ctx context.Context, in *api.Pin, out *api.IPFSPinStatus) error {
+func (mock *mockIPFS) PinLsCid(ctx context.Context, in api.Pin, out *api.IPFSPinStatus) error {
 	switch in.Cid {
 	case test.Cid1, test.Cid2:
 		*out = api.IPFSPinStatusRecursive
@@ -114,7 +114,7 @@ func mockRPCClient(t testing.TB) *rpc.Client {
 	return c
 }
 
-func getStateFunc(t testing.TB, items ...*api.Pin) func(context.Context) (state.ReadOnly, error) {
+func getStateFunc(t testing.TB, items ...api.Pin) func(context.Context) (state.ReadOnly, error) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -135,7 +135,7 @@ func getStateFunc(t testing.TB, items ...*api.Pin) func(context.Context) (state.
 
 }
 
-func testStatelessPinTracker(t testing.TB, pins ...*api.Pin) *Tracker {
+func testStatelessPinTracker(t testing.TB, pins ...api.Pin) *Tracker {
 	t.Helper()
 
 	cfg := &Config{}

--- a/rpcutil/rpcutil.go
+++ b/rpcutil/rpcutil.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/ipfs/ipfs-cluster/api"
-
-	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 // CtxsWithTimeout returns n contexts, derived from the given parent
@@ -57,25 +55,25 @@ func MultiCancel(cancels []context.CancelFunc) {
 
 // The copy functions below are used in calls to Cluster.multiRPC()
 
-// CopyPIDsToIfaces converts a peer.ID slice to an empty interface
-// slice using pointers to each elements of the original slice.
-// Useful to handle gorpc.MultiCall() replies.
-func CopyPIDsToIfaces(in []peer.ID) []interface{} {
-	ifaces := make([]interface{}, len(in))
-	for i := range in {
-		ifaces[i] = &in[i]
-	}
-	return ifaces
-}
+// // CopyPIDsToIfaces converts a peer.ID slice to an empty interface
+// // slice using pointers to each elements of the original slice.
+// // Useful to handle gorpc.MultiCall() replies.
+// func CopyPIDsToIfaces(in []peer.ID) []interface{} {
+// 	ifaces := make([]interface{}, len(in))
+// 	for i := range in {
+// 		ifaces[i] = &in[i]
+// 	}
+// 	return ifaces
+// }
 
 // CopyIDsToIfaces converts an api.ID slice to an empty interface
 // slice using pointers to each elements of the original slice.
 // Useful to handle gorpc.MultiCall() replies.
-func CopyIDsToIfaces(in []*api.ID) []interface{} {
+func CopyIDsToIfaces(in []api.ID) []interface{} {
 	ifaces := make([]interface{}, len(in))
 	for i := range in {
-		in[i] = &api.ID{}
-		ifaces[i] = in[i]
+		in[i] = api.ID{}
+		ifaces[i] = &(in[i])
 	}
 	return ifaces
 }
@@ -83,10 +81,10 @@ func CopyIDsToIfaces(in []*api.ID) []interface{} {
 // CopyIDSliceToIfaces converts an api.ID slice of slices
 // to an empty interface slice using pointers to each elements of the
 // original slice. Useful to handle gorpc.MultiCall() replies.
-func CopyIDSliceToIfaces(in [][]*api.ID) []interface{} {
+func CopyIDSliceToIfaces(in [][]api.ID) []interface{} {
 	ifaces := make([]interface{}, len(in))
 	for i := range in {
-		ifaces[i] = &in[i]
+		ifaces[i] = &(in[i])
 	}
 	return ifaces
 }
@@ -94,11 +92,11 @@ func CopyIDSliceToIfaces(in [][]*api.ID) []interface{} {
 // CopyPinInfoToIfaces converts an api.PinInfo slice to
 // an empty interface slice using pointers to each elements of
 // the original slice. Useful to handle gorpc.MultiCall() replies.
-func CopyPinInfoToIfaces(in []*api.PinInfo) []interface{} {
+func CopyPinInfoToIfaces(in []api.PinInfo) []interface{} {
 	ifaces := make([]interface{}, len(in))
 	for i := range in {
-		in[i] = &api.PinInfo{}
-		ifaces[i] = in[i]
+		in[i] = api.PinInfo{}
+		ifaces[i] = &(in[i])
 	}
 	return ifaces
 }
@@ -106,10 +104,10 @@ func CopyPinInfoToIfaces(in []*api.PinInfo) []interface{} {
 // CopyPinInfoSliceToIfaces converts an api.PinInfo slice of slices
 // to an empty interface slice using pointers to each elements of the original
 // slice. Useful to handle gorpc.MultiCall() replies.
-func CopyPinInfoSliceToIfaces(in [][]*api.PinInfo) []interface{} {
+func CopyPinInfoSliceToIfaces(in [][]api.PinInfo) []interface{} {
 	ifaces := make([]interface{}, len(in))
 	for i := range in {
-		ifaces[i] = &in[i]
+		ifaces[i] = &(in[i])
 	}
 	return ifaces
 }
@@ -117,11 +115,11 @@ func CopyPinInfoSliceToIfaces(in [][]*api.PinInfo) []interface{} {
 // CopyRepoGCSliceToIfaces converts an api.RepoGC slice to
 // an empty interface slice using pointers to each elements of
 // the original slice. Useful to handle gorpc.MultiCall() replies.
-func CopyRepoGCSliceToIfaces(in []*api.RepoGC) []interface{} {
+func CopyRepoGCSliceToIfaces(in []api.RepoGC) []interface{} {
 	ifaces := make([]interface{}, len(in))
 	for i := range in {
-		in[i] = &api.RepoGC{}
-		ifaces[i] = in[i]
+		in[i] = api.RepoGC{}
+		ifaces[i] = &(in[i])
 	}
 	return ifaces
 }
@@ -132,7 +130,7 @@ func CopyRepoGCSliceToIfaces(in []*api.RepoGC) []interface{} {
 func CopyEmptyStructToIfaces(in []struct{}) []interface{} {
 	ifaces := make([]interface{}, len(in))
 	for i := range in {
-		ifaces[i] = &in[i]
+		ifaces[i] = &(in[i])
 	}
 	return ifaces
 }

--- a/sharness/t0030-ctl-pin.sh
+++ b/sharness/t0030-ctl-pin.sh
@@ -15,7 +15,7 @@ test_expect_success IPFS,CLUSTER "pin data to cluster with ctl" '
 '
 
 test_expect_success IPFS,CLUSTER "unpin data from cluster with ctl" '
-    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".[] | .cid | .[\"/\"]" | head -1`
+    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".cid | .[\"/\"]" | head -1`
     ipfs-cluster-ctl pin rm "$cid" &&
     !(ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid") &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
@@ -29,7 +29,7 @@ test_expect_success IPFS,CLUSTER "wait for data to pin to cluster with ctl" '
 '
 
 test_expect_success IPFS,CLUSTER "wait for data to unpin from cluster with ctl" '
-    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".[] | .cid | .[\"/\"]" | head -1`
+    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".cid | .[\"/\"]" | head -1`
     ipfs-cluster-ctl pin rm --wait "$cid" | grep -q -i "UNPINNED" &&
     !(ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid") &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
@@ -43,7 +43,7 @@ test_expect_success IPFS,CLUSTER "wait for data to pin to cluster with ctl with 
 '
 
 test_expect_success IPFS,CLUSTER "wait for data to unpin from cluster with ctl with timeout" '
-    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".[] | .cid | .[\"/\"]" | head -1`
+    cid=`ipfs-cluster-ctl --enc=json pin ls | jq -r ".cid | .[\"/\"]" | head -1`
     ipfs-cluster-ctl pin rm --wait --wait-timeout 2s "$cid" | grep -q -i "UNPINNED" &&
     !(ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid") &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "UNPINNED"
@@ -83,7 +83,7 @@ test_expect_success IPFS,CLUSTER "pin data to cluster with user allocations" '
     ipfs-cluster-ctl pin add --allocations ${pid} -r 1 "${cid[0]}"
     ipfs-cluster-ctl pin ls "${cid[0]}" | grep -q "${cid[0]}" &&
     ipfs-cluster-ctl status "${cid[0]}" | grep -q -i "PINNED"
-    allocations=`ipfs-cluster-ctl --enc=json pin ls | jq .[0].allocations[]`
+    allocations=`ipfs-cluster-ctl --enc=json pin ls | jq -r .allocations[]`
     echo $allocations | wc -w | grep -q 1 &&
     echo $allocations | grep -q ${pid}
 '

--- a/state/empty.go
+++ b/state/empty.go
@@ -10,16 +10,18 @@ import (
 
 type empty struct{}
 
-func (e *empty) List(ctx context.Context) ([]*api.Pin, error) {
-	return []*api.Pin{}, nil
+func (e *empty) List(ctx context.Context) (<-chan api.Pin, error) {
+	ch := make(chan api.Pin)
+	close(ch)
+	return ch, nil
 }
 
 func (e *empty) Has(ctx context.Context, c cid.Cid) (bool, error) {
 	return false, nil
 }
 
-func (e *empty) Get(ctx context.Context, c cid.Cid) (*api.Pin, error) {
-	return nil, ErrNotFound
+func (e *empty) Get(ctx context.Context, c cid.Cid) (api.Pin, error) {
+	return api.Pin{}, ErrNotFound
 }
 
 // Empty returns an empty read-only state.

--- a/state/interface.go
+++ b/state/interface.go
@@ -34,18 +34,18 @@ type State interface {
 // ReadOnly represents the read side of a State.
 type ReadOnly interface {
 	// List lists all the pins in the state.
-	List(context.Context) ([]*api.Pin, error)
+	List(context.Context) (<-chan api.Pin, error)
 	// Has returns true if the state is holding information for a Cid.
 	Has(context.Context, cid.Cid) (bool, error)
 	// Get returns the information attacthed to this pin, if any. If the
 	// pin is not part of the state, it should return ErrNotFound.
-	Get(context.Context, cid.Cid) (*api.Pin, error)
+	Get(context.Context, cid.Cid) (api.Pin, error)
 }
 
 // WriteOnly represents the write side of a State.
 type WriteOnly interface {
 	// Add adds a pin to the State
-	Add(context.Context, *api.Pin) error
+	Add(context.Context, api.Pin) error
 	// Rm removes a pin from the State.
 	Rm(context.Context, cid.Cid) error
 }

--- a/test/ipfs_mock.go
+++ b/test/ipfs_mock.go
@@ -275,7 +275,7 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				goto ERROR
 			}
-			for _, p := range pins {
+			for p := range pins {
 				rMap[p.Cid.String()] = mockPinType{p.Mode.String()}
 			}
 			j, _ := json.Marshal(mockPinLsResp{rMap})
@@ -424,11 +424,17 @@ func (m *IpfsMock) handler(w http.ResponseWriter, r *http.Request) {
 
 	case "repo/stat":
 		sizeOnly := r.URL.Query().Get("size-only")
-		list, err := m.pinMap.List(ctx)
+		pinsCh, err := m.pinMap.List(ctx)
 		if err != nil {
 			goto ERROR
 		}
-		len := len(list)
+
+		var pins []api.Pin
+		for p := range pinsCh {
+			pins = append(pins, p)
+		}
+
+		len := len(pins)
 		numObjs := uint64(len)
 		if sizeOnly == "true" {
 			numObjs = 0

--- a/util.go
+++ b/util.go
@@ -176,10 +176,7 @@ func (pv pingValue) Valid() bool {
 
 // PingValue from metric parses a ping value from the value of a given metric,
 // if possible.
-func pingValueFromMetric(m *api.Metric) (pv pingValue) {
-	if m == nil {
-		return
-	}
+func pingValueFromMetric(m api.Metric) (pv pingValue) {
 	json.Unmarshal([]byte(m.Value), &pv)
 	return
 }


### PR DESCRIPTION
This commit introduces the new go-libp2p-gorpc streaming capabilities for
Cluster. The main aim is to work towards heavily reducing memory usage when
working with very large pinsets.

As a side-effect, it takes the chance to revampt all types for all public
methods so that pointers to static what should be static objects are not used
anymore. This should heavily reduce heap allocations and GC activity.

The main change is that state.List now returns a channel from which to read
the pins, rather than pins being all loaded into a huge slice.

Things reading pins have been all updated to iterate on the channel rather
than on the slice. The full pinset is no longer fully loaded onto memory for
things that run regularly like StateSync().

Additionally, the /allocations endpoint of the rest API no longer returns an
array of pins, but rather streams json-encoded pin objects directly. This
change has extended to the restapi client (which puts pins into a channel as
they arrive) and to ipfs-cluster-ctl.

There are still pending improvements like StatusAll() calls which should also
stream responses, and specially BlockPut calls which should stream blocks
directly into IPFS on a single call.

These are coming up in future commits.