### PR TITLE
Fix: bad behaviour when adding and ipfs is down

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -1086,7 +1086,7 @@ func (ipfs *Connector) BlockStream(ctx context.Context, blocks <-chan api.NodeWi
 		var res ipfsBlockPutResp
 		err = dec.Decode(&res)
 		if err == io.EOF {
-			break
+			return nil
 		}
 		if err != nil {
 			logger.Error(err)


### PR DESCRIPTION
Adding keeps retrying indefinitely to send blocks to ipfs. When ipfs is down this:

* Stores all errors
* Keeps retrying
* Additionally, forgot to close bodies

This resulted in memory leaks. The new behaviour does not keep retrying. And
response bodies are closed after reading.