### PR TITLE
pintracker: metrics: convert pinning/queued/error metrics to gauges

### DIFF
--- a/observations/metrics.go
+++ b/observations/metrics.go
@@ -54,19 +54,19 @@ var (
 	PinsQueuedView = &view.View{
 		Measure: PinsQueued,
 		//TagKeys:     []tag.Key{HostKey},
-		Aggregation: view.Sum(),
+		Aggregation: view.LastValue(),
 	}
 
 	PinsPinningView = &view.View{
 		Measure: PinsPinning,
 		//TagKeys:     []tag.Key{HostKey},
-		Aggregation: view.Sum(),
+		Aggregation: view.LastValue(),
 	}
 
 	PinsPinErrorView = &view.View{
 		Measure: PinsPinError,
 		//TagKeys:     []tag.Key{HostKey},
-		Aggregation: view.Sum(),
+		Aggregation: view.LastValue(),
 	}
 
 	DefaultViews = []*view.View{

--- a/pintracker/optracker/operation_test.go
+++ b/pintracker/optracker/operation_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestOperation(t *testing.T) {
 	tim := time.Now().Add(-2 * time.Second)
-	op := NewOperation(context.Background(), api.PinCid(test.Cid1), OperationUnpin, PhaseQueued)
+	op := newOperation(context.Background(), api.PinCid(test.Cid1), OperationUnpin, PhaseQueued, nil)
 	if !op.Cid().Equals(test.Cid1) {
 		t.Error("bad cid")
 	}


### PR DESCRIPTION
We were currently tracking this metrics as a counter (SUM). The number is
good, but conceptually this is more a gauge (LastValue), given it can go down.

Thus we switch it by tracking the aggregation numbers directy in the operation
tracker.