### PR TITLE
ctl: Set exit status to 1 when app.Run() fails

### DIFF
--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -1109,7 +1109,10 @@ deamon, otherwise on all IPFS daemons.
 		},
 	}
 
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		os.Exit(1)
+	}
 }
 
 func localFlag() cli.BoolFlag {


### PR DESCRIPTION
1 corresponds to arguments errors and anything that prevents the app from
making a request.