### PR TITLE
Always include the X-Stream-Error trailer (even without errors)

### DIFF
--- a/api/common/api.go
+++ b/api/common/api.go
@@ -644,6 +644,10 @@ func (api *API) StreamResponse(w http.ResponseWriter, next StreamIterator, errCh
 
 	if err != nil {
 		w.Header().Set("X-Stream-Error", err.Error())
+	} else {
+		// Due to some Javascript-browser-land stuff, we set the header
+		// even when there is no error.
+		w.Header().Set("X-Stream-Error", "")
 	}
 	// check for function errors
 	for funcErr := range errCh {

--- a/api/common/test/helpers.go
+++ b/api/common/test/helpers.go
@@ -97,12 +97,12 @@ func ProcessStreamingResp(t *testing.T, httpResp *http.Response, err error, resp
 			}
 		}
 	}
-	trailerMsg := httpResp.Trailer.Get("X-Stream-Error")
-	if trailerError && trailerMsg == "" {
+	trailerValues := httpResp.Trailer.Values("X-Stream-Error")
+	if trailerError && len(trailerValues) <= 1 && trailerValues[0] == "" {
 		t.Error("expected trailer error")
 	}
-	if !trailerError && trailerMsg != "" {
-		t.Error("got trailer error: ", trailerMsg)
+	if !trailerError && len(trailerValues) >= 2 {
+		t.Error("got trailer error: ", trailerValues)
 	}
 }
 

--- a/api/rest/client/request.go
+++ b/api/rest/client/request.go
@@ -156,7 +156,9 @@ func (c *defaultClient) handleStreamResponse(resp *http.Response, handler respon
 	trailerErrs := resp.Trailer.Values("X-Stream-Error")
 	var err error
 	for _, trailerErr := range trailerErrs {
-		err = multierr.Append(err, errors.New(trailerErr))
+		if trailerErr != "" {
+			err = multierr.Append(err, errors.New(trailerErr))
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
This is to potentially address things like this:

https://github.com/nodejs/undici/issues/432#issuecomment-1047931107