### PR TITLE
Fix: wrong pins metric when batching enabled

### DIFF
--- a/consensus/crdt/consensus.go
+++ b/consensus/crdt/consensus.go
@@ -583,6 +583,9 @@ func (css *Consensus) State(ctx context.Context) (state.ReadOnly, error) {
 	case <-css.ctx.Done():
 		return nil, css.ctx.Err()
 	case <-css.stateReady:
+		if css.config.batchingEnabled() {
+			return css.batchingState, nil
+		}
 		return css.state, nil
 	}
 }

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/ipfs/ipfs-cluster/api"
-	"github.com/ipfs/ipfs-cluster/observations"
 	"go.uber.org/multierr"
 
 	cid "github.com/ipfs/go-cid"
@@ -34,7 +33,6 @@ import (
 
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
-	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -401,7 +399,6 @@ func (ipfs *Connector) Pin(ctx context.Context, pin api.Pin) error {
 	}
 
 	logger.Info("IPFS Pin request succeeded: ", hash)
-	stats.Record(ctx, observations.Pins.M(1))
 	return nil
 }
 
@@ -461,7 +458,6 @@ func (ipfs *Connector) pinUpdate(ctx context.Context, from, to api.Cid) error {
 		return err
 	}
 	logger.Infof("IPFS Pin Update request succeeded. %s -> %s (unpin=false)", from, to)
-	stats.Record(ctx, observations.Pins.M(1))
 	return nil
 }
 
@@ -495,7 +491,6 @@ func (ipfs *Connector) Unpin(ctx context.Context, hash api.Cid) error {
 	}
 
 	logger.Info("IPFS Unpin request succeeded:", hash)
-	stats.Record(ctx, observations.Pins.M(-1))
 	return nil
 }
 


### PR DESCRIPTION
When batching is enabled, the "batchingstate" is used to add/remove pins, but the
non-batching state is used as read-only state for doing List().

This means that both states will be writing pins metrics but the batching
state is never used for List(), so it never has the right total number.

This fixes that.