### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/api/pinsvcapi/pinsvc/pinsvc.go
+++ b/api/pinsvcapi/pinsvc/pinsvc.go
@@ -251,7 +251,7 @@ type ListOptions struct {
 func (lo *ListOptions) FromQuery(q url.Values) error {
 	cidq := q.Get("cid")
 	if len(cidq) > 0 {
-		for _, cstr := range strings.Split(cidq, ",") {
+		for cstr := range strings.SplitSeq(cidq, ",") {
 			c, err := types.DecodeCid(cstr)
 			if err != nil {
 				return fmt.Errorf("error decoding cid %s: %w", cstr, err)

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -478,7 +478,7 @@ func (api *API) allocationsHandler(w http.ResponseWriter, r *http.Request) {
 	queryValues := r.URL.Query()
 	filterStr := queryValues.Get("filter")
 	var filter types.PinType
-	for _, f := range strings.Split(filterStr, ",") {
+	for f := range strings.SplitSeq(filterStr, ",") {
 		filter |= types.PinTypeFromString(f)
 	}
 

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -197,7 +197,7 @@ requires authorization. implies --https, which you can disable with --force-http
 
 		var configs []*client.Config
 		var err error
-		for _, addr := range strings.Split(c.String("host"), ",") {
+		for addr := range strings.SplitSeq(c.String("host"), ",") {
 			multiaddr, err := ma.NewMultiaddr(addr)
 			checkErr("parsing host multiaddress", err)
 
@@ -883,8 +883,8 @@ The filter only takes effect when listing all pins. The possible values are:
 							formatResponse(c, resp, cerr)
 						} else {
 							var filter api.PinType
-							strFilter := strings.Split(c.String("filter"), ",")
-							for _, f := range strFilter {
+							strFilter := strings.SplitSeq(c.String("filter"), ",")
+							for f := range strFilter {
 								filter |= api.PinTypeFromString(f)
 							}
 

--- a/cmd/ipfs-cluster-service/main.go
+++ b/cmd/ipfs-cluster-service/main.go
@@ -382,9 +382,9 @@ the peer IDs in the given multiaddresses.
 				peersOpt := c.String("peers")
 				var multiAddrs []ma.Multiaddr
 				if peersOpt != "" {
-					addrs := strings.Split(peersOpt, ",")
+					addrs := strings.SplitSeq(peersOpt, ",")
 
-					for _, addr := range addrs {
+					for addr := range addrs {
 						addr = strings.TrimSpace(addr)
 						multiAddr, err := ma.NewMultiaddr(addr)
 						checkErr("parsing peer multiaddress: "+addr, err)

--- a/config/util.go
+++ b/config/util.go
@@ -157,7 +157,7 @@ func DisplayJSON(cfg interface{}) ([]byte, error) {
 
 		// remove omitempty from tag, ignore other tags except json
 		var jsonTags []string
-		for _, s := range strings.Split(f.Tag.Get("json"), ",") {
+		for s := range strings.SplitSeq(f.Tag.Get("json"), ",") {
 			if s != "omitempty" {
 				jsonTags = append(jsonTags, s)
 			}

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -83,7 +83,7 @@ func (lg *logFacilities) Set(value string) error {
 	if len(*lg) > 0 {
 		return errors.New("logFacilities flag already set")
 	}
-	for _, lf := range strings.Split(value, ",") {
+	for lf := range strings.SplitSeq(value, ",") {
 		*lg = append(*lg, lf)
 	}
 	return nil

--- a/pintracker/optracker/operation.go
+++ b/pintracker/optracker/operation.go
@@ -98,8 +98,8 @@ func (op *Operation) String() string {
 	fmt.Fprintf(&b, "type: %s\n", op.Type().String())
 	fmt.Fprint(&b, "pin:\n")
 	pinstr := op.Pin().String()
-	pinstrs := strings.Split(pinstr, "\n")
-	for _, s := range pinstrs {
+	pinstrs := strings.SplitSeq(pinstr, "\n")
+	for s := range pinstrs {
 		fmt.Fprintf(&b, "\t%s\n", s)
 	}
 	fmt.Fprintf(&b, "phase: %s\n", op.Phase().String())

--- a/pintracker/optracker/operationtracker.go
+++ b/pintracker/optracker/operationtracker.go
@@ -50,8 +50,8 @@ func (opt *OperationTracker) String() string {
 	defer opt.mu.RUnlock()
 	for _, op := range opt.operations {
 		opstr := op.String()
-		opstrs := strings.Split(opstr, "\n")
-		for _, s := range opstrs {
+		opstrs := strings.SplitSeq(opstr, "\n")
+		for s := range opstrs {
 			fmt.Fprintf(&b, "\t%s\n", s)
 		}
 	}


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901