### PR TITLE
Streaming Peers(): make Peers() a streaming call

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -51,7 +51,7 @@ type Client interface {
 	ID(context.Context) (api.ID, error)
 
 	// Peers requests ID information for all cluster peers.
-	Peers(context.Context) ([]api.ID, error)
+	Peers(context.Context, chan<- api.ID) error
 	// PeerAdd adds a new peer to the cluster.
 	PeerAdd(ctx context.Context, pid peer.ID) (api.ID, error)
 	// PeerRm removes a current peer from the cluster

--- a/api/rest/client/lbclient.go
+++ b/api/rest/client/lbclient.go
@@ -123,16 +123,13 @@ func (lc *loadBalancingClient) ID(ctx context.Context) (api.ID, error) {
 }
 
 // Peers requests ID information for all cluster peers.
-func (lc *loadBalancingClient) Peers(ctx context.Context) ([]api.ID, error) {
-	var peers []api.ID
+func (lc *loadBalancingClient) Peers(ctx context.Context, out chan<- api.ID) error {
 	call := func(c Client) error {
-		var err error
-		peers, err = c.Peers(ctx)
-		return err
+		return c.Peers(ctx, out)
 	}
 
 	err := lc.retry(0, call)
-	return peers, err
+	return err
 }
 
 // PeerAdd adds a new peer to the cluster.

--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -71,11 +71,12 @@ func TestPeers(t *testing.T) {
 	defer shutdown(api)
 
 	testF := func(t *testing.T, c Client) {
-		ids, err := c.Peers(ctx)
+		out := make(chan types.ID, 10)
+		err := c.Peers(ctx, out)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(ids) == 0 {
+		if len(out) == 0 {
 			t.Error("expected some peers")
 		}
 	}
@@ -92,11 +93,12 @@ func TestPeersWithError(t *testing.T) {
 		addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/44444")
 		var _ = c
 		c, _ = NewDefaultClient(&Config{APIAddr: addr, DisableKeepAlives: true})
-		ids, err := c.Peers(ctx)
+		out := make(chan types.ID, 10)
+		err := c.Peers(ctx, out)
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if ids != nil {
+		if len(out) > 0 {
 			t.Fatal("expected no ids")
 		}
 	}

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -96,14 +96,14 @@ func TestAPIVersionEndpoint(t *testing.T) {
 	test.BothEndpoints(t, tf)
 }
 
-func TestAPIPeerstEndpoint(t *testing.T) {
+func TestAPIPeersEndpoint(t *testing.T) {
 	ctx := context.Background()
 	rest := testAPI(t)
 	defer rest.Shutdown(ctx)
 
 	tf := func(t *testing.T, url test.URLFunc) {
-		var list []*api.ID
-		test.MakeGet(t, rest, url(rest)+"/peers", &list)
+		var list []api.ID
+		test.MakeStreamingGet(t, rest, url(rest)+"/peers", &list, false)
 		if len(list) != 1 {
 			t.Fatal("expected 1 element")
 		}
@@ -559,7 +559,7 @@ func TestAPIMetricsEndpoint(t *testing.T) {
 	defer rest.Shutdown(ctx)
 
 	tf := func(t *testing.T, url test.URLFunc) {
-		var resp []*api.Metric
+		var resp []api.Metric
 		test.MakeGet(t, rest, url(rest)+"/monitor/metrics/somemetricstype", &resp)
 		if len(resp) == 0 {
 			t.Fatal("No metrics found")
@@ -804,7 +804,7 @@ func TestAPIIPFSGCEndpoint(t *testing.T) {
 	rest := testAPI(t)
 	defer rest.Shutdown(ctx)
 
-	testGlobalRepoGC := func(t *testing.T, gRepoGC *api.GlobalRepoGC) {
+	testGlobalRepoGC := func(t *testing.T, gRepoGC api.GlobalRepoGC) {
 		if gRepoGC.PeerMap == nil {
 			t.Fatal("expected a non-nil peer map")
 		}
@@ -836,11 +836,11 @@ func TestAPIIPFSGCEndpoint(t *testing.T) {
 	tf := func(t *testing.T, url test.URLFunc) {
 		var resp api.GlobalRepoGC
 		test.MakePost(t, rest, url(rest)+"/ipfs/gc?local=true", []byte{}, &resp)
-		testGlobalRepoGC(t, &resp)
+		testGlobalRepoGC(t, resp)
 
 		var resp1 api.GlobalRepoGC
 		test.MakePost(t, rest, url(rest)+"/ipfs/gc", []byte{}, &resp1)
-		testGlobalRepoGC(t, &resp1)
+		testGlobalRepoGC(t, resp1)
 	}
 
 	test.BothEndpoints(t, tf)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -905,8 +905,10 @@ func TestClusterPeers(t *testing.T) {
 	cl, _, _, _ := testingCluster(t)
 	defer cleanState()
 	defer cl.Shutdown(ctx)
-	peers := cl.Peers(ctx)
-	if len(peers) != 1 {
+
+	out := make(chan api.ID, 10)
+	cl.Peers(ctx, out)
+	if len(out) != 1 {
 		t.Fatal("expected 1 peer")
 	}
 
@@ -916,7 +918,8 @@ func TestClusterPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if peers[0].ID != ident.ID {
+	p := <-out
+	if p.ID != ident.ID {
 		t.Error("bad member")
 	}
 }

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -54,6 +54,10 @@ func jsonFormatPrint(obj interface{}) {
 		for o := range r {
 			print(o)
 		}
+	case chan api.ID:
+		for o := range r {
+			print(o)
+		}
 	default:
 		print(obj)
 	}
@@ -84,8 +88,8 @@ func textFormatObject(resp interface{}) {
 		textFormatPrintMetric(r)
 	case api.Alert:
 		textFormatPrintAlert(r)
-	case []api.ID:
-		for _, item := range r {
+	case chan api.ID:
+		for item := range r {
 			textFormatObject(item)
 		}
 	case chan api.GlobalPinInfo:

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -251,8 +251,15 @@ This command provides a list of the ID information of all the peers in the Clust
 					Flags:     []cli.Flag{},
 					ArgsUsage: " ",
 					Action: func(c *cli.Context) error {
-						resp, cerr := globalClient.Peers(ctx)
-						formatResponse(c, resp, cerr)
+						out := make(chan api.ID, 1024)
+						errCh := make(chan error, 1)
+						go func() {
+							defer close(errCh)
+							errCh <- globalClient.Peers(ctx, out)
+						}()
+						formatResponse(c, out, nil)
+						err := <-errCh
+						formatResponse(c, nil, err)
 						return nil
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.3.1
 	github.com/libp2p/go-libp2p-consensus v0.0.1
 	github.com/libp2p/go-libp2p-core v0.13.0
-	github.com/libp2p/go-libp2p-gorpc v0.3.1
+	github.com/libp2p/go-libp2p-gorpc v0.3.2
 	github.com/libp2p/go-libp2p-gostream v0.3.1
 	github.com/libp2p/go-libp2p-http v0.2.1
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,8 @@ github.com/libp2p/go-libp2p-discovery v0.5.0/go.mod h1:+srtPIU9gDaBNu//UHvcdliKB
 github.com/libp2p/go-libp2p-discovery v0.6.0 h1:1XdPmhMJr8Tmj/yUfkJMIi8mgwWrLUsCB3bMxdT+DSo=
 github.com/libp2p/go-libp2p-discovery v0.6.0/go.mod h1:/u1voHt0tKIe5oIA1RHBKQLVCWPna2dXmPNHc2zR9S8=
 github.com/libp2p/go-libp2p-gorpc v0.1.0/go.mod h1:DrswTLnu7qjLgbqe4fekX4ISoPiHUqtA45thTsJdE1w=
-github.com/libp2p/go-libp2p-gorpc v0.3.1 h1:ZmqQIgHccgh/Ff1kS3ZlwATZRLvtuRUd633/MLWAx20=
-github.com/libp2p/go-libp2p-gorpc v0.3.1/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
+github.com/libp2p/go-libp2p-gorpc v0.3.2 h1:pQdGWqB+HImCXbKVbjqpgckUzGcXEPIYP8aisaYfkrs=
+github.com/libp2p/go-libp2p-gorpc v0.3.2/go.mod h1:sRz9ybP9rlOkJB1v65SMLr+NUEPB/ioLZn26MWIV4DU=
 github.com/libp2p/go-libp2p-gostream v0.3.0/go.mod h1:pLBQu8db7vBMNINGsAwLL/ZCE8wng5V1FThoaE5rNjc=
 github.com/libp2p/go-libp2p-gostream v0.3.1 h1:XlwohsPn6uopGluEWs1Csv1QCEjrTXf2ZQagzZ5paAg=
 github.com/libp2p/go-libp2p-gostream v0.3.1/go.mod h1:1V3b+u4Zhaq407UUY9JLCpboaeufAeVQbnvAt12LRsI=

--- a/pnet_test.go
+++ b/pnet_test.go
@@ -51,10 +51,10 @@ func TestSimplePNet(t *testing.T) {
 	}
 	ttlDelay()
 
-	if len(clusters[0].Peers(ctx)) != len(clusters[1].Peers(ctx)) {
+	if len(peers(ctx, t, clusters[0])) != len(peers(ctx, t, clusters[1])) {
 		t.Fatal("Expected same number of peers")
 	}
-	if len(clusters[0].Peers(ctx)) < 2 {
+	if len(peers(ctx, t, clusters[0])) < 2 {
 		// crdt mode has auto discovered all peers at this point.
 		// Raft mode has 2 peers only.
 		t.Fatal("Expected at least 2 peers")

--- a/rpc_policy.go
+++ b/rpc_policy.go
@@ -11,6 +11,7 @@ var DefaultRPCPolicy = map[string]RPCEndpointType{
 	"Cluster.BlockAllocate":        RPCClosed,
 	"Cluster.ConnectGraph":         RPCClosed,
 	"Cluster.ID":                   RPCOpen,
+	"Cluster.IDStream":             RPCOpen,
 	"Cluster.IPFSID":               RPCClosed,
 	"Cluster.Join":                 RPCClosed,
 	"Cluster.PeerAdd":              RPCOpen, // Used by Join()

--- a/sharness/t0025-ctl-status-report-commands.sh
+++ b/sharness/t0025-ctl-status-report-commands.sh
@@ -12,8 +12,8 @@ test_expect_success IPFS,CLUSTER,JQ "cluster-ctl can read id" '
     [ -n "$id" ] && ( ipfs-cluster-ctl id | egrep -q "$id" )
 '
 
-test_expect_success IPFS,CLUSTER "cluster-ctl list 0 peers" '
-    peer_length=`ipfs-cluster-ctl --enc=json peers ls | jq ". | length"`
+test_expect_success IPFS,CLUSTER "cluster-ctl list 1 peer" '
+    peer_length=`ipfs-cluster-ctl --enc=json peers ls | jq -n "[inputs] | length"`
     [ $peer_length -eq 1 ]
 '
 


### PR DESCRIPTION
This commit makes all the changes to make Peers() a streaming call.

While Peers is usually a non problematic call, for consistency, all calls
returning collections assembled through broadcast to cluster peers are now
streaming calls.