### PR TITLE
Pintracker: streaming methods

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -85,9 +85,9 @@ type Client interface {
 	// is fetched from all cluster peers.
 	Status(ctx context.Context, ci cid.Cid, local bool) (api.GlobalPinInfo, error)
 	// StatusCids status information for the requested CIDs.
-	StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]api.GlobalPinInfo, error)
+	StatusCids(ctx context.Context, cids []cid.Cid, local bool, out chan<- api.GlobalPinInfo) error
 	// StatusAll gathers Status() for all tracked items.
-	StatusAll(ctx context.Context, filter api.TrackerStatus, local bool) ([]api.GlobalPinInfo, error)
+	StatusAll(ctx context.Context, filter api.TrackerStatus, local bool, out chan<- api.GlobalPinInfo) error
 
 	// Recover retriggers pin or unpin ipfs operations for a Cid in error
 	// state.  If local is true, the operation is limited to the current
@@ -96,7 +96,7 @@ type Client interface {
 	// RecoverAll triggers Recover() operations on all tracked items. If
 	// local is true, the operation is limited to the current peer.
 	// Otherwise, it happens everywhere.
-	RecoverAll(ctx context.Context, local bool) ([]api.GlobalPinInfo, error)
+	RecoverAll(ctx context.Context, local bool, out chan<- api.GlobalPinInfo) error
 
 	// Alerts returns information health events in the cluster (expired
 	// metrics etc.).

--- a/api/rest/client/lbclient.go
+++ b/api/rest/client/lbclient.go
@@ -253,16 +253,13 @@ func (lc *loadBalancingClient) Status(ctx context.Context, ci cid.Cid, local boo
 // StatusCids returns Status() information for the given Cids. If local is
 // true, the information affects only the current peer, otherwise the
 // information is fetched from all cluster peers.
-func (lc *loadBalancingClient) StatusCids(ctx context.Context, cids []cid.Cid, local bool) ([]api.GlobalPinInfo, error) {
-	var pinInfos []api.GlobalPinInfo
+func (lc *loadBalancingClient) StatusCids(ctx context.Context, cids []cid.Cid, local bool, out chan<- api.GlobalPinInfo) error {
 	call := func(c Client) error {
-		var err error
-		pinInfos, err = c.StatusCids(ctx, cids, local)
-		return err
+		return c.StatusCids(ctx, cids, local, out)
 	}
 
 	err := lc.retry(0, call)
-	return pinInfos, err
+	return err
 }
 
 // StatusAll gathers Status() for all tracked items. If a filter is
@@ -270,16 +267,13 @@ func (lc *loadBalancingClient) StatusCids(ctx context.Context, cids []cid.Cid, l
 // will be returned. A filter can be built by merging TrackerStatuses with
 // a bitwise OR operation (st1 | st2 | ...). A "0" filter value (or
 // api.TrackerStatusUndefined), means all.
-func (lc *loadBalancingClient) StatusAll(ctx context.Context, filter api.TrackerStatus, local bool) ([]api.GlobalPinInfo, error) {
-	var pinInfos []api.GlobalPinInfo
+func (lc *loadBalancingClient) StatusAll(ctx context.Context, filter api.TrackerStatus, local bool, out chan<- api.GlobalPinInfo) error {
 	call := func(c Client) error {
-		var err error
-		pinInfos, err = c.StatusAll(ctx, filter, local)
-		return err
+		return c.StatusAll(ctx, filter, local, out)
 	}
 
 	err := lc.retry(0, call)
-	return pinInfos, err
+	return err
 }
 
 // Recover retriggers pin or unpin ipfs operations for a Cid in error state.
@@ -300,16 +294,13 @@ func (lc *loadBalancingClient) Recover(ctx context.Context, ci cid.Cid, local bo
 // RecoverAll triggers Recover() operations on all tracked items. If local is
 // true, the operation is limited to the current peer. Otherwise, it happens
 // everywhere.
-func (lc *loadBalancingClient) RecoverAll(ctx context.Context, local bool) ([]api.GlobalPinInfo, error) {
-	var pinInfos []api.GlobalPinInfo
+func (lc *loadBalancingClient) RecoverAll(ctx context.Context, local bool, out chan<- api.GlobalPinInfo) error {
 	call := func(c Client) error {
-		var err error
-		pinInfos, err = c.RecoverAll(ctx, local)
-		return err
+		return c.RecoverAll(ctx, local, out)
 	}
 
 	err := lc.retry(0, call)
-	return pinInfos, err
+	return err
 }
 
 // Alerts returns things that are wrong with cluster.

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -39,17 +39,23 @@ func jsonFormatObject(resp interface{}) {
 }
 
 func jsonFormatPrint(obj interface{}) {
+	print := func(o interface{}) {
+		j, err := json.MarshalIndent(o, "", "    ")
+		checkErr("generating json output", err)
+		fmt.Printf("%s\n", j)
+	}
+
 	switch r := obj.(type) {
 	case chan api.Pin:
 		for o := range r {
-			j, err := json.MarshalIndent(o, "", "    ")
-			checkErr("generating json output", err)
-			fmt.Printf("%s\n", j)
+			print(o)
+		}
+	case chan api.GlobalPinInfo:
+		for o := range r {
+			print(o)
 		}
 	default:
-		j, err := json.MarshalIndent(obj, "", "    ")
-		checkErr("generating json output", err)
-		fmt.Printf("%s\n", j)
+		print(obj)
 	}
 
 }
@@ -82,8 +88,8 @@ func textFormatObject(resp interface{}) {
 		for _, item := range r {
 			textFormatObject(item)
 		}
-	case []api.GlobalPinInfo:
-		for _, item := range r {
+	case chan api.GlobalPinInfo:
+		for item := range r {
 			textFormatObject(item)
 		}
 	case chan api.Pin:

--- a/consensus/crdt/consensus_test.go
+++ b/consensus/crdt/consensus_test.go
@@ -125,14 +125,14 @@ func TestConsensusPin(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	ch, err := st.List(ctx)
+	out := make(chan api.Pin, 10)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
-
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -186,14 +186,16 @@ func TestConsensusUpdate(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	ch, err := st.List(ctx)
+	// Channel will not block sending because plenty of space
+	out := make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
 
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -243,14 +245,15 @@ func TestConsensusAddRmPeer(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	ch, err := st.List(ctx)
+	out := make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
 
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -310,14 +313,15 @@ func TestConsensusDistrustPeer(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	ch, err := st.List(ctx)
+	out := make(chan api.Pin, 10)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
 
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -372,14 +376,15 @@ func TestOfflineState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ch, err := offlineState.List(ctx)
+	out := make(chan api.Pin, 100)
+	err = offlineState.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
 
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -412,14 +417,15 @@ func TestBatching(t *testing.T) {
 
 	time.Sleep(250 * time.Millisecond)
 
-	ch, err := st.List(ctx)
+	out := make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
 
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -430,14 +436,15 @@ func TestBatching(t *testing.T) {
 	// Trigger batch auto-commit by time
 	time.Sleep(time.Second)
 
-	ch, err = st.List(ctx)
+	out = make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	pins = nil
 
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -456,13 +463,14 @@ func TestBatching(t *testing.T) {
 	// Give a chance for things to persist
 	time.Sleep(250 * time.Millisecond)
 
-	ch, err = st.List(ctx)
+	out = make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	pins = nil
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -472,12 +480,14 @@ func TestBatching(t *testing.T) {
 
 	// wait for the last pin
 	time.Sleep(time.Second)
-	ch, err = st.List(ctx)
+
+	out = make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 	pins = nil
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 

--- a/consensus/raft/consensus_test.go
+++ b/consensus/raft/consensus_test.go
@@ -99,13 +99,14 @@ func TestConsensusPin(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	ch, err := st.List(ctx)
+	out := make(chan api.Pin, 10)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -154,13 +155,14 @@ func TestConsensusUpdate(t *testing.T) {
 		t.Fatal("error getting state:", err)
 	}
 
-	ch, err := st.List(ctx)
+	out := make(chan api.Pin, 10)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -330,13 +332,15 @@ func TestRaftLatestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal("Snapshot bytes returned could not restore to state: ", err)
 	}
-	ch, err := snapState.List(ctx)
+
+	out := make(chan api.Pin, 100)
+	err = snapState.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 

--- a/consensus/raft/log_op_test.go
+++ b/consensus/raft/log_op_test.go
@@ -27,13 +27,14 @@ func TestApplyToPin(t *testing.T) {
 	}
 	op.ApplyTo(st)
 
-	ch, err := st.List(ctx)
+	out := make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var pins []api.Pin
-	for p := range ch {
+	for p := range out {
 		pins = append(pins, p)
 	}
 
@@ -59,11 +60,13 @@ func TestApplyToUnpin(t *testing.T) {
 	}
 	st.Add(ctx, testPin(test.Cid1))
 	op.ApplyTo(st)
-	pins, err := st.List(ctx)
+
+	out := make(chan api.Pin, 100)
+	err = st.List(ctx, out)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pins) != 0 {
+	if len(out) != 0 {
 		t.Error("the state was not modified correctly")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-ds-badger v0.3.0
-	github.com/ipfs/go-ds-crdt v0.3.3
+	github.com/ipfs/go-ds-crdt v0.3.4
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-fs-lock v0.0.7
 	github.com/ipfs/go-ipfs-api v0.3.0
@@ -30,10 +30,10 @@ require (
 	github.com/ipfs/go-ipfs-pinner v0.2.1
 	github.com/ipfs/go-ipfs-posinfo v0.0.1
 	github.com/ipfs/go-ipld-cbor v0.0.6
-	github.com/ipfs/go-ipld-format v0.2.0
+	github.com/ipfs/go-ipld-format v0.3.0
 	github.com/ipfs/go-ipns v0.1.2
 	github.com/ipfs/go-log/v2 v2.5.0
-	github.com/ipfs/go-merkledag v0.5.1
+	github.com/ipfs/go-merkledag v0.6.0
 	github.com/ipfs/go-mfs v0.1.3-0.20210507195338-96fbfa122164
 	github.com/ipfs/go-path v0.2.2
 	github.com/ipfs/go-unixfs v0.3.1
@@ -45,7 +45,7 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.3.1
 	github.com/libp2p/go-libp2p-consensus v0.0.1
 	github.com/libp2p/go-libp2p-core v0.13.0
-	github.com/libp2p/go-libp2p-gorpc v0.3.0
+	github.com/libp2p/go-libp2p-gorpc v0.3.1
 	github.com/libp2p/go-libp2p-gostream v0.3.1
 	github.com/libp2p/go-libp2p-http v0.2.1
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
@@ -119,14 +119,14 @@ require (
 	github.com/huin/goupnp v1.0.2 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-bitfield v1.0.0 // indirect
-	github.com/ipfs/go-bitswap v0.5.1 // indirect
-	github.com/ipfs/go-blockservice v0.2.1 // indirect
+	github.com/ipfs/go-bitswap v0.6.0 // indirect
+	github.com/ipfs/go-blockservice v0.3.0 // indirect
 	github.com/ipfs/go-cidutil v0.0.2 // indirect
 	github.com/ipfs/go-fetcher v1.6.1 // indirect
-	github.com/ipfs/go-ipfs-blockstore v1.1.2 // indirect
+	github.com/ipfs/go-ipfs-blockstore v1.2.0 // indirect
 	github.com/ipfs/go-ipfs-delay v0.0.1 // indirect
 	github.com/ipfs/go-ipfs-exchange-interface v0.1.0 // indirect
-	github.com/ipfs/go-ipfs-exchange-offline v0.1.1 // indirect
+	github.com/ipfs/go-ipfs-exchange-offline v0.2.0 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.2 // indirect
 	github.com/ipfs/go-ipfs-provider v0.7.1 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -424,8 +424,9 @@ github.com/ipfs/go-bitswap v0.1.2/go.mod h1:qxSWS4NXGs7jQ6zQvoPY3+NmOfHHG47mhkiL
 github.com/ipfs/go-bitswap v0.1.3/go.mod h1:YEQlFy0kkxops5Vy+OxWdRSEZIoS7I7KDIwoa5Chkps=
 github.com/ipfs/go-bitswap v0.1.8/go.mod h1:TOWoxllhccevbWFUR2N7B1MTSVVge1s6XSMiCSA4MzM=
 github.com/ipfs/go-bitswap v0.3.4/go.mod h1:4T7fvNv/LmOys+21tnLzGKncMeeXUYUd1nUiJ2teMvI=
-github.com/ipfs/go-bitswap v0.5.1 h1:721YAEDBnLIrvcIMkCHCdqp34hA8jwL9yKMkyJpSpco=
 github.com/ipfs/go-bitswap v0.5.1/go.mod h1:P+ckC87ri1xFLvk74NlXdP0Kj9RmWAh4+H78sC6Qopo=
+github.com/ipfs/go-bitswap v0.6.0 h1:f2rc6GZtoSFhEIzQmddgGiel9xntj02Dg0ZNf2hSC+w=
+github.com/ipfs/go-bitswap v0.6.0/go.mod h1:Hj3ZXdOC5wBJvENtdqsixmzzRukqd8EHLxZLZc3mzRA=
 github.com/ipfs/go-block-format v0.0.1/go.mod h1:DK/YYcsSUIVAFNwo/KZCdIIbpN0ROH/baNLgayt4pFc=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-block-format v0.0.3 h1:r8t66QstRp/pd/or4dpnbVfXT5Gt7lOqRvC+/dDTpMc=
@@ -434,8 +435,9 @@ github.com/ipfs/go-blockservice v0.0.7/go.mod h1:EOfb9k/Y878ZTRY/CH0x5+ATtaipfbR
 github.com/ipfs/go-blockservice v0.1.0/go.mod h1:hzmMScl1kXHg3M2BjTymbVPjv627N7sYcvYaKbop39M=
 github.com/ipfs/go-blockservice v0.1.1/go.mod h1:t+411r7psEUhLueM8C7aPA7cxCclv4O3VsUVxt9kz2I=
 github.com/ipfs/go-blockservice v0.1.4/go.mod h1:OTZhFpkgY48kNzbgyvcexW9cHrpjBYIjSR0KoDOFOLU=
-github.com/ipfs/go-blockservice v0.2.1 h1:NJ4j/cwEfIg60rzAWcCIxRtOwbf6ZPK49MewNxObCPQ=
 github.com/ipfs/go-blockservice v0.2.1/go.mod h1:k6SiwmgyYgs4M/qt+ww6amPeUH9EISLRBnvUurKJhi8=
+github.com/ipfs/go-blockservice v0.3.0 h1:cDgcZ+0P0Ih3sl8+qjFr2sVaMdysg/YZpLj5WJ8kiiw=
+github.com/ipfs/go-blockservice v0.3.0/go.mod h1:P5ppi8IHDC7O+pA0AlGTF09jruB2h+oP3wVVaZl8sfk=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -469,8 +471,8 @@ github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBR
 github.com/ipfs/go-ds-badger v0.2.7/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
 github.com/ipfs/go-ds-badger v0.3.0 h1:xREL3V0EH9S219kFFueOYJJTcjgNSZ2HY1iSvN7U1Ro=
 github.com/ipfs/go-ds-badger v0.3.0/go.mod h1:1ke6mXNqeV8K3y5Ak2bAA0osoTfmxUdupVCGm4QUIek=
-github.com/ipfs/go-ds-crdt v0.3.3 h1:Q7fj+bm/gCfHte3axLQuCEzK1Uhsxgf065WLRvfeb0w=
-github.com/ipfs/go-ds-crdt v0.3.3/go.mod h1:rcfJixHEd+hIWcu/8SecC/lVlNcAkhE6DNgRKPd1xgU=
+github.com/ipfs/go-ds-crdt v0.3.4 h1:O/dFBkxxXxNO9cjfQwFQHTsoehfJtV1GNAhuRmLh2Dg=
+github.com/ipfs/go-ds-crdt v0.3.4/go.mod h1:bFHBkP56kWufO55QxAKT7qZqz23thrh7FN5l+hYTHa4=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
@@ -488,8 +490,9 @@ github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
 github.com/ipfs/go-ipfs-blockstore v0.1.4/go.mod h1:Jxm3XMVjh6R17WvxFEiyKBLUGr86HgIYJW/D/MwqeYQ=
 github.com/ipfs/go-ipfs-blockstore v0.2.1/go.mod h1:jGesd8EtCM3/zPgx+qr0/feTXGUeRai6adgwC+Q+JvE=
-github.com/ipfs/go-ipfs-blockstore v1.1.2 h1:WCXoZcMYnvOTmlpX+RSSnhVN0uCmbWTeepTGX5lgiXw=
 github.com/ipfs/go-ipfs-blockstore v1.1.2/go.mod h1:w51tNR9y5+QXB0wkNcHt4O2aSZjTdqaEWaQdSxEyUOY=
+github.com/ipfs/go-ipfs-blockstore v1.2.0 h1:n3WTeJ4LdICWs/0VSfjHrlqpPpl6MZ+ySd3j8qz0ykw=
+github.com/ipfs/go-ipfs-blockstore v1.2.0/go.mod h1:eh8eTFLiINYNSNawfZOC7HOxNTxpB1PFuA5E1m/7exE=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IWFJMcGIPQ=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
 github.com/ipfs/go-ipfs-chunker v0.0.1/go.mod h1:tWewYK0we3+rMbOh7pPFGDyypCtvGcBFymgY4rSDLAw=
@@ -510,8 +513,9 @@ github.com/ipfs/go-ipfs-exchange-interface v0.0.1/go.mod h1:c8MwfHjtQjPoDyiy9cFq
 github.com/ipfs/go-ipfs-exchange-interface v0.1.0 h1:TiMekCrOGQuWYtZO3mf4YJXDIdNgnKWZ9IE3fGlnWfo=
 github.com/ipfs/go-ipfs-exchange-interface v0.1.0/go.mod h1:ych7WPlyHqFvCi/uQI48zLZuAWVP5iTQPXEfVaw5WEI=
 github.com/ipfs/go-ipfs-exchange-offline v0.0.1/go.mod h1:WhHSFCVYX36H/anEKQboAzpUws3x7UeEGkzQc3iNkM0=
-github.com/ipfs/go-ipfs-exchange-offline v0.1.1 h1:mEiXWdbMN6C7vtDG21Fphx8TGCbZPpQnz/496w/PL4g=
 github.com/ipfs/go-ipfs-exchange-offline v0.1.1/go.mod h1:vTiBRIbzSwDD0OWm+i3xeT0mO7jG2cbJYatp3HPk5XY=
+github.com/ipfs/go-ipfs-exchange-offline v0.2.0 h1:2PF4o4A7W656rC0RxuhUace997FTcDTcIQ6NoEtyjAI=
+github.com/ipfs/go-ipfs-exchange-offline v0.2.0/go.mod h1:HjwBeW0dvZvfOMwDP0TSKXIHf2s+ksdP4E3MLDRtLKY=
 github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-files v0.0.8/go.mod h1:wiN/jSG8FKyk7N0WyctKSvq3ljIa2NNTiZB55kpTdOs=
 github.com/ipfs/go-ipfs-files v0.0.9/go.mod h1:aFv2uQ/qxWpL/6lidWvnSQmaVqCrf0TBGoUr+C1Fo84=
@@ -541,8 +545,9 @@ github.com/ipfs/go-ipld-cbor v0.0.6 h1:pYuWHyvSpIsOOLw4Jy7NbBkCyzLDcl64Bf/LZW7eB
 github.com/ipfs/go-ipld-cbor v0.0.6/go.mod h1:ssdxxaLJPXH7OjF5V4NSjBbcfh+evoR4ukuru0oPXMA=
 github.com/ipfs/go-ipld-format v0.0.1/go.mod h1:kyJtbkDALmFHv3QR6et67i35QzO3S0dCDnkOJhcZkms=
 github.com/ipfs/go-ipld-format v0.0.2/go.mod h1:4B6+FM2u9OJ9zCV+kSbgFAZlOrv1Hqbf0INGQgiKf9k=
-github.com/ipfs/go-ipld-format v0.2.0 h1:xGlJKkArkmBvowr+GMCX0FEZtkro71K1AwiKnL37mwA=
 github.com/ipfs/go-ipld-format v0.2.0/go.mod h1:3l3C1uKoadTPbeNfrDi+xMInYKlx2Cvg1BuydPSdzQs=
+github.com/ipfs/go-ipld-format v0.3.0 h1:Mwm2oRLzIuUwEPewWAWyMuuBQUsn3awfFEYVb8akMOQ=
+github.com/ipfs/go-ipld-format v0.3.0/go.mod h1:co/SdBE8h99968X0hViiw1MNlh6fvxxnHpvVLnH7jSM=
 github.com/ipfs/go-ipld-legacy v0.1.0 h1:wxkkc4k8cnvIGIjPO0waJCe7SHEyFgl+yQdafdjGrpA=
 github.com/ipfs/go-ipld-legacy v0.1.0/go.mod h1:86f5P/srAmh9GcIcWQR9lfFLZPrIyyXQeVlOWeeWEuI=
 github.com/ipfs/go-ipns v0.1.2 h1:O/s/0ht+4Jl9+VoxoUo0zaHjnZUS+aBQIKTuzdZ/ucI=
@@ -565,8 +570,9 @@ github.com/ipfs/go-log/v2 v2.5.0/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOL
 github.com/ipfs/go-merkledag v0.0.6/go.mod h1:QYPdnlvkOg7GnQRofu9XZimC5ZW5Wi3bKys/4GQQfto=
 github.com/ipfs/go-merkledag v0.2.3/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-merkledag v0.3.2/go.mod h1:fvkZNNZixVW6cKSZ/JfLlON5OlgTXNdRLz0p6QG/I2M=
-github.com/ipfs/go-merkledag v0.5.1 h1:tr17GPP5XtPhvPPiWtu20tSGZiZDuTaJRXBLcr79Umk=
 github.com/ipfs/go-merkledag v0.5.1/go.mod h1:cLMZXx8J08idkp5+id62iVftUQV+HlYJ3PIhDfZsjA4=
+github.com/ipfs/go-merkledag v0.6.0 h1:oV5WT2321tS4YQVOPgIrWHvJ0lJobRTerU+i9nmUCuA=
+github.com/ipfs/go-merkledag v0.6.0/go.mod h1:9HSEwRd5sV+lbykiYP+2NC/3o6MZbKNaa4hfNcH5iH0=
 github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fGD6n0jO4kdg=
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
 github.com/ipfs/go-mfs v0.1.3-0.20210507195338-96fbfa122164 h1:0ATu9s5KktHhm8aYRSe1ysOJPik3dRwU/uag1Bcz+tg=
@@ -774,8 +780,8 @@ github.com/libp2p/go-libp2p-discovery v0.5.0/go.mod h1:+srtPIU9gDaBNu//UHvcdliKB
 github.com/libp2p/go-libp2p-discovery v0.6.0 h1:1XdPmhMJr8Tmj/yUfkJMIi8mgwWrLUsCB3bMxdT+DSo=
 github.com/libp2p/go-libp2p-discovery v0.6.0/go.mod h1:/u1voHt0tKIe5oIA1RHBKQLVCWPna2dXmPNHc2zR9S8=
 github.com/libp2p/go-libp2p-gorpc v0.1.0/go.mod h1:DrswTLnu7qjLgbqe4fekX4ISoPiHUqtA45thTsJdE1w=
-github.com/libp2p/go-libp2p-gorpc v0.3.0 h1:1ww39zPEclHh8p1Exk882Xhy3CK2gW+JZYd+6NZp+q0=
-github.com/libp2p/go-libp2p-gorpc v0.3.0/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
+github.com/libp2p/go-libp2p-gorpc v0.3.1 h1:ZmqQIgHccgh/Ff1kS3ZlwATZRLvtuRUd633/MLWAx20=
+github.com/libp2p/go-libp2p-gorpc v0.3.1/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
 github.com/libp2p/go-libp2p-gostream v0.3.0/go.mod h1:pLBQu8db7vBMNINGsAwLL/ZCE8wng5V1FThoaE5rNjc=
 github.com/libp2p/go-libp2p-gostream v0.3.1 h1:XlwohsPn6uopGluEWs1Csv1QCEjrTXf2ZQagzZ5paAg=
 github.com/libp2p/go-libp2p-gostream v0.3.1/go.mod h1:1V3b+u4Zhaq407UUY9JLCpboaeufAeVQbnvAt12LRsI=

--- a/informer/numpin/numpin_test.go
+++ b/informer/numpin/numpin_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/ipfs-cluster/api"
+	"github.com/ipfs/ipfs-cluster/test"
 
 	rpc "github.com/libp2p/go-libp2p-gorpc"
 )
@@ -21,11 +22,10 @@ func mockRPCClient(t *testing.T) *rpc.Client {
 	return c
 }
 
-func (mock *mockService) PinLs(ctx context.Context, in string, out *map[string]api.IPFSPinStatus) error {
-	*out = map[string]api.IPFSPinStatus{
-		"QmPGDFvBkgWhvzEK9qaTWrWurSwqXNmhnK3hgELPdZZNPa": api.IPFSPinStatusRecursive,
-		"QmUZ13osndQ5uL4tPWHXe3iBgBgq9gfewcBMSCAuMBsDJ6": api.IPFSPinStatusRecursive,
-	}
+func (mock *mockService) PinLs(ctx context.Context, in <-chan []string, out chan<- api.IPFSPinInfo) error {
+	out <- api.IPFSPinInfo{Cid: api.Cid(test.Cid1), Type: api.IPFSPinStatusRecursive}
+	out <- api.IPFSPinInfo{Cid: api.Cid(test.Cid2), Type: api.IPFSPinStatusRecursive}
+	close(out)
 	return nil
 }
 

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -78,7 +78,8 @@ type IPFSConnector interface {
 	Pin(context.Context, api.Pin) error
 	Unpin(context.Context, cid.Cid) error
 	PinLsCid(context.Context, api.Pin) (api.IPFSPinStatus, error)
-	PinLs(ctx context.Context, typeFilter string) (map[string]api.IPFSPinStatus, error)
+	// PinLs returns pins in the pinset of the given types (recursive, direct...)
+	PinLs(ctx context.Context, typeFilters []string, out chan<- api.IPFSPinInfo) error
 	// ConnectSwarms make sure this peer's IPFS daemon is connected to
 	// other peers IPFS daemons.
 	ConnectSwarms(context.Context) error
@@ -121,12 +122,11 @@ type PinTracker interface {
 	Untrack(context.Context, cid.Cid) error
 	// StatusAll returns the list of pins with their local status. Takes a
 	// filter to specify which statuses to report.
-	StatusAll(context.Context, api.TrackerStatus) []api.PinInfo
+	StatusAll(context.Context, api.TrackerStatus, chan<- api.PinInfo) error
 	// Status returns the local status of a given Cid.
 	Status(context.Context, cid.Cid) api.PinInfo
-	// RecoverAll calls Recover() for all pins tracked. Returns only
-	// informations for retriggered pins.
-	RecoverAll(context.Context) ([]api.PinInfo, error)
+	// RecoverAll calls Recover() for all pins tracked.
+	RecoverAll(context.Context, chan<- api.PinInfo) error
 	// Recover retriggers a Pin/Unpin operation in a Cids with error status.
 	Recover(context.Context, cid.Cid) (api.PinInfo, error)
 }

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -114,7 +114,7 @@ func TestClustersPeerAdd(t *testing.T) {
 		}
 
 		// Check that they are part of the consensus
-		pins, err := c.Pins(ctx)
+		pins, err := c.pinsSlice(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -463,7 +463,7 @@ func TestClustersPeerRemoveReallocsPins(t *testing.T) {
 	// Find out which pins are associated to the chosen peer.
 	interestingCids := []cid.Cid{}
 
-	pins, err := chosen.Pins(ctx)
+	pins, err := chosen.pinsSlice(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func TestClustersPeerJoin(t *testing.T) {
 		if len(peers) != nClusters {
 			t.Error("all peers should be connected")
 		}
-		pins, err := c.Pins(ctx)
+		pins, err := c.pinsSlice(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -575,7 +575,7 @@ func TestClustersPeerJoinAllAtOnce(t *testing.T) {
 		if len(peers) != nClusters {
 			t.Error("all peers should be connected")
 		}
-		pins, err := c.Pins(ctx)
+		pins, err := c.pinsSlice(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pintracker/optracker/operationtracker_test.go
+++ b/pintracker/optracker/operationtracker_test.go
@@ -126,7 +126,7 @@ func TestOperationTracker_SetError(t *testing.T) {
 	opt := testOperationTracker(t)
 	opt.TrackNewOperation(ctx, api.PinCid(test.Cid1), OperationPin, PhaseDone)
 	opt.SetError(ctx, test.Cid1, errors.New("fake error"))
-	pinfo := opt.Get(ctx, test.Cid1)
+	pinfo := opt.Get(ctx, test.Cid1, api.IPFSID{})
 	if pinfo.Status != api.TrackerStatusPinError {
 		t.Error("should have updated the status")
 	}
@@ -148,7 +148,7 @@ func TestOperationTracker_Get(t *testing.T) {
 	opt.TrackNewOperation(ctx, api.PinCid(test.Cid1), OperationPin, PhaseDone)
 
 	t.Run("Get with existing item", func(t *testing.T) {
-		pinfo := opt.Get(ctx, test.Cid1)
+		pinfo := opt.Get(ctx, test.Cid1, api.IPFSID{})
 		if pinfo.Status != api.TrackerStatusPinned {
 			t.Error("bad status")
 		}
@@ -163,7 +163,7 @@ func TestOperationTracker_Get(t *testing.T) {
 	})
 
 	t.Run("Get with unexisting item", func(t *testing.T) {
-		pinfo := opt.Get(ctx, test.Cid2)
+		pinfo := opt.Get(ctx, test.Cid2, api.IPFSID{})
 		if pinfo.Status != api.TrackerStatusUnpinned {
 			t.Error("bad status")
 		}
@@ -181,7 +181,7 @@ func TestOperationTracker_GetAll(t *testing.T) {
 	ctx := context.Background()
 	opt := testOperationTracker(t)
 	opt.TrackNewOperation(ctx, api.PinCid(test.Cid1), OperationPin, PhaseInProgress)
-	pinfos := opt.GetAll(ctx)
+	pinfos := opt.GetAll(ctx, api.IPFSID{})
 	if len(pinfos) != 1 {
 		t.Fatal("expected 1 item")
 	}

--- a/sharness/t0054-service-state-clean.sh
+++ b/sharness/t0054-service-state-clean.sh
@@ -12,17 +12,17 @@ test_expect_success IPFS,CLUSTER "state cleanup refreshes state on restart (crdt
      ipfs-cluster-ctl pin add "$cid" && sleep 5 &&
      ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
      ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED" &&
-     [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ] &&
+     [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ] &&
      cluster_kill && sleep 5 &&
      ipfs-cluster-service --config "test-config" state cleanup -f &&
      cluster_start && sleep 5 &&
-     [ 0 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ]
+     [ 0 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ]
 '
 
 test_expect_success IPFS,CLUSTER "export + cleanup + import == noop (crdt)" '
     cid=`docker exec ipfs sh -c "echo test_54 | ipfs add -q"` &&
     ipfs-cluster-ctl pin add "$cid" && sleep 5 &&
-    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ] &&
+    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ] &&
     cluster_kill && sleep 5 &&
     ipfs-cluster-service --config "test-config" state export -f import.json &&
     ipfs-cluster-service --config "test-config" state cleanup -f &&
@@ -30,7 +30,7 @@ test_expect_success IPFS,CLUSTER "export + cleanup + import == noop (crdt)" '
     cluster_start && sleep 5 &&
     ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED" &&
-    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ]
+    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ]
 '
 
 cluster_kill
@@ -42,17 +42,17 @@ test_expect_success IPFS,CLUSTER "state cleanup refreshes state on restart (raft
      ipfs-cluster-ctl pin add "$cid" && sleep 5 &&
      ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
      ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED" &&
-     [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ] &&
+     [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ] &&
      cluster_kill && sleep 5 &&
      ipfs-cluster-service --config "test-config" state cleanup -f &&
      cluster_start && sleep 5 &&
-     [ 0 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ]
+     [ 0 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ]
 '
 
 test_expect_success IPFS,CLUSTER "export + cleanup + import == noop (raft)" '
     cid=`docker exec ipfs sh -c "echo test_54 | ipfs add -q"` &&
     ipfs-cluster-ctl pin add "$cid" && sleep 5 &&
-    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ] &&
+    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ] &&
     cluster_kill && sleep 5 &&
     ipfs-cluster-service --config "test-config" state export -f import.json &&
     ipfs-cluster-service --config "test-config" state cleanup -f &&
@@ -60,7 +60,7 @@ test_expect_success IPFS,CLUSTER "export + cleanup + import == noop (raft)" '
     cluster_start && sleep 5 &&
     ipfs-cluster-ctl pin ls "$cid" | grep -q "$cid" &&
     ipfs-cluster-ctl status "$cid" | grep -q -i "PINNED" &&
-    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq ". | length")" ]
+    [ 1 -eq "$(ipfs-cluster-ctl --enc=json status | jq -n "[inputs] | length")" ]
 '
 
 

--- a/state/dsstate/datastore_test.go
+++ b/state/dsstate/datastore_test.go
@@ -93,10 +93,13 @@ func TestList(t *testing.T) {
 	}()
 	st := newState(t)
 	st.Add(ctx, c)
-	pinCh, err := st.List(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	out := make(chan api.Pin)
+	go func() {
+		err := st.List(ctx, out)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -104,7 +107,7 @@ func TestList(t *testing.T) {
 	var list0 api.Pin
 	for {
 		select {
-		case p, ok := <-pinCh:
+		case p, ok := <-out:
 			if !ok && !list0.Cid.Defined() {
 				t.Fatal("should have read list0 first")
 			}

--- a/state/empty.go
+++ b/state/empty.go
@@ -10,10 +10,9 @@ import (
 
 type empty struct{}
 
-func (e *empty) List(ctx context.Context) (<-chan api.Pin, error) {
-	ch := make(chan api.Pin)
-	close(ch)
-	return ch, nil
+func (e *empty) List(ctx context.Context, out chan<- api.Pin) error {
+	close(out)
+	return nil
 }
 
 func (e *empty) Has(ctx context.Context, c cid.Cid) (bool, error) {

--- a/state/interface.go
+++ b/state/interface.go
@@ -34,7 +34,7 @@ type State interface {
 // ReadOnly represents the read side of a State.
 type ReadOnly interface {
 	// List lists all the pins in the state.
-	List(context.Context) (<-chan api.Pin, error)
+	List(context.Context, chan<- api.Pin) error
 	// Has returns true if the state is holding information for a Cid.
 	Has(context.Context, cid.Cid) (bool, error)
 	// Get returns the information attacthed to this pin, if any. If the

--- a/test/sharding.go
+++ b/test/sharding.go
@@ -300,7 +300,7 @@ func (d *MockDAGService) Get(ctx context.Context, cid cid.Cid) (format.Node, err
 	if n, ok := d.Nodes[cid]; ok {
 		return n, nil
 	}
-	return nil, format.ErrNotFound
+	return nil, format.ErrNotFound{Cid: cid}
 }
 
 // GetMany reads many nodes.
@@ -312,7 +312,7 @@ func (d *MockDAGService) GetMany(ctx context.Context, cids []cid.Cid) <-chan *fo
 		if n, ok := d.Nodes[c]; ok {
 			out <- &format.NodeOption{Node: n}
 		} else {
-			out <- &format.NodeOption{Err: format.ErrNotFound}
+			out <- &format.NodeOption{Err: format.ErrNotFound{Cid: c}}
 		}
 	}
 	close(out)


### PR DESCRIPTION
This commit continues the work of taking advantage of the streaming
capabilities in go-libp2p-gorpc by improving the ipfsconnector and pintracker
components.

StatusAll and RecoverAll methods are now streaming methods, with the REST API
output changing accordingly to produce a stream of GlobalPinInfos rather than
a json array.

pin/ls request to the ipfs daemon now use ?stream=true and avoid having to
load the full pinset map on memory. StatusAllLocal and RecoverAllLocal
requests to the pin tracker stream all the way and no longer store the full
pinset, and the full PinInfo status slice before sending it out.

We have additionally switched to a pattern where streaming methods receive the
channel as an argument, allowing the caller to decide on whether to launch a
goroutine, do buffering etc.