### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1369,11 +1369,7 @@ func (m *Metric) SetTTL(d time.Duration) {
 // GetTTL returns the time left before the Metric expires
 func (m Metric) GetTTL() time.Duration {
 	expDate := time.Unix(0, m.Expire)
-	ttl := time.Until(expDate)
-	if ttl < 0 {
-		ttl = 0
-	}
-	return ttl
+	return max(time.Until(expDate), 0)
 }
 
 // Expired returns if the Metric has expired

--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -425,10 +425,7 @@ func (ipfs *Connector) Pin(ctx context.Context, pin api.Pin) error {
 	defer cancelRequest()
 
 	// If the pin has origins, tell ipfs to connect to a maximum of 10.
-	bound := len(pin.Origins)
-	if bound > 10 {
-		bound = 10
-	}
+	bound := min(len(pin.Origins), 10)
 	for _, orig := range pin.Origins[0:bound] {
 		// do it in the background, ignoring errors.
 		go func(o string) {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.