### PR TITLE
Adders: stream blocks to destinations

### DIFF
--- a/add_test.go
+++ b/add_test.go
@@ -32,7 +32,7 @@ func TestAdd(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 		r := multipart.NewReader(mfr, mfr.Boundary())
-		ci, err := clusters[0].AddFile(r, params)
+		ci, err := clusters[0].AddFile(context.Background(), r, params)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -67,7 +67,7 @@ func TestAdd(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 		r := multipart.NewReader(mfr, mfr.Boundary())
-		ci, err := clusters[2].AddFile(r, params)
+		ci, err := clusters[2].AddFile(context.Background(), r, params)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,7 +119,7 @@ func TestAddWithUserAllocations(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 		r := multipart.NewReader(mfr, mfr.Boundary())
-		ci, err := clusters[0].AddFile(r, params)
+		ci, err := clusters[0].AddFile(context.Background(), r, params)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,7 +167,7 @@ func TestAddPeerDown(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 		r := multipart.NewReader(mfr, mfr.Boundary())
-		ci, err := clusters[1].AddFile(r, params)
+		ci, err := clusters[1].AddFile(context.Background(), r, params)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -218,7 +218,7 @@ func TestAddOnePeerFails(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := clusters[0].AddFile(r, params)
+			_, err := clusters[0].AddFile(context.Background(), r, params)
 			if err != nil {
 				t.Error(err)
 			}
@@ -276,7 +276,7 @@ func TestAddAllPeersFail(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := clusters[0].AddFile(r, params)
+			_, err := clusters[0].AddFile(context.Background(), r, params)
 			if err != adder.ErrBlockAdder {
 				t.Error("expected ErrBlockAdder. Got: ", err)
 			}

--- a/adder/adder.go
+++ b/adder/adder.go
@@ -68,18 +68,18 @@ type Adder struct {
 	// whenever a block is processed. They contain information
 	// about the block, the CID, the Name etc. and are mostly
 	// meant to be streamed back to the user.
-	output chan *api.AddedOutput
+	output chan api.AddedOutput
 }
 
 // New returns a new Adder with the given ClusterDAGService, add options and a
 // channel to send updates during the adding process.
 //
 // An Adder may only be used once.
-func New(ds ClusterDAGService, p api.AddParams, out chan *api.AddedOutput) *Adder {
+func New(ds ClusterDAGService, p api.AddParams, out chan api.AddedOutput) *Adder {
 	// Discard all progress update output as the caller has not provided
 	// a channel for them to listen on.
 	if out == nil {
-		out = make(chan *api.AddedOutput, 100)
+		out = make(chan api.AddedOutput, 100)
 		go func() {
 			for range out {
 			}
@@ -188,7 +188,7 @@ type ipfsAdder struct {
 	*ipfsadd.Adder
 }
 
-func newIpfsAdder(ctx context.Context, dgs ClusterDAGService, params api.AddParams, out chan *api.AddedOutput) (*ipfsAdder, error) {
+func newIpfsAdder(ctx context.Context, dgs ClusterDAGService, params api.AddParams, out chan api.AddedOutput) (*ipfsAdder, error) {
 	iadder, err := ipfsadd.NewAdder(ctx, dgs, dgs.Allocations)
 	if err != nil {
 		logger.Error(err)
@@ -253,10 +253,10 @@ type carAdder struct {
 	ctx    context.Context
 	dgs    ClusterDAGService
 	params api.AddParams
-	output chan *api.AddedOutput
+	output chan api.AddedOutput
 }
 
-func newCarAdder(ctx context.Context, dgs ClusterDAGService, params api.AddParams, out chan *api.AddedOutput) (*carAdder, error) {
+func newCarAdder(ctx context.Context, dgs ClusterDAGService, params api.AddParams, out chan api.AddedOutput) (*carAdder, error) {
 	return &carAdder{
 		ctx:    ctx,
 		dgs:    dgs,
@@ -319,7 +319,7 @@ func (ca *carAdder) Add(name string, fn files.Node) (cid.Cid, error) {
 		}
 	}
 
-	ca.output <- &api.AddedOutput{
+	ca.output <- api.AddedOutput{
 		Name:        name,
 		Cid:         root,
 		Bytes:       bytes,

--- a/adder/ipfsadd/add.go
+++ b/adder/ipfsadd/add.go
@@ -51,7 +51,7 @@ type Adder struct {
 	ctx        context.Context
 	dagService ipld.DAGService
 	allocsFun  func() []peer.ID
-	Out        chan *api.AddedOutput
+	Out        chan api.AddedOutput
 	Progress   bool
 	Trickle    bool
 	RawLeaves  bool
@@ -425,9 +425,9 @@ func (adder *Adder) addDir(path string, dir files.Directory, toplevel bool) erro
 }
 
 // outputDagnode sends dagnode info over the output channel.
-// Cluster: we use *api.AddedOutput instead of coreiface events
+// Cluster: we use api.AddedOutput instead of coreiface events
 // and make this an adder method to be be able to prefix.
-func (adder *Adder) outputDagnode(out chan *api.AddedOutput, name string, dn ipld.Node) error {
+func (adder *Adder) outputDagnode(out chan api.AddedOutput, name string, dn ipld.Node) error {
 	if out == nil {
 		return nil
 	}
@@ -445,7 +445,7 @@ func (adder *Adder) outputDagnode(out chan *api.AddedOutput, name string, dn ipl
 	// account for this here.
 	name = filepath.Join(adder.OutputPrefix, name)
 
-	out <- &api.AddedOutput{
+	out <- api.AddedOutput{
 		Cid:         dn.Cid(),
 		Name:        name,
 		Size:        s,
@@ -458,7 +458,7 @@ func (adder *Adder) outputDagnode(out chan *api.AddedOutput, name string, dn ipl
 type progressReader struct {
 	file         io.Reader
 	path         string
-	out          chan *api.AddedOutput
+	out          chan api.AddedOutput
 	bytes        int64
 	lastProgress int64
 }
@@ -469,7 +469,7 @@ func (i *progressReader) Read(p []byte) (int, error) {
 	i.bytes += int64(n)
 	if i.bytes-i.lastProgress >= progressReaderIncrement || err == io.EOF {
 		i.lastProgress = i.bytes
-		i.out <- &api.AddedOutput{
+		i.out <- api.AddedOutput{
 			Name:  i.path,
 			Bytes: uint64(i.bytes),
 		}

--- a/api/ipfsproxy/ipfsproxy.go
+++ b/api/ipfsproxy/ipfsproxy.go
@@ -615,7 +615,7 @@ func (proxy *Server) addHandler(w http.ResponseWriter, r *http.Request) {
 
 	logger.Warnf("Proxy/add does not support all IPFS params. Current options: %+v", params)
 
-	outputTransform := func(in *api.AddedOutput) interface{} {
+	outputTransform := func(in api.AddedOutput) interface{} {
 		cidStr := ""
 		if in.Cid.Defined() {
 			cidStr = in.Cid.String()

--- a/cluster.go
+++ b/cluster.go
@@ -1728,17 +1728,17 @@ func (c *Cluster) UnpinPath(ctx context.Context, path string) (api.Pin, error) {
 // pipeline is used to DAGify the file.  Depending on input parameters this
 // DAG can be added locally to the calling cluster peer's ipfs repo, or
 // sharded across the entire cluster.
-func (c *Cluster) AddFile(reader *multipart.Reader, params api.AddParams) (cid.Cid, error) {
+func (c *Cluster) AddFile(ctx context.Context, reader *multipart.Reader, params api.AddParams) (cid.Cid, error) {
 	// TODO: add context param and tracing
 
 	var dags adder.ClusterDAGService
 	if params.Shard {
-		dags = sharding.New(c.rpcClient, params, nil)
+		dags = sharding.New(ctx, c.rpcClient, params, nil)
 	} else {
-		dags = single.New(c.rpcClient, params, params.Local)
+		dags = single.New(ctx, c.rpcClient, params, params.Local)
 	}
 	add := adder.New(dags, params, nil)
-	return add.FromMultipart(c.ctx, reader)
+	return add.FromMultipart(ctx, reader)
 }
 
 // Version returns the current IPFS Cluster version.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -134,8 +134,10 @@ func (ipfs *mockConnector) Resolve(ctx context.Context, path string) (cid.Cid, e
 func (ipfs *mockConnector) ConnectSwarms(ctx context.Context) error       { return nil }
 func (ipfs *mockConnector) ConfigKey(keypath string) (interface{}, error) { return nil, nil }
 
-func (ipfs *mockConnector) BlockPut(ctx context.Context, nwm api.NodeWithMeta) error {
-	ipfs.blocks.Store(nwm.Cid.String(), nwm.Data)
+func (ipfs *mockConnector) BlockStream(ctx context.Context, in <-chan api.NodeWithMeta) error {
+	for n := range in {
+		ipfs.blocks.Store(n.Cid.String(), n.Data)
+	}
 	return nil
 }
 
@@ -372,7 +374,7 @@ func TestAddFile(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 		r := multipart.NewReader(mfr, mfr.Boundary())
-		c, err := cl.AddFile(r, params)
+		c, err := cl.AddFile(context.Background(), r, params)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -401,7 +403,7 @@ func TestAddFile(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 		r := multipart.NewReader(mfr, mfr.Boundary())
-		c, err := cl.AddFile(r, params)
+		c, err := cl.AddFile(context.Background(), r, params)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -431,7 +433,7 @@ func TestUnpinShard(t *testing.T) {
 	mfr, closer := sth.GetTreeMultiReader(t)
 	defer closer.Close()
 	r := multipart.NewReader(mfr, mfr.Boundary())
-	root, err := cl.AddFile(r, params)
+	root, err := cl.AddFile(context.Background(), r, params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ipfscluster.go
+++ b/ipfscluster.go
@@ -95,8 +95,8 @@ type IPFSConnector interface {
 	RepoGC(context.Context) (api.RepoGC, error)
 	// Resolve returns a cid given a path.
 	Resolve(context.Context, string) (cid.Cid, error)
-	// BlockPut directly adds a block of data to the IPFS repo.
-	BlockPut(context.Context, api.NodeWithMeta) error
+	// BlockStream adds a stream of blocks to IPFS.
+	BlockStream(context.Context, <-chan api.NodeWithMeta) error
 	// BlockGet retrieves the raw data of an IPFS block.
 	BlockGet(context.Context, cid.Cid) ([]byte, error)
 }

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -2150,7 +2150,7 @@ func TestClustersFollowerMode(t *testing.T) {
 		mfr, closer := sth.GetTreeMultiReader(t)
 		defer closer.Close()
 		r := multipart.NewReader(mfr, mfr.Boundary())
-		_, err = clusters[1].AddFile(r, params)
+		_, err = clusters[1].AddFile(ctx, r, params)
 		if err != errFollowerMode {
 			t.Error("expected follower mode error")
 		}

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ipfs/ipfs-cluster/api"
 	"github.com/ipfs/ipfs-cluster/observations"
+	"go.uber.org/multierr"
 
 	cid "github.com/ipfs/go-cid"
 	files "github.com/ipfs/go-ipfs-files"
@@ -118,7 +119,7 @@ type ipfsSwarmPeersResp struct {
 }
 
 type ipfsBlockPutResp struct {
-	Key  string
+	Key  api.Cid
 	Size int
 }
 
@@ -903,35 +904,128 @@ func (ipfs *Connector) SwarmPeers(ctx context.Context) ([]peer.ID, error) {
 	return swarm, nil
 }
 
-// BlockPut triggers an ipfs block put on the given data, inserting the block
-// into the ipfs daemon's repo.
-func (ipfs *Connector) BlockPut(ctx context.Context, b api.NodeWithMeta) error {
-	ctx, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/BlockPut")
-	defer span.End()
+// chanDirectory implementes the files.Directory interace
+type chanDirectory struct {
+	iterator files.DirIterator
+}
 
-	logger.Debugf("putting block to IPFS: %s", b.Cid)
-	ctx, cancel := context.WithTimeout(ctx, ipfs.config.IPFSRequestTimeout)
-	defer cancel()
-	defer ipfs.updateInformerMetric(ctx)
+// Close is a no-op and it is not used.
+func (cd *chanDirectory) Close() error {
+	return nil
+}
 
-	mapDir := files.NewMapDirectory(
-		map[string]files.Node{ // IPFS reqs require a wrapping directory
-			"": files.NewBytesFile(b.Data),
-		},
-	)
+// not implemented, I think not needed for multipart.
+func (cd *chanDirectory) Size() (int64, error) {
+	return 0, nil
+}
 
-	multiFileR := files.NewMultiFileReader(mapDir, true)
+func (cd *chanDirectory) Entries() files.DirIterator {
+	return cd.iterator
+}
 
+// chanIterator implements the files.DirIterator interface.
+type chanIterator struct {
+	ctx    context.Context
+	blocks <-chan api.NodeWithMeta
+
+	current api.NodeWithMeta
+	peeked  api.NodeWithMeta
+	done    bool
+	err     error
+
+	seenMu sync.Mutex
+	seen   *cid.Set
+}
+
+func (ci *chanIterator) Name() string {
+	if !ci.current.Cid.Defined() {
+		return ""
+	}
+	return ci.current.Cid.String()
+}
+
+// return NewBytesFile.
+func (ci *chanIterator) Node() files.Node {
+	if !ci.current.Cid.Defined() {
+		return nil
+	}
+	ci.seenMu.Lock()
+	if ci.seen.Visit(ci.current.Cid) {
+		logger.Debugf("block %s", ci.current.Cid)
+	}
+	ci.seenMu.Unlock()
+	return files.NewBytesFile(ci.current.Data)
+}
+
+func (ci *chanIterator) Seen(c api.Cid) bool {
+	ci.seenMu.Lock()
+	has := ci.seen.Has(cid.Cid(c))
+	ci.seen.Remove(cid.Cid(c))
+	ci.seenMu.Unlock()
+	return has
+}
+
+func (ci *chanIterator) Done() bool {
+	return ci.done
+}
+
+// Peek reads one block from the channel but saves it so that Next also
+// returns it.
+func (ci *chanIterator) Peek() (api.NodeWithMeta, bool) {
+	if ci.done {
+		return api.NodeWithMeta{}, false
+	}
+
+	select {
+	case <-ci.ctx.Done():
+		return api.NodeWithMeta{}, false
+	case next, ok := <-ci.blocks:
+		if !ok {
+			return api.NodeWithMeta{}, false
+		}
+		ci.peeked = next
+		return next, true
+	}
+}
+
+func (ci *chanIterator) Next() bool {
+	if ci.done {
+		return false
+	}
+	if ci.peeked.Cid.Defined() {
+		ci.current = ci.peeked
+		ci.peeked = api.NodeWithMeta{}
+		return true
+	}
+	select {
+	case <-ci.ctx.Done():
+		ci.done = true
+		ci.err = ci.ctx.Err()
+		return false
+	case next, ok := <-ci.blocks:
+		if !ok {
+			ci.done = true
+			return false
+		}
+		ci.current = next
+		return true
+	}
+}
+
+func (ci *chanIterator) Err() error {
+	return ci.err
+}
+
+func blockPutQuery(prefix cid.Prefix) (url.Values, error) {
 	q := make(url.Values, 3)
-	prefix := b.Cid.Prefix()
 	format, ok := cid.CodecToStr[prefix.Codec]
 	if !ok {
-		return fmt.Errorf("cannot find name for the blocks' CID codec: %x", prefix.Codec)
+		return q, fmt.Errorf("cannot find name for the blocks' CID codec: %x", prefix.Codec)
 	}
 
 	mhType, ok := multihash.Codes[prefix.MhType]
 	if !ok {
-		return fmt.Errorf("cannot find name for the blocks' Multihash type: %x", prefix.MhType)
+		return q, fmt.Errorf("cannot find name for the blocks' Multihash type: %x", prefix.MhType)
 	}
 
 	// IPFS behaves differently when using v0 or protobuf which are
@@ -944,35 +1038,76 @@ func (ipfs *Connector) BlockPut(ctx context.Context, b api.NodeWithMeta) error {
 
 	q.Set("mhtype", mhType)
 	q.Set("mhlen", strconv.Itoa(prefix.MhLength))
+	return q, nil
+}
 
+// BlockStream performs a multipart request to block/put with the blocks
+// received on the channel.
+func (ipfs *Connector) BlockStream(ctx context.Context, blocks <-chan api.NodeWithMeta) error {
+	ctx, span := trace.StartSpan(ctx, "ipfsconn/ipfshttp/BlockStream")
+	defer span.End()
+
+	logger.Debug("streaming blocks to IPFS")
+	defer ipfs.updateInformerMetric(ctx)
+
+	var errs error
+
+	it := &chanIterator{
+		ctx:    ctx,
+		blocks: blocks,
+		seen:   cid.NewSet(),
+	}
+	dir := &chanDirectory{
+		iterator: it,
+	}
+
+	// We need to pick into the first block to know which Cid prefix we
+	// are writing blocks with, so that ipfs calculates the expected
+	// multihash (we select the function used). This means that all blocks
+	// in a stream should use the same.
+	peek, ok := it.Peek()
+	if !ok {
+		return errors.New("BlockStream: no blocks to peek in blocks channel")
+	}
+
+	q, err := blockPutQuery(peek.Cid.Prefix())
+	if err != nil {
+		return err
+	}
 	url := "block/put?" + q.Encode()
-	contentType := "multipart/form-data; boundary=" + multiFileR.Boundary()
 
-	body, err := ipfs.postCtx(ctx, url, contentType, multiFileR)
-	if err != nil {
-		return err
+	// We essentially keep going on any request errors and keep putting
+	// blocks until we are done. We will, however, return a final error if
+	// there were errors along the way, but we do not abort the blocks
+	// stream because we could not block/put.
+	for !it.Done() {
+		multiFileR := files.NewMultiFileReader(dir, true)
+		contentType := "multipart/form-data; boundary=" + multiFileR.Boundary()
+		body, err := ipfs.postCtxStreamResponse(ctx, url, contentType, multiFileR)
+		if err != nil {
+			errs = multierr.Append(errs, err)
+			continue
+		}
+		dec := json.NewDecoder(body)
+		for {
+			var res ipfsBlockPutResp
+			err := dec.Decode(&res)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				logger.Error(err)
+				errs = multierr.Append(errs, err)
+				break
+			}
+			if !it.Seen(res.Key) {
+				logger.Warnf("blockPut response CID (%s) does not match any blocks sent", res.Key)
+			}
+		}
+		// continue until it.Done()
 	}
 
-	var res ipfsBlockPutResp
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		return err
-	}
-
-	logger.Debug("block/put response CID", res.Key)
-	respCid, err := cid.Decode(res.Key)
-	if err != nil {
-		logger.Error("cannot parse CID from BlockPut response")
-		return err
-	}
-
-	// IPFS is too brittle here. CIDv0 != CIDv1. Sending "protobuf" format
-	// returns CidV1.  Sending "v0" format (which maps to protobuf)
-	// returns CidV0. Leaving this as warning.
-	if !respCid.Equals(b.Cid) {
-		logger.Warnf("blockPut response CID (%s) does not match the block sent (%s)", respCid, b.Cid)
-	}
-	return nil
+	return errs
 }
 
 // BlockGet retrieves an ipfs block with the given cid

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -570,9 +570,10 @@ func (rpcapi *IPFSConnectorRPCAPI) SwarmPeers(ctx context.Context, in struct{}, 
 	return nil
 }
 
-// BlockPut runs IPFSConnector.BlockPut().
-func (rpcapi *IPFSConnectorRPCAPI) BlockPut(ctx context.Context, in api.NodeWithMeta, out *struct{}) error {
-	return rpcapi.ipfs.BlockPut(ctx, in)
+// BlockStream runs IPFSConnector.BlockStream().
+func (rpcapi *IPFSConnectorRPCAPI) BlockStream(ctx context.Context, in <-chan api.NodeWithMeta, out chan<- struct{}) error {
+	close(out)
+	return rpcapi.ipfs.BlockStream(ctx, in)
 }
 
 // BlockGet runs IPFSConnector.BlockGet().

--- a/rpc_policy.go
+++ b/rpc_policy.go
@@ -47,16 +47,17 @@ var DefaultRPCPolicy = map[string]RPCEndpointType{
 	"PinTracker.Untrack":    RPCClosed,
 
 	// IPFSConnector methods
-	"IPFSConnector.BlockGet":   RPCClosed,
-	"IPFSConnector.BlockPut":   RPCTrusted, // Called from Add()
-	"IPFSConnector.ConfigKey":  RPCClosed,
-	"IPFSConnector.Pin":        RPCClosed,
-	"IPFSConnector.PinLs":      RPCClosed,
-	"IPFSConnector.PinLsCid":   RPCClosed,
-	"IPFSConnector.RepoStat":   RPCTrusted, // Called in broadcast from proxy/repo/stat
-	"IPFSConnector.Resolve":    RPCClosed,
-	"IPFSConnector.SwarmPeers": RPCTrusted, // Called in ConnectGraph
-	"IPFSConnector.Unpin":      RPCClosed,
+	"IPFSConnector.BlockGet":    RPCClosed,
+	"IPFSConnector.BlockPut":    RPCClosed,  // Not used - replaced by BlockStream
+	"IPFSConnector.BlockStream": RPCTrusted, // Called by adders
+	"IPFSConnector.ConfigKey":   RPCClosed,
+	"IPFSConnector.Pin":         RPCClosed,
+	"IPFSConnector.PinLs":       RPCClosed,
+	"IPFSConnector.PinLsCid":    RPCClosed,
+	"IPFSConnector.RepoStat":    RPCTrusted, // Called in broadcast from proxy/repo/stat
+	"IPFSConnector.Resolve":     RPCClosed,
+	"IPFSConnector.SwarmPeers":  RPCTrusted, // Called in ConnectGraph
+	"IPFSConnector.Unpin":       RPCClosed,
 
 	// Consensus methods
 	"Consensus.AddPeer":  RPCTrusted, // Called by Raft/redirect to leader

--- a/rpcutil/policygen/policygen.go
+++ b/rpcutil/policygen/policygen.go
@@ -24,20 +24,21 @@ func rpcTypeStr(t cluster.RPCEndpointType) string {
 }
 
 var comments = map[string]string{
-	"Cluster.PeerAdd":          "Used by Join()",
-	"Cluster.Peers":            "Used by ConnectGraph()",
-	"Cluster.Pins":             "Used in stateless tracker, ipfsproxy, restapi",
-	"PinTracker.Recover":       "Called in broadcast from Recover()",
-	"PinTracker.RecoverAll":    "Broadcast in RecoverAll unimplemented",
-	"Pintracker.Status":        "Called in broadcast from Status()",
-	"Pintracker.StatusAll":     "Called in broadcast from StatusAll()",
-	"IPFSConnector.BlockPut":   "Called from Add()",
-	"IPFSConnector.RepoStat":   "Called in broadcast from proxy/repo/stat",
-	"IPFSConnector.SwarmPeers": "Called in ConnectGraph",
-	"Consensus.AddPeer":        "Called by Raft/redirect to leader",
-	"Consensus.LogPin":         "Called by Raft/redirect to leader",
-	"Consensus.LogUnpin":       "Called by Raft/redirect to leader",
-	"Consensus.RmPeer":         "Called by Raft/redirect to leader",
+	"Cluster.PeerAdd":           "Used by Join()",
+	"Cluster.Peers":             "Used by ConnectGraph()",
+	"Cluster.Pins":              "Used in stateless tracker, ipfsproxy, restapi",
+	"PinTracker.Recover":        "Called in broadcast from Recover()",
+	"PinTracker.RecoverAll":     "Broadcast in RecoverAll unimplemented",
+	"Pintracker.Status":         "Called in broadcast from Status()",
+	"Pintracker.StatusAll":      "Called in broadcast from StatusAll()",
+	"IPFSConnector.BlockPut":    "Not used - replaced by BlockStream",
+	"IPFSConnector.BlockStream": "Called by adders",
+	"IPFSConnector.RepoStat":    "Called in broadcast from proxy/repo/stat",
+	"IPFSConnector.SwarmPeers":  "Called in ConnectGraph",
+	"Consensus.AddPeer":         "Called by Raft/redirect to leader",
+	"Consensus.LogPin":          "Called by Raft/redirect to leader",
+	"Consensus.LogUnpin":        "Called by Raft/redirect to leader",
+	"Consensus.RmPeer":          "Called by Raft/redirect to leader",
 }
 
 func main() {

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -584,7 +584,8 @@ func (mock *mockIPFSConnector) RepoStat(ctx context.Context, in struct{}, out *a
 	return nil
 }
 
-func (mock *mockIPFSConnector) BlockPut(ctx context.Context, in api.NodeWithMeta, out *struct{}) error {
+func (mock *mockIPFSConnector) BlockStream(ctx context.Context, in <-chan api.NodeWithMeta, out chan<- struct{}) error {
+	close(out)
 	return nil
 }
 


### PR DESCRIPTION
This commit fixes #810 and adds block streaming to the final destinations when
adding. This should add major performance gains when adding data to clusters.

Before, everytime cluster issued a block, it was broadcasted individually to
all destinations (new libp2p stream), where it was block/put to IPFS (a single
block/put http roundtrip per block).

Now, blocks are streamed all the way from the adder module to the ipfs daemon,
by making every block as it arrives a single part in a multipart block/put
request.

Before, block-broadcast needed to wait for all destinations to finish in order
to process the next block. Now, buffers allow some destinations to be faster
than others while sending and receiving blocks.

Before, if a block put request failed to be broadcasted everywhere, an error
would happen at that moment.

Now, we keep streaming until the end and only then report any errors. The
operation succeeds as long as at least one stream finished successfully.

Errors block/putting to IPFS will not abort streams. Instead, subsequent
blocks are retried with a new request, although the method will return an
error when the stream finishes if there were errors at any point.