### PR TITLE
ci: attach binaries to github releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,107 @@
+name: Release Binaries
+
+# Run manually (workflow_dispatch) against a release tag. Cross-compiles ipfs-cluster-ctl,
+# ipfs-cluster-follow and ipfs-cluster-service for every platform and attaches any archive
+# missing from the GitHub Release. Idempotent: an asset that already exists (including one
+# uploaded by hand) is left untouched, so a re-run only fills gaps. See RELEASE.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and attach binaries for (e.g. v1.1.6)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      build: ${{ steps.resolve.outputs.build }}
+    steps:
+      - id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="$INPUT_TAG"
+          if [ -z "$TAG" ]; then
+            echo "::error::no tag to build for"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # Only releases that carry GitHub binaries (>= v1.1.6); older tags are a no-op.
+          floor="v1.1.6"
+          lowest="$(printf '%s\n%s\n' "$floor" "$TAG" | sort -V | head -n1)"
+          if [ "$TAG" = "$floor" ] || [ "$lowest" = "$floor" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::$TAG predates $floor; nothing to attach"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  attach:
+    needs: prepare
+    if: needs.prepare.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - darwin/amd64
+          - darwin/arm64
+          - linux/amd64
+          - linux/arm64
+          - freebsd/amd64
+          - openbsd/amd64
+          - windows/amd64
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ needs.prepare.outputs.tag }}
+      PLATFORM: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build and attach missing binaries
+        run: |
+          set -euo pipefail
+          GOOS="${PLATFORM%/*}"
+          GOARCH="${PLATFORM#*/}"
+          ext="tar.gz"
+          exe=""
+          if [ "$GOOS" = "windows" ]; then
+            ext="zip"
+            exe=".exe"
+          fi
+
+          existing="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+
+          for tool in ipfs-cluster-ctl ipfs-cluster-follow ipfs-cluster-service; do
+            asset="${tool}_${TAG}_${GOOS}-${GOARCH}.${ext}"
+            if grep -qxF "$asset" <<< "$existing"; then
+              echo "skip $asset (already on the release)"
+              continue
+            fi
+            echo "building $asset"
+            rm -rf "$tool"
+            mkdir -p "$tool"
+            ( cd "cmd/$tool" && CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+                go build -trimpath -mod=readonly -o "$GITHUB_WORKSPACE/$tool/${tool}${exe}" . ) \
+              > "$tool/build-log" 2>&1
+            cp cmd/"$tool"/dist/* "$tool"/
+            if [ "$ext" = "zip" ]; then
+              zip -r "$asset" "$tool" > /dev/null
+            else
+              tar czf "$asset" "$tool"
+            fi
+            gh release upload "$TAG" "$asset"
+            rm -rf "$tool" "$asset"
+          done

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,11 +30,25 @@ Tags are signed: `vX.Y.Z` for finals, `vX.Y.Z-rcN` for release candidates.
 5. Wait for the `docker-image` workflow to publish `vX.Y.Z`, `stable`, and `latest` to [Docker Hub](https://hub.docker.com/r/ipfs/ipfs-cluster/tags).
 6. Create a GitHub Release for the tag (web UI or `gh release create vX.Y.Z`) and paste the new `CHANGELOG.md` entry as the body.
 7. Close the `Release vX.Y.Z` milestone and open `Release vX.Y.(Z+1)`.
-8. Open a PR against [`ipfs/distributions`](https://github.com/ipfs/distributions/) to publish binaries on `dist.ipfs.tech` (see [ipfs/distributions#1188](https://github.com/ipfs/distributions/pull/1188) as a template).
+8. Run the [`Release Binaries`](.github/workflows/release-binaries.yml) workflow (`workflow_dispatch`) against `vX.Y.Z`, then confirm it built and attached the archives to the release (see [Binary artifacts](#binary-artifacts)).
 
 ## Release candidates
 
-Major releases usually go through one or more RCs (v1.0.0 had five). Patch releases skip them. Run `./release.sh X.Y.Z-rcN`, then push the commit and tag the same way. CI publishes only the `vX.Y.Z-rcN` tag to [Docker Hub](https://hub.docker.com/r/ipfs/ipfs-cluster/tags) and does not move `stable` or `latest`. Open a separate [`ipfs/distributions`](https://github.com/ipfs/distributions/) PR for the RC.
+Major releases usually go through one or more RCs (v1.0.0 had five). Patch releases skip them. Run `./release.sh X.Y.Z-rcN`, then push the commit and tag the same way. CI publishes only the `vX.Y.Z-rcN` tag to [Docker Hub](https://hub.docker.com/r/ipfs/ipfs-cluster/tags) and does not move `stable` or `latest`. If you publish a GitHub Release for the RC, attach its binaries the same way; the workflow builds RC tags too.
+
+## Binary artifacts
+
+Every release `>= v1.1.6` has binaries for `ipfs-cluster-ctl`, `ipfs-cluster-follow` and `ipfs-cluster-service` attached, which [download-ipfs-distribution-action](https://github.com/ipfs/download-ipfs-distribution-action) fetches.
+
+Archives are named `<command>_<tag>_<goos>-<goarch>.<ext>` (`zip` on windows, `tar.gz` elsewhere), e.g. `ipfs-cluster-ctl_v1.1.6_linux-amd64.tar.gz`. Each contains a directory named after the command with the binary, its `build-log`, and the `README`/`LICENSE*` files from `cmd/<command>/dist/`. The platform set is in `.github/workflows/release-binaries.yml`.
+
+The code is pure Go, so one Linux runner cross-compiles every platform (`CGO_ENABLED=0 go build -trimpath`). `release.sh` sets the version in the source, so building the tag needs no ldflags. Checksums are not attached; consumers verify against the release API's per-asset `sha256` digest.
+
+## Attaching binaries
+
+`.github/workflows/release-binaries.yml` cross-compiles the archives and uploads any missing from a release. It is idempotent: existing assets (including hand-uploaded ones) stay untouched, so a re-run only fills gaps. It acts only on tags `>= v1.1.6`.
+
+Run it from the Actions tab (`workflow_dispatch`) against the tag, once the release exists (step 6). It has no other trigger, so it never fires on its own.
 
 ## Notes
 


### PR DESCRIPTION
> [!NOTE]
> @hsanjuan, would appreciate your feedback when you have a moment, no rush. The motivation: we need to move off `dist.ipfs.tech` for distribution, and the most future-proof path looks like each project owning its own binary pipeline rather than relying on the shared one. This PR adds that for ipfs-cluster; happy to rework it if you see things differently.
>
> Draft until [download-ipfs-distribution-action](https://github.com/ipfs/download-ipfs-distribution-action/) ships its fix to fetch from GitHub releases first (with `dist.ipfs.tech` as fallback); merge after that lands.

## Problem

ipfs-cluster binaries are published only to `dist.ipfs.tech` (via `ipfs/distributions`); the GitHub Release itself carries none. Anything pulling binaries from the release finds nothing, so the v1.1.6 assets had to be uploaded by hand.

## Fix

- Add `.github/workflows/release-binaries.yml`: a `workflow_dispatch` job that cross-compiles `ipfs-cluster-ctl`, `ipfs-cluster-follow` and `ipfs-cluster-service` for every platform and uploads any archive missing from a release. Idempotent, gated to tags `>= v1.1.6`.
- Document the artifact set in `RELEASE.md` and swap the `ipfs/distributions` step for running this workflow.

Run it against a tag after creating the release; re-runs only fill gaps. It does not change `dist.ipfs.tech` publishing or fire on its own.