### PR TITLE
Fix: slog integration for golog

### DIFF
--- a/clusterhost.go
+++ b/clusterhost.go
@@ -3,6 +3,7 @@ package ipfscluster
 import (
 	"context"
 	"encoding/hex"
+	"log/slog"
 	"time"
 
 	config "github.com/ipfs-cluster/ipfs-cluster/config"
@@ -13,6 +14,7 @@ import (
 	ipns "github.com/ipfs/boxo/ipns"
 	ds "github.com/ipfs/go-datastore"
 	namespace "github.com/ipfs/go-datastore/namespace"
+	logging "github.com/ipfs/go-log/v2"
 	libp2p "github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dual "github.com/libp2p/go-libp2p-kad-dht/dual"
@@ -26,6 +28,7 @@ import (
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	corepnet "github.com/libp2p/go-libp2p/core/pnet"
 	routing "github.com/libp2p/go-libp2p/core/routing"
+	"github.com/libp2p/go-libp2p/gologshim"
 	autorelay "github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	p2pbhost "github.com/libp2p/go-libp2p/p2p/host/basic"
 	"github.com/libp2p/go-libp2p/p2p/host/observedaddrs"
@@ -55,6 +58,12 @@ func init() {
 	// NATed addresses too eagerly, but they should progressively be
 	// cleaned up.
 	observedaddrs.ActivationThresh = 1
+
+	// Route all slog logs through go-log
+	slog.SetDefault(slog.New(logging.SlogHandler()))
+
+	// Connect go-libp2p to go-log
+	gologshim.SetDefaultHandler(logging.SlogHandler())
 }
 
 // NewClusterHost creates a fully-featured libp2p Host with the options from

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
@@ -17,6 +18,7 @@ import (
 
 	logging "github.com/ipfs/go-log/v2"
 	peer "github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/gologshim"
 	ma "github.com/multiformats/go-multiaddr"
 
 	uuid "github.com/google/uuid"
@@ -37,6 +39,14 @@ var (
 )
 
 var logger = logging.Logger("cluster-ctl")
+
+func init() {
+	// Route all slog logs through go-log
+	slog.SetDefault(slog.New(logging.SlogHandler()))
+
+	// Connect go-libp2p to go-log
+	gologshim.SetDefaultHandler(logging.SlogHandler())
+}
 
 var globalClient client.Client
 

--- a/cmd/ipfs-cluster-follow/main.go
+++ b/cmd/ipfs-cluster-follow/main.go
@@ -3,20 +3,23 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"os/user"
 	"path/filepath"
 	"syscall"
 
+	semver "github.com/blang/semver"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/gologshim"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/pkg/errors"
+	cli "github.com/urfave/cli/v2"
+
 	"github.com/ipfs-cluster/ipfs-cluster/api/rest/client"
 	"github.com/ipfs-cluster/ipfs-cluster/cmdutils"
 	"github.com/ipfs-cluster/ipfs-cluster/version"
-	"github.com/multiformats/go-multiaddr"
-	"github.com/pkg/errors"
-
-	semver "github.com/blang/semver"
-	cli "github.com/urfave/cli/v2"
 )
 
 const (
@@ -151,6 +154,12 @@ func init() {
 		}
 		os.Exit(1)
 	}()
+
+	// Route all slog logs through go-log
+	slog.SetDefault(slog.New(logging.SlogHandler()))
+
+	// Connect go-libp2p to go-log
+	gologshim.SetDefaultHandler(logging.SlogHandler())
 }
 
 func main() {

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	"github.com/ipfs-cluster/ipfs-cluster/pstoremgr"
 	"github.com/ipfs-cluster/ipfs-cluster/version"
 	peer "github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/gologshim"
 	ma "github.com/multiformats/go-multiaddr"
 
 	semver "github.com/blang/semver"
@@ -160,6 +162,12 @@ func init() {
 	}
 
 	DefaultPath = filepath.Join(home, DefaultFolder)
+
+	// Route all slog logs through go-log
+	slog.SetDefault(slog.New(logging.SlogHandler()))
+
+	// Connect go-libp2p to go-log
+	gologshim.SetDefaultHandler(logging.SlogHandler())
 }
 
 func out(m string, a ...interface{}) {


### PR DESCRIPTION
It seems libp2p v0.44 broke logging management using go-log, so we need to add integration code all around.